### PR TITLE
Address review findings on WhatsApp connect OAuth flow

### DIFF
--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -106,6 +106,8 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
 
             response = self.client.get(connect_whatsapp_cloud_url)
             self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "https://www.facebook.com/v25.0/dialog/oauth")
+            self.assertNotContains(response, "sdk.js")
 
             # 400 status
             response = self.client.post(connect_whatsapp_cloud_url, dict(user_access_token="X" * 36), follow=True)

--- a/templates/channels/types/whatsapp/claim.html
+++ b/templates/channels/types/whatsapp/claim.html
@@ -54,7 +54,7 @@
       {% else %}
       connectFB.addEventListener('click', function(evt) {
         fetchAjax("{{clear_session_token_url}}");
-        location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_whatsapp_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token");
+        location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_whatsapp_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token" + "&extras=" + encodeURIComponent('{"feature":"whatsapp_embedded_signup","setup":{}}'));
       });
       {% endif %}
 

--- a/templates/channels/types/whatsapp/connect.html
+++ b/templates/channels/types/whatsapp/connect.html
@@ -35,41 +35,31 @@
   {{ block.super }}
   <script type="text/javascript">
     onSpload(function() {
-      var hash = window.location.hash.substring(1)
-      var result = hash.split('&').reduce(function(res, item) {
-        var parts = item.split('=');
-        res[parts[0]] = parts[1];
-        return res;
-      }, {});
+      const urlParams = new URLSearchParams(window.location.search);
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
 
-      const urlParams = new URLSearchParams(window.location.search)
+      // the code (config_id flow) or token (implicit flow) granted by the OAuth dialog
+      var credential = urlParams.get("code") || hashParams.get("long_lived_token") || hashParams.get("access_token");
+      var oauthError = urlParams.get("error") || hashParams.get("error");
 
-      var accessToken = urlParams.get("code") || result.long_lived_token || result.access_token;
-
-      var oauthError = urlParams.get("error") || result.error;
-      var errorDescription = urlParams.get("error_description");
-      if (!errorDescription && result.error_description) {
-        errorDescription = decodeURIComponent(result.error_description.replace(/\+/g, " "));
+      // don't leave the credential or error details in the address bar and browser history
+      if (credential || oauthError) {
+        history.replaceState(history.state, "", window.location.pathname);
       }
 
-      // don't leave the code/token or error details in the address bar and browser history
-      if (accessToken || oauthError) {
-        history.replaceState(null, "", window.location.pathname);
-      }
-
-      if (accessToken) {
-        var userAccessToken = document.getElementById("user-access-token");
-        var claimForm = document.getElementById("claim-form");
-
-        if (userAccessToken) {
-          userAccessToken.value = accessToken;
-        }
-        if (claimForm) {
-          claimForm.submit();
-        }
+      if (credential) {
+        document.getElementById("user-access-token").value = credential;
+        document.getElementById("claim-form").submit();
       } else if (oauthError) {
+        // only show our own messages, the dialog's error text is not trustworthy
+        console.log(oauthError + ": " + (urlParams.get("error_description") || hashParams.get("error_description")));
+
         var errorAlert = document.getElementById("connect-error");
-        errorAlert.textContent = errorDescription || "{% trans 'Login was cancelled or failed, please try again.' %}";
+        if (oauthError == "access_denied") {
+          errorAlert.textContent = "{{ _("Login was cancelled, please try again.") |escapejs }}";
+        } else {
+          errorAlert.textContent = "{{ _("Login failed, please try again.") |escapejs }}";
+        }
         errorAlert.classList.remove("hidden");
       }
     });
@@ -80,7 +70,7 @@
       {% if facebook_login_whatsapp_config_id %}
       location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&config_id={{ facebook_login_whatsapp_config_id }}&response_type=code&override_default_response_type=true");
       {% else %}
-      location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token");
+      location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token" + "&extras=" + encodeURIComponent('{"feature":"whatsapp_embedded_signup","setup":{}}'));
       {% endif %}
     }
   </script>


### PR DESCRIPTION
Follow-up to #6775 addressing expert review findings on the full-page OAuth dialog flow:

- **Restore the embedded signup wizard on the non-`config_id` path** — the JS SDK previously sent `extras: {feature: 'whatsapp_embedded_signup', setup: {}}`, which is what triggers the signup wizard (create WABA, register a number). The plain scope-based dialog URL lost that, so both `connect.html` and `claim.html` now append the URL-encoded `extras` param.
- **Parse the redirect with `URLSearchParams`** — the hand-rolled hash parsing plus `decodeURIComponent` could throw on malformed input and abort the whole handler (no scrub, no submit, no feedback). `URLSearchParams` never throws, and also fixes hash token values never being percent-decoded and values containing `=` being truncated.
- **Stop rendering the dialog's `error_description` verbatim** — it's attacker-controllable free text in an official-looking alert. Show only our own translated messages (`access_denied` → cancelled, otherwise generic failure) and log the raw error to console for support.
- **Fix i18n escaping** — `{% trans %}` inside a JS string HTML-escapes translations; switched to the `{{ _("...") |escapejs }}` convention used elsewhere.
- Minor: preserve `history.state` when scrubbing the URL, drop dead element guards, rename `accessToken` → `credential`, and add a template assertion pinning the `dialog/oauth` redirect (and absence of `sdk.js`).