### PR TITLE
Configure Turn.io webhooks automatically on claim and release

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 20:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -1649,10 +1649,12 @@ msgstr ""
 msgid "If you have an enterprise Turn.io WhatsApp account, you can connect it to communicate with your contacts"
 msgstr ""
 
-msgid "To finish configuring this channel, you'll need Turn.io to use the following callback URL."
+#, python-format
+msgid "Unable to register webhooks: %(resp)s"
 msgstr ""
 
-msgid "This URL should be called by Turn.io when new messages are received."
+#, python-format
+msgid "Unable to remove webhooks: %(resp)s"
 msgstr ""
 
 msgid "Your enterprise Turn.io WhatsApp number"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 20:46+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1663,11 +1663,13 @@ msgstr "Número de teléfono no válido, incluya el código del país. ej .: +12
 msgid "If you have an enterprise Turn.io WhatsApp account, you can connect it to communicate with your contacts"
 msgstr "Si tiene una cuenta de WhatsApp empresarial de Turn.io, puede conectarla para comunicarse con sus contactos"
 
-msgid "To finish configuring this channel, you'll need Turn.io to use the following callback URL."
-msgstr "Para terminar de configurar este canal, necesitará que Turn.io utilice la siguiente URL de callback."
+#, python-format
+msgid "Unable to register webhooks: %(resp)s"
+msgstr "No se pudieron registrar los webhooks: %(resp)s"
 
-msgid "This URL should be called by Turn.io when new messages are received."
-msgstr "Turn.io debe llamar a esta URL cuando se reciban nuevos mensajes."
+#, python-format
+msgid "Unable to remove webhooks: %(resp)s"
+msgstr "No se pudieron eliminar los webhooks: %(resp)s"
 
 msgid "Your enterprise Turn.io WhatsApp number"
 msgstr "Su número de WhatsApp empresarial de Turn.io"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 20:46+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -1663,11 +1663,13 @@ msgstr "Numéro de téléphone non valide, veuillez inclure le code du pays. ex:
 msgid "If you have an enterprise Turn.io WhatsApp account, you can connect it to communicate with your contacts"
 msgstr "Si vous disposez d'un compte WhatsApp entreprise Turn.io, vous pouvez le connecter pour communiquer avec vos contacts"
 
-msgid "To finish configuring this channel, you'll need Turn.io to use the following callback URL."
-msgstr "Pour terminer la configuration de ce canal, Turn.io devra utiliser l'URL de rappel suivante."
+#, python-format
+msgid "Unable to register webhooks: %(resp)s"
+msgstr "Impossible d'enregistrer les webhooks: %(resp)s"
 
-msgid "This URL should be called by Turn.io when new messages are received."
-msgstr "Cette URL doit être appelée par Turn.io lorsque de nouveaux messages sont reçus."
+#, python-format
+msgid "Unable to remove webhooks: %(resp)s"
+msgstr "Impossible de supprimer les webhooks: %(resp)s"
 
 msgid "Your enterprise Turn.io WhatsApp number"
 msgstr "Votre numéro WhatsApp entreprise Turn.io"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 20:46+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -1667,11 +1667,13 @@ msgstr "Número de telefone inválido, por favor inclua o código do país. Ex: 
 msgid "If you have an enterprise Turn.io WhatsApp account, you can connect it to communicate with your contacts"
 msgstr "Se você tem uma conta corporativa do WhatsApp na Turn.io, você pode conectá-la para se comunicar com os seus contatos"
 
-msgid "To finish configuring this channel, you'll need Turn.io to use the following callback URL."
-msgstr "Para concluir a configuração deste canal, você precisará que a Turn.io use a seguinte URL de retorno de chamada."
+#, python-format
+msgid "Unable to register webhooks: %(resp)s"
+msgstr "Não foi possível registrar os webhooks: %(resp)s"
 
-msgid "This URL should be called by Turn.io when new messages are received."
-msgstr "Esta URL deve ser chamada pela Turn.io quando novas mensagens forem recebidas."
+#, python-format
+msgid "Unable to remove webhooks: %(resp)s"
+msgstr "Não foi possível remover os webhooks: %(resp)s"
 
 msgid "Your enterprise Turn.io WhatsApp number"
 msgstr "O número do WhatsApp corporativo da sua Turn.io"

