### PR TITLE
Don't tell browsers to retry a websocket connection refused as unauthorized

### DIFF
--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -73,13 +73,13 @@ class EndpointsTest(APITestMixin, TembaTest):
         session.save()
         response = self.post("api.websockets.connect")
         self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
 
         # an unauthenticated request is told to disconnect
         self.client.logout()
         response = self.post("api.websockets.connect")
         self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
 
         # because it's a server-to-server POST with no CSRF token, it still works when CSRF checks are enforced
         csrf_client = self.client_class(enforce_csrf_checks=True)
@@ -183,7 +183,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.client.logout()
         response = subscribe(f"history:{contact.uuid}")
         self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
 
     def test_subscribe_notifications(self):
         def subscribe(socket, client="conn-1"):
@@ -434,7 +434,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.client.logout()
         response = self.post("api.websockets.connect")
         self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
 
     @override_settings(WEBSOCKETS_AUTH_SECRET=None)
     def test_secret_required(self):

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -47,6 +47,13 @@ SUBSCRIPTION_WINDOW = 60
 # minutes once the last subscriber stops refreshing (there's no unsubscribe callback, so this TTL is the only GC).
 SUBSCRIPTION_TTL = 150
 
+# instruction returned when a request has no valid session, telling the realtime server to close the connection. The
+# realtime protocol takes reconnect semantics from the *band* a custom disconnect code falls in, not from the number
+# itself: 3500-3999 and 4500-4999 tell the client not to reconnect, and every other custom code tells it to retry. Both
+# cases we send this for are terminal - the page needs a fresh session, which only a reload can produce - so the code
+# has to sit in a no-reconnect band or a logged-out tab retries the handshake for as long as it stays open.
+UNAUTHORIZED_DISCONNECT = {"disconnect": {"code": 4501, "reason": "unauthorized"}}
+
 
 class WebSocketsSessionAuthentication(APISessionAuthentication):
     """
@@ -89,8 +96,9 @@ class ConnectEndpoint(BaseEndpoint):
     Connection proxy called by the realtime messaging server when a browser opens a WebSocket. The browser connects
     with no auth token; the realtime server forwards the browser's session cookie and we resolve the user.
 
-    We currently require an authenticated user with a current workspace; if either is missing we return a disconnect
-    instruction so the realtime server closes the connection.
+    We currently require an authenticated user with a current workspace; if either is missing we return
+    ``UNAUTHORIZED_DISCONNECT`` so the realtime server closes the connection, and closes it terminally - the browser
+    can't fix a missing session by connecting again, so it shouldn't retry until the page is reloaded.
 
     On success the result carries:
       * ``user`` - the user identifier (uuid);
@@ -109,7 +117,7 @@ class ConnectEndpoint(BaseEndpoint):
         # for now a connection requires an authenticated user with a current workspace. This could be reworked in
         # future to also support anonymous connections - e.g. webchat - which have no Django user or workspace.
         if not user.is_authenticated or not request.org:
-            return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
+            return Response(UNAUTHORIZED_DISCONNECT)
 
         org = request.org
         meta = {"user_id": user.id, "user_uuid": str(user.uuid), "org_id": org.id, "org_uuid": str(org.uuid)}
@@ -259,7 +267,8 @@ class SubscribeEndpoint(SubscriptionEndpoint):
     Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a socket. The request
     body carries the requested socket name (in its ``channel`` field), which we authorize against the live session.
 
-    An unauthenticated request is told to disconnect (its connection should never have got this far). Otherwise, if the
+    An unauthenticated request is told to disconnect terminally (its connection should never have got this far, and
+    like connect there's nothing a retry could fix). Otherwise, if the
     user has a current workspace and may access the socket, we record the subscription and return an ``expire_at`` so
     the realtime server schedules a sub_refresh; anything else is refused with a forbidden error, which Centrifugo
     surfaces to the browser as a failed subscribe without tearing down the whole connection.
@@ -267,7 +276,7 @@ class SubscribeEndpoint(SubscriptionEndpoint):
 
     def post(self, request, *args, **kwargs):
         if not request.user.is_authenticated:
-            return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
+            return Response(UNAUTHORIZED_DISCONNECT)
 
         socket = request.data.get("channel", "")
 


### PR DESCRIPTION
## Problem

The websockets API refused unauthenticated `connect` and `subscribe` proxy calls with disconnect code **4401**, presumably chosen to echo HTTP 401. But in the realtime protocol the numeric *band* of a custom disconnect code carries reconnect semantics:

- `3500-3999` and `4500-4999` → client does **not** reconnect
- everything else custom (including `4000-4499`) → client **does** reconnect

So 4401 read as "unauthorized, please try again", and browsers did exactly that. A tab whose Django session expired or logged out re-attempted the connection roughly every 25 seconds (the client's backoff cap) for as long as it stayed open — each attempt a WebSocket handshake plus a connect-proxy POST and a full session read. It produces no reply-error metric either, so the retry storm is invisible to monitoring.

Verified against centrifuge-js 5.7 (`_handleDisconnect` and the transport close handler both clear `reconnect` only for those two bands).

## Fix

Use **4501** instead, with the same `"reason": "unauthorized"`. Both sites are terminal cases — the page needs a fresh session, which only a reload can produce — so a session-less page now stops asking.

The literal is pulled up into a named `UNAUTHORIZED_DISCONNECT` constant carrying a comment on why the band matters, since the bare number otherwise looks like an arbitrary HTTP-ish status to the next reader. The `ConnectEndpoint` / `SubscribeEndpoint` docstrings now say the disconnect is terminal.

Nothing on the client side changes.

## Testing

`temba.api.websockets` — 11 tests, all passing.