--- a/temba/channels/types/turn/tests.py
+++ b/temba/channels/types/turn/tests.py
@@ -71,20 +71,57 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
 
             self.assertFormError(response.context["form"], None, ["Unable to access Messages templates from turn.io"])
 
+        # registering the webhooks fails
         with (
             patch("socket.gethostbyname", return_value="123.123.123.123"),
             patch("requests.post") as mock_post,
             patch("requests.get") as mock_get,
+            patch("requests.patch") as mock_patch,
         ):
             mock_post.return_value = MockResponse(200, '{"users": [{"token": "abc123"}]}')
             mock_get.return_value = MockResponse(200, '{"data": []}')
+            mock_patch.return_value = MockResponse(400, '{"errors": ["invalid"]}')
+
+            response = self.client.post(url, post_data)
+
+            self.assertEqual(200, response.status_code)
+
+            # once to register the webhooks, then again to clear them as the channel is released
+            self.assertEqual(2, mock_patch.call_count)
+
+            self.assertFormError(
+                response.context["form"], None, ['Unable to register webhooks: {"errors": ["invalid"]}']
+            )
+            self.assertContains(response, "Unable to register webhooks")
+            self.assertFalse(Channel.objects.filter(is_active=True))
+
+        with (
+            patch("socket.gethostbyname", return_value="123.123.123.123"),
+            patch("requests.post") as mock_post,
+            patch("requests.get") as mock_get,
+            patch("requests.patch") as mock_patch,
+        ):
+            mock_post.return_value = MockResponse(200, '{"users": [{"token": "abc123"}]}')
+            mock_get.return_value = MockResponse(200, '{"data": []}')
+            mock_patch.return_value = MockResponse(200, '{"webhooks": []}')
 
             response = self.client.post(url, post_data)
             self.assertEqual(302, response.status_code)
 
-        channel = Channel.objects.get()
-        self.assertRedirects(response, reverse("channels.channel_configuration", args=[channel.uuid]))
+        channel = Channel.objects.get(is_active=True)
+        self.assertRedirects(response, reverse("channels.channel_read", args=[channel.uuid]))
         self.assertEqual(channel.channel_type, "TRN")
+
+        # check the webhooks were registered with the courier receive URL for this channel
+        self.assertEqual("https://whatsapp.turn.io/v1/settings/application", mock_patch.call_args_list[0][0][0])
+        self.assertEqual(
+            {"webhooks": {"url": f"https://app.rapidpro.io/c/trn/{channel.uuid}/receive"}},
+            mock_patch.call_args_list[0][1]["json"],
+        )
+        self.assertEqual(
+            {"Authorization": "Bearer abc123", "Content-Type": "application/json"},
+            mock_patch.call_args_list[0][1]["headers"],
+        )
 
         self.assertEqual("abc123", channel.config[Channel.CONFIG_AUTH_TOKEN])
         self.assertEqual("https://whatsapp.turn.io", channel.config[Channel.CONFIG_BASE_URL])
@@ -96,8 +133,53 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
         self.assertEqual("TRN", channel.type.code)
         self.assertEqual("whatsapp", channel.template_type.slug)
 
+        # no configuration page for this type as webhooks are registered automatically
         response = self.client.get(reverse("channels.channel_configuration", args=[channel.uuid]))
-        self.assertContains(response, reverse("courier.trn", args=[channel.uuid, "receive"]))
+        self.assertRedirects(response, reverse("channels.channel_read", args=[channel.uuid]))
+
+    def test_release(self):
+        def create_turn_channel(address):
+            return self.create_channel(
+                "TRN",
+                "Turn: %s" % address,
+                address,
+                config={
+                    Channel.CONFIG_BASE_URL: "https://whatsapp.turn.io",
+                    Channel.CONFIG_USERNAME: "temba",
+                    Channel.CONFIG_PASSWORD: "tembapasswd",
+                    Channel.CONFIG_AUTH_TOKEN: "authtoken123",
+                },
+            )
+
+        channel = create_turn_channel("1234")
+
+        # releasing the channel clears the webhooks
+        with patch("requests.patch") as mock_patch:
+            mock_patch.return_value = MockResponse(200, '{"webhooks": []}')
+
+            channel.release(self.admin, interrupt=False)
+
+        mock_patch.assert_called_once_with(
+            "https://whatsapp.turn.io/v1/settings/application",
+            json={"webhooks": {"url": ""}},
+            headers={"Authorization": "Bearer authtoken123", "Content-Type": "application/json"},
+        )
+
+        channel.refresh_from_db()
+        self.assertFalse(channel.is_active)
+
+        # a failure to clear the webhooks doesn't prevent the channel being released
+        channel = create_turn_channel("1235")
+
+        with patch("requests.patch") as mock_patch:
+            mock_patch.return_value = MockResponse(400, '{"errors": ["invalid"]}')
+
+            channel.release(self.admin, interrupt=False)
+
+        self.assertEqual(1, mock_patch.call_count)
+
+        channel.refresh_from_db()
+        self.assertFalse(channel.is_active)
 
     @patch("requests.get")
     def test_fetch_templates(self, mock_get):

--- a/temba/channels/types/turn/tests.py
+++ b/temba/channels/types/turn/tests.py
@@ -11,6 +11,7 @@ from temba.channels.types.turn.type import (
     CONFIG_FB_BUSINESS_ID,
     CONFIG_FB_NAMESPACE,
     CONFIG_FB_TEMPLATE_LIST_DOMAIN,
+    CONFIG_WEBHOOK_URL,
 )
 from temba.request_logs.models import HTTPLog
 from temba.templates.models import TemplateTranslation
@@ -88,9 +89,10 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
 
             self.assertEqual(200, response.status_code)
 
-            # once to register the webhooks, then a delete to clear them as the channel is released
+            # we tried to register the webhooks, but because that failed we don't try to clear them as the channel is
+            # released - the user may have a webhook of their own configured
             self.assertEqual(1, mock_patch.call_count)
-            self.assertEqual(1, mock_delete.call_count)
+            self.assertEqual(0, mock_delete.call_count)
 
             self.assertFormError(
                 response.context["form"], None, ['Unable to register webhooks: {"errors": ["invalid"]}']
@@ -129,6 +131,9 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
         self.assertEqual("abc123", channel.config[Channel.CONFIG_AUTH_TOKEN])
         self.assertEqual("https://whatsapp.turn.io", channel.config[Channel.CONFIG_BASE_URL])
 
+        # the registered webhook is recorded so that we know to clear it when the channel is released
+        self.assertEqual(f"https://app.rapidpro.io/c/trn/{channel.uuid}/receive", channel.config[CONFIG_WEBHOOK_URL])
+
         self.assertEqual("+250788123123", channel.address)
         self.assertEqual("RW", channel.country)
         self.assertEqual("TRN", channel.channel_type)
@@ -141,18 +146,17 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
         self.assertRedirects(response, reverse("channels.channel_read", args=[channel.uuid]))
 
     def test_release(self):
-        def create_turn_channel(address):
-            return self.create_channel(
-                "TRN",
-                "Turn: %s" % address,
-                address,
-                config={
-                    Channel.CONFIG_BASE_URL: "https://whatsapp.turn.io",
-                    Channel.CONFIG_USERNAME: "temba",
-                    Channel.CONFIG_PASSWORD: "tembapasswd",
-                    Channel.CONFIG_AUTH_TOKEN: "authtoken123",
-                },
-            )
+        def create_turn_channel(address, webhook_url="https://app.rapidpro.io/c/trn/1234/receive"):
+            config = {
+                Channel.CONFIG_BASE_URL: "https://whatsapp.turn.io",
+                Channel.CONFIG_USERNAME: "temba",
+                Channel.CONFIG_PASSWORD: "tembapasswd",
+                Channel.CONFIG_AUTH_TOKEN: "authtoken123",
+            }
+            if webhook_url:
+                config[CONFIG_WEBHOOK_URL] = webhook_url
+
+            return self.create_channel("TRN", "Turn: %s" % address, address, config=config)
 
         channel = create_turn_channel("1234")
 
@@ -179,6 +183,17 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
             channel.release(self.admin, interrupt=False)
 
         self.assertEqual(1, mock_delete.call_count)
+
+        channel.refresh_from_db()
+        self.assertFalse(channel.is_active)
+
+        # a channel we never registered a webhook for is released without touching the turn.io settings
+        channel = create_turn_channel("1236", webhook_url=None)
+
+        with patch("requests.delete") as mock_delete:
+            channel.release(self.admin, interrupt=False)
+
+        self.assertEqual(0, mock_delete.call_count)
 
         channel.refresh_from_db()
         self.assertFalse(channel.is_active)

--- a/temba/channels/types/turn/tests.py
+++ b/temba/channels/types/turn/tests.py
@@ -77,17 +77,20 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
             patch("requests.post") as mock_post,
             patch("requests.get") as mock_get,
             patch("requests.patch") as mock_patch,
+            patch("requests.delete") as mock_delete,
         ):
             mock_post.return_value = MockResponse(200, '{"users": [{"token": "abc123"}]}')
             mock_get.return_value = MockResponse(200, '{"data": []}')
             mock_patch.return_value = MockResponse(400, '{"errors": ["invalid"]}')
+            mock_delete.return_value = MockResponse(200, "{}")
 
             response = self.client.post(url, post_data)
 
             self.assertEqual(200, response.status_code)
 
-            # once to register the webhooks, then again to clear them as the channel is released
-            self.assertEqual(2, mock_patch.call_count)
+            # once to register the webhooks, then a delete to clear them as the channel is released
+            self.assertEqual(1, mock_patch.call_count)
+            self.assertEqual(1, mock_delete.call_count)
 
             self.assertFormError(
                 response.context["form"], None, ['Unable to register webhooks: {"errors": ["invalid"]}']
@@ -153,15 +156,14 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
 
         channel = create_turn_channel("1234")
 
-        # releasing the channel clears the webhooks
-        with patch("requests.patch") as mock_patch:
-            mock_patch.return_value = MockResponse(200, '{"webhooks": []}')
+        # releasing the channel clears the webhooks by resetting the application settings
+        with patch("requests.delete") as mock_delete:
+            mock_delete.return_value = MockResponse(200, "{}")
 
             channel.release(self.admin, interrupt=False)
 
-        mock_patch.assert_called_once_with(
+        mock_delete.assert_called_once_with(
             "https://whatsapp.turn.io/v1/settings/application",
-            json={"webhooks": {"url": ""}},
             headers={"Authorization": "Bearer authtoken123", "Content-Type": "application/json"},
         )
 
@@ -171,12 +173,12 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
         # a failure to clear the webhooks doesn't prevent the channel being released
         channel = create_turn_channel("1235")
 
-        with patch("requests.patch") as mock_patch:
-            mock_patch.return_value = MockResponse(400, '{"errors": ["invalid"]}')
+        with patch("requests.delete") as mock_delete:
+            mock_delete.return_value = MockResponse(400, '{"errors": ["invalid"]}')
 
             channel.release(self.admin, interrupt=False)
 
-        self.assertEqual(1, mock_patch.call_count)
+        self.assertEqual(1, mock_delete.call_count)
 
         channel.refresh_from_db()
         self.assertFalse(channel.is_active)

--- a/temba/channels/types/turn/type.py
+++ b/temba/channels/types/turn/type.py
@@ -18,6 +18,7 @@ CONFIG_FB_ACCESS_TOKEN = "fb_access_token"
 CONFIG_FB_NAMESPACE = "fb_namespace"
 CONFIG_FB_TEMPLATE_LIST_DOMAIN = "fb_template_list_domain"
 CONFIG_FB_TEMPLATE_API_VERSION = "fb_template_list_domain_api_version"
+CONFIG_WEBHOOK_URL = "webhook_url"
 
 TEMPLATE_LIST_URL = "https://%s/%s/%s/message_templates"
 
@@ -64,7 +65,15 @@ class TurnType(ChannelType):
         if resp.status_code != 200:
             raise ValidationError(_("Unable to register webhooks: %(resp)s"), params={"resp": resp.text})
 
+        channel.config[CONFIG_WEBHOOK_URL] = receive_url
+        channel.save(update_fields=("config",))
+
     def deactivate(self, channel):
+        # only clear the webhook if we're the one that registered it - channels claimed before we did this, or whose
+        # registration failed, may have a webhook the user configured themselves
+        if not channel.config.get(CONFIG_WEBHOOK_URL):
+            return
+
         # resetting the application settings clears the primary webhook
         resp = requests.delete(
             channel.config[Channel.CONFIG_BASE_URL] + "/v1/settings/application",

--- a/temba/channels/types/turn/type.py
+++ b/temba/channels/types/turn/type.py
@@ -51,24 +51,25 @@ class TurnType(ChannelType):
             "Content-Type": "application/json",
         }
 
-    def _set_webhook_url(self, channel, url: str):
-        return requests.patch(
-            channel.config[Channel.CONFIG_BASE_URL] + "/v1/settings/application",
-            json={"webhooks": {"url": url}},
-            headers=self.get_headers(channel),
-        )
-
     def activate(self, channel):
         domain = channel.org.get_brand_domain()
         receive_url = "https://" + domain + reverse("courier.trn", args=[channel.uuid, "receive"])
 
-        resp = self._set_webhook_url(channel, receive_url)
+        resp = requests.patch(
+            channel.config[Channel.CONFIG_BASE_URL] + "/v1/settings/application",
+            json={"webhooks": {"url": receive_url}},
+            headers=self.get_headers(channel),
+        )
 
         if resp.status_code != 200:
             raise ValidationError(_("Unable to register webhooks: %(resp)s"), params={"resp": resp.text})
 
     def deactivate(self, channel):
-        resp = self._set_webhook_url(channel, "")
+        # resetting the application settings clears the primary webhook
+        resp = requests.delete(
+            channel.config[Channel.CONFIG_BASE_URL] + "/v1/settings/application",
+            headers=self.get_headers(channel),
+        )
 
         if resp.status_code != 200:
             raise ValidationError(_("Unable to remove webhooks: %(resp)s"), params={"resp": resp.text})

--- a/temba/channels/types/turn/type.py
+++ b/temba/channels/types/turn/type.py
@@ -3,10 +3,12 @@ import logging
 
 import requests
 
+from django.forms import ValidationError
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import Channel, ChannelType, ConfigUI
+from temba.channels.models import Channel, ChannelType
 from temba.channels.types.turn.views import ClaimView
 from temba.contacts.models import URN
 from temba.request_logs.models import HTTPLog
@@ -35,6 +37,7 @@ class TurnType(ChannelType):
 
     courier_url = r"^trn/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive)$"
     schemes = [URN.WHATSAPP_SCHEME]
+    async_activation = False
     template_type = "whatsapp"
 
     claim_blurb = _(
@@ -42,16 +45,33 @@ class TurnType(ChannelType):
     )
     claim_view = ClaimView
 
-    config_ui = ConfigUI(
-        blurb=_("To finish configuring this channel, you'll need Turn.io to use the following callback URL."),
-        endpoints=[
-            ConfigUI.Endpoint(
-                courier="receive",
-                label=_("Receive URL"),
-                help=_("This URL should be called by Turn.io when new messages are received."),
-            ),
-        ],
-    )
+    def get_headers(self, channel):
+        return {
+            "Authorization": "Bearer %s" % channel.config[Channel.CONFIG_AUTH_TOKEN],
+            "Content-Type": "application/json",
+        }
+
+    def _set_webhook_url(self, channel, url: str):
+        return requests.patch(
+            channel.config[Channel.CONFIG_BASE_URL] + "/v1/settings/application",
+            json={"webhooks": {"url": url}},
+            headers=self.get_headers(channel),
+        )
+
+    def activate(self, channel):
+        domain = channel.org.get_brand_domain()
+        receive_url = "https://" + domain + reverse("courier.trn", args=[channel.uuid, "receive"])
+
+        resp = self._set_webhook_url(channel, receive_url)
+
+        if resp.status_code != 200:
+            raise ValidationError(_("Unable to register webhooks: %(resp)s"), params={"resp": resp.text})
+
+    def deactivate(self, channel):
+        resp = self._set_webhook_url(channel, "")
+
+        if resp.status_code != 200:
+            raise ValidationError(_("Unable to remove webhooks: %(resp)s"), params={"resp": resp.text})
 
     def fetch_templates(self, channel) -> list:
         # Retrieve the template domain, fallback to the default for channels that have been setup earlier for backwards

--- a/temba/channels/types/turn/views.py
+++ b/temba/channels/types/turn/views.py
@@ -103,7 +103,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
                 tps=45,
             )
         except forms.ValidationError as e:
-            form._errors["__all__"] = form.error_class(e.messages)
+            form.add_error(None, e)
             return self.form_invalid(form)
 
         return super().form_valid(form)

--- a/temba/channels/types/turn/views.py
+++ b/temba/channels/types/turn/views.py
@@ -91,15 +91,19 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             CONFIG_FB_TEMPLATE_LIST_DOMAIN: "whatsapp.turn.io",
         }
 
-        self.object = Channel.create(
-            self.request.org,
-            self.request.user,
-            data["country"],
-            self.channel_type,
-            name="WhatsApp: %s" % data["address"],
-            address=data["address"],
-            config=config,
-            tps=45,
-        )
+        try:
+            self.object = Channel.create(
+                self.request.org,
+                self.request.user,
+                data["country"],
+                self.channel_type,
+                name="WhatsApp: %s" % data["address"],
+                address=data["address"],
+                config=config,
+                tps=45,
+            )
+        except forms.ValidationError as e:
+            form._errors["__all__"] = form.error_class(e.messages)
+            return self.form_invalid(form)
 
         return super().form_valid(form)


### PR DESCRIPTION
## Summary

Turn.io WhatsApp channels now register their webhook automatically when claimed and clear it when released, removing the need for users to manually configure the callback URL in Turn.io after claiming.

## Changes

**`temba/channels/types/turn/type.py`**
- Added `activate()`, which registers the courier receive URL as the primary webhook via `PATCH /v1/settings/application`, using the auth token obtained during claim. Raises `ValidationError` with the provider's response on failure.
- On success the registered URL is recorded in the channel config as `webhook_url`, so we know later that the webhook is ours.
- Added `deactivate()`, which clears the webhook on release via `DELETE /v1/settings/application` — the documented way to reset application settings, which clears the primary webhook. It's a no-op unless `webhook_url` is set, so we never clear a webhook we didn't register. Failures are logged by `Channel.release()` without blocking the release.
- Shared request logic factored into `get_headers()` (following the 360Dialog precedent); recording config on activation follows the Zenvia precedent.
- Set `async_activation = False` so activation runs inline during claim and failures surface to the user immediately.
- Removed `config_ui` — since the webhook is now configured automatically, the post-claim configuration page is no longer shown and the "Configuration" menu item disappears for these channels.

**`temba/channels/types/turn/views.py`**
- `ClaimView.form_valid` catches activation errors and re-renders the claim form with the error message instead of returning a server error.

## Behavior

| | Before | After |
|---|---|---|
| Claim | Channel created; user shown a configuration page with the receive URL to paste into Turn.io | Webhook registered automatically; user lands on the channel read page |
| Claim with webhook registration failure | n/a (no registration attempted) | Claim form re-rendered with the provider's error; channel not left active, and the account's existing webhook left untouched |
| Release of a channel we registered | Webhook left pointing at the dead channel | Webhook cleared on Turn.io |
| Release of a channel claimed before this change | Webhook left pointing at the dead channel | Unchanged — that webhook was configured by the user, so it isn't ours to clear |

## Test plan

- [x] `temba.channels` tests pass (claim success/failure, template fetching, token refresh, release paths)
- [x] Claim success asserts the webhook registration request URL, payload and auth headers, and that the registered URL is stored in config
- [x] Claim failure asserts the form error is shown, no active channel remains, and no clearing request is sent
- [x] Release asserts the webhook is cleared, that a failed clear still releases the channel, and that a channel without a registered webhook releases without calling Turn.io
- [x] `code_check.py` (ruff format/check, migrations, locale) clean
