### PR TITLE
Block re-paging while a list fetch is in flight and keep position out of list URLs

### DIFF
--- a/components/src/list/ContentList.ts
+++ b/components/src/list/ContentList.ts
@@ -1362,11 +1362,13 @@ export class ContentList<T = any> extends RapidElement {
   @property({ type: Boolean, attribute: 'fill-window' })
   fillWindow = false;
 
-  /** When true, sort/search state is reflected to the URL via
+  /** When true, sort/search/page state is reflected to the URL via
    * `history.pushState` so the page is deep-linkable and back/forward
-   * navigates between list states. List position stays out of the URL
-   * (it restores from history state instead); a `page` param is still
-   * read on load for old bookmarked URLs. Off by default — opt in. */
+   * navigates between list states. This mode has no history stash, so
+   * the URL is its only position store: page-counted lists round-trip
+   * `page=N` (a cursor slice has no page number to round-trip). Off
+   * by default — opt in; mutually exclusive with
+   * {@link historyStateKey}, which keeps position out of the URL. */
   @property({ type: Boolean })
   urlState = false;
 
@@ -1823,10 +1825,11 @@ export class ContentList<T = any> extends RapidElement {
     if (overflows !== this.bulkCollapsed) this.bulkCollapsed = overflows;
   }
 
-  /** Read sort/page/search from the URL on first load / popstate. The
-   * page param is read-only compatibility — we never write it (see
-   * {@link buildBrowserUrl}), but an old bookmarked URL may carry one
-   * and page-counted endpoints still honor it. */
+  /** Read sort/page/search from the URL on first load / popstate. In
+   * history-state mode the page param is read-only compatibility — we
+   * never write it there (see {@link buildBrowserUrl}), but an old
+   * bookmarked URL may carry one and page-counted endpoints still
+   * honor it. In urlState mode it's the round-tripped position. */
   private readUrlState(): void {
     const params = new URLSearchParams(window.location.search);
     const k = (name: string) =>
@@ -1882,12 +1885,20 @@ export class ContentList<T = any> extends RapidElement {
     };
     setOrDelete(k('search'), this.search);
     setOrDelete(k('sort'), this.sort);
-    // List position never reaches the URL — a cursor slice has no
-    // meaningful page number, and page-counted lists restore their
-    // position from the history stash instead, so all list pages keep
-    // the same clean URL while paging. Passing '' also scrubs a stale
-    // page param arriving on an old bookmarked URL.
-    setOrDelete(k('page'), '');
+    // In history-state mode list position never reaches the URL — a
+    // cursor slice has no meaningful page number, and page-counted
+    // lists restore their position from the history stash instead, so
+    // all list pages keep the same clean URL while paging (passing ''
+    // also scrubs a stale page param arriving on an old bookmarked
+    // URL). A pure urlState list is the exception: it has no history
+    // stash — the URL is its only position store — so a page-counted
+    // one keeps round-tripping `page=N` there.
+    setOrDelete(
+      k('page'),
+      this.urlState && !this.cursorMode && this.page > 1
+        ? String(this.page)
+        : ''
+    );
 
     const qs = params.toString();
     return window.location.pathname + (qs ? '?' + qs : '');

--- a/components/src/list/ContentList.ts
+++ b/components/src/list/ContentList.ts
@@ -1362,9 +1362,11 @@ export class ContentList<T = any> extends RapidElement {
   @property({ type: Boolean, attribute: 'fill-window' })
   fillWindow = false;
 
-  /** When true, sort/search/page state is reflected to the URL via
+  /** When true, sort/search state is reflected to the URL via
    * `history.pushState` so the page is deep-linkable and back/forward
-   * navigates between list states. Off by default — opt in. */
+   * navigates between list states. List position stays out of the URL
+   * (it restores from history state instead); a `page` param is still
+   * read on load for old bookmarked URLs. Off by default — opt in. */
   @property({ type: Boolean })
   urlState = false;
 
@@ -1700,7 +1702,7 @@ export class ContentList<T = any> extends RapidElement {
         this.readHistoryState();
         const restore = this.restoreUrl;
         this.restoreUrl = '';
-        this.fetchPage(restore || undefined);
+        this.fetchPage(restore || undefined, !!restore);
       };
       window.addEventListener('popstate', this.popstateHandler);
     }
@@ -1772,7 +1774,7 @@ export class ContentList<T = any> extends RapidElement {
       // Clear it so subsequent fetches use the live state.
       const restore = this.restoreUrl;
       this.restoreUrl = '';
-      this.fetchPage(restore || undefined);
+      this.fetchPage(restore || undefined, !!restore);
     }
     // Pinned-column offsets and the scroll affordances both depend
     // on the freshly-laid-out DOM, so settle them after each render.
@@ -1821,7 +1823,10 @@ export class ContentList<T = any> extends RapidElement {
     if (overflows !== this.bulkCollapsed) this.bulkCollapsed = overflows;
   }
 
-  /** Read sort/page/search from the URL on first load / popstate. */
+  /** Read sort/page/search from the URL on first load / popstate. The
+   * page param is read-only compatibility — we never write it (see
+   * {@link buildBrowserUrl}), but an old bookmarked URL may carry one
+   * and page-counted endpoints still honor it. */
   private readUrlState(): void {
     const params = new URLSearchParams(window.location.search);
     const k = (name: string) =>
@@ -1877,7 +1882,12 @@ export class ContentList<T = any> extends RapidElement {
     };
     setOrDelete(k('search'), this.search);
     setOrDelete(k('sort'), this.sort);
-    setOrDelete(k('page'), this.page > 1 ? String(this.page) : '');
+    // List position never reaches the URL — a cursor slice has no
+    // meaningful page number, and page-counted lists restore their
+    // position from the history stash instead, so all list pages keep
+    // the same clean URL while paging. Passing '' also scrubs a stale
+    // page param arriving on an old bookmarked URL.
+    setOrDelete(k('page'), '');
 
     const qs = params.toString();
     return window.location.pathname + (qs ? '?' + qs : '');
@@ -2020,8 +2030,13 @@ export class ContentList<T = any> extends RapidElement {
   /** Fetch a page. With no argument this builds a fresh request from
    * the endpoint + current sort/search/page (resetting a cursor list
    * to its first page); pass an explicit `url` to follow a cursor or
-   * to re-request {@link currentUrl}. */
-  private async fetchPage(url?: string): Promise<void> {
+   * to re-request {@link currentUrl}. `restash` marks a restore fetch
+   * (one following a {@link restoreUrl} out of history state): on
+   * success the list re-bubbles its state with `replace` so the stash
+   * is written back onto the freshly loaded entry — the SPA frame's
+   * history bootstrap rebuilds entry state on every page load, so
+   * without this a stash would only reliably survive one refresh. */
+  private async fetchPage(url?: string, restash = false): Promise<void> {
     if (!this.endpoint) return;
     if (this.pending) this.pending.abort();
     const controller = new AbortController();
@@ -2080,6 +2095,12 @@ export class ContentList<T = any> extends RapidElement {
       if (wasSearch && typeof data.query === 'string') {
         this.search = data.query;
         this.searchDraft = data.query;
+        this.writeUrlState(true);
+      }
+      // A restore fetch re-writes its stash onto the current entry
+      // (replacing, so no new back-history) now that the state it was
+      // restored from is live again.
+      if (restash) {
         this.writeUrlState(true);
       }
     } catch (err) {
@@ -2358,13 +2379,20 @@ export class ContentList<T = any> extends RapidElement {
   }
 
   private handlePage(delta: number): void {
+    // One page step at a time: while a fetch is in flight the buttons
+    // render disabled, but guard here too so a click that lands before
+    // the re-render can't fire a second request — in cursor mode it
+    // would re-follow the same stale next/previous URL and land on the
+    // wrong slice.
+    if (this.loading) return;
     // A cursor list has no page numbers — step by following the
     // opaque next/previous URL the last response handed back. Call
     // fetchPage first so currentUrl is updated synchronously, then
     // bubble state so the saved URL points at the new view. The
-    // synthetic page number is bumped only to give each history entry
-    // a distinct URL; the cursor URL stashed in history.state is what
-    // actually drives restoration.
+    // synthetic page number is bumped only to position the pager's
+    // "N–M of Total" window (it never reaches the URL in cursor
+    // mode); the cursor URL stashed in history.state is what actually
+    // drives restoration.
     if (this.cursorMode) {
       const target = delta > 0 ? this.nextCursor : this.prevCursor;
       if (target) {
@@ -3863,8 +3891,10 @@ export class ContentList<T = any> extends RapidElement {
    * the response carried a count (`hasCount`) — in cursor mode too,
    * using the synthetic page for the range; an uncounted cursor list
    * falls back to chevrons only, gated on whether the last response
-   * handed back a cursor for that direction. Returns nothing when there
-   * is neither a page to move to nor a count worth showing. */
+   * handed back a cursor for that direction. Both buttons disable
+   * while a fetch is in flight so a second step can't fire until the
+   * first comes back (or fails). Returns nothing when there is neither
+   * a page to move to nor a count worth showing. */
   private renderPager(): TemplateResult {
     const lastPage = Math.max(1, Math.ceil(this.total / this.pageSize));
     const first = this.total === 0 ? 0 : (this.page - 1) * this.pageSize + 1;
@@ -3886,7 +3916,7 @@ export class ContentList<T = any> extends RapidElement {
       <div class="pager">
         <span
           class="page-btn"
-          ?disabled=${atStart}
+          ?disabled=${atStart || this.loading}
           @click=${() => this.handlePage(-1)}
           aria-label="Previous page"
         >
@@ -3900,7 +3930,7 @@ export class ContentList<T = any> extends RapidElement {
           : null}
         <span
           class="page-btn"
-          ?disabled=${atEnd}
+          ?disabled=${atEnd || this.loading}
           @click=${() => this.handlePage(1)}
           aria-label="Next page"
         >

--- a/components/test/temba-content-list.test.ts
+++ b/components/test/temba-content-list.test.ts
@@ -1563,6 +1563,145 @@ describe('temba-content-list', () => {
     expect(next2.hasAttribute('disabled')).to.equal(true);
   });
 
+  it('blocks paging while a page fetch is in flight', async () => {
+    clearMockGets();
+    // a counted cursor endpoint (like the messages API)
+    mockGET(/\/msgs\.json\?cursor=abc/, {
+      next: null,
+      previous: '/msgs.json?cursor=xyz',
+      count: 4,
+      results: [
+        { uuid: 'm-3', name: 'Charlie' },
+        { uuid: 'm-4', name: 'Delta' }
+      ]
+    });
+    mockGET(/\/msgs\.json$/, {
+      next: '/msgs.json?cursor=abc',
+      previous: null,
+      count: 4,
+      results: [
+        { uuid: 'm-1', name: 'Alpha' },
+        { uuid: 'm-2', name: 'Bravo' }
+      ]
+    });
+
+    const list = (await getList({
+      endpoint: '/msgs.json'
+    })) as ContentList;
+    list.columns = [{ key: 'name', label: 'Name' }];
+    await list.updateComplete;
+
+    const fetchStub = window.fetch as any;
+    const countCursorFetches = () =>
+      fetchStub
+        .getCalls()
+        .filter((c: any) => String(c.args[0]).includes('cursor=abc')).length;
+
+    const onPage2 = new Promise<void>((resolve) => {
+      list.addEventListener(CustomEventType.FetchComplete, () => resolve(), {
+        once: true
+      });
+    });
+    const [, next] = list.shadowRoot!.querySelectorAll('.page-btn');
+    (next as HTMLElement).click();
+
+    // while the request is in flight further paging is blocked — a
+    // repeat click can't fire a second fetch (in cursor mode it would
+    // re-follow the same stale next URL and land on the wrong slice)
+    expect((list as any).loading).to.equal(true);
+    (next as HTMLElement).click();
+    expect(countCursorFetches()).to.equal(1);
+
+    await onPage2;
+    await list.updateComplete;
+    expect((list as any).items[0].name).to.equal('Charlie');
+
+    // and the buttons themselves render disabled while loading
+    (list as any).loading = true;
+    await list.updateComplete;
+    list.shadowRoot!.querySelectorAll('.page-btn').forEach((btn) => {
+      expect(btn.hasAttribute('disabled')).to.equal(true);
+    });
+    (list as any).loading = false;
+    await list.updateComplete;
+  });
+
+  it('keeps position out of the URL for page-counted lists too', async () => {
+    const list = (await getList({
+      endpoint: '/test-assets/content-list/items.json'
+    })) as ContentList;
+    // a page-counted list several pages in still bubbles a clean URL —
+    // position restores from the history stash, not the query string
+    (list as any).page = 3;
+    expect((list as any).cursorMode).to.equal(false);
+    expect((list as any).buildBrowserUrl()).to.not.contain('page=');
+  });
+
+  it('re-stashes its state onto the history entry after restoring from it', async () => {
+    clearMockGets();
+    mockGET(/\/msgs\.json\?cursor=abc/, {
+      next: null,
+      previous: '/msgs.json?cursor=xyz',
+      count: 4,
+      results: [
+        { uuid: 'm-3', name: 'Charlie' },
+        { uuid: 'm-4', name: 'Delta' }
+      ]
+    });
+    mockGET(/\/msgs\.json$/, {
+      next: '/msgs.json?cursor=abc',
+      previous: null,
+      count: 4,
+      results: [
+        { uuid: 'm-1', name: 'Alpha' },
+        { uuid: 'm-2', name: 'Bravo' }
+      ]
+    });
+
+    const list = (await getList({
+      endpoint: '/msgs.json',
+      'history-state-key': 'msgs'
+    })) as ContentList;
+    list.columns = [{ key: 'name', label: 'Name' }];
+    await list.updateComplete;
+
+    try {
+      // return to an entry whose stash points at the second slice (as
+      // after a refresh, where the SPA frame's history bootstrap has
+      // rebuilt the entry state around the preserved stash)
+      history.replaceState(
+        {
+          msgs: { page: 2, sort: '', search: '', url: '/msgs.json?cursor=abc' }
+        },
+        ''
+      );
+
+      const events: any[] = [];
+      list.addEventListener(CustomEventType.HistoryChange, (e: any) =>
+        events.push(e.detail)
+      );
+      const onRestore = new Promise<void>((resolve) => {
+        list.addEventListener(CustomEventType.FetchComplete, () => resolve(), {
+          once: true
+        });
+      });
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      await onRestore;
+
+      // the restore followed the stashed cursor URL to the saved slice
+      expect((list as any).items[0].name).to.equal('Charlie');
+
+      // and re-bubbled a replacing stash so the entry carries the
+      // state again — this is what lets the next refresh restore too
+      const restash = events.find((e) => e.replace && e.state?.url);
+      assert.exists(restash, 'restore should re-bubble a replacing stash');
+      expect(restash.state.url).to.equal('/msgs.json?cursor=abc');
+      expect(restash.state.page).to.equal(2);
+    } finally {
+      history.replaceState({}, '');
+    }
+  });
+
   it('shows the run-search icon and its hint only while a pending draft is uncommitted', async () => {
     const list = (await getList({
       endpoint: '/test-assets/content-list/items.json'
@@ -1898,6 +2037,9 @@ describe('temba-content-list', () => {
     expect(pageEvent.key).to.equal('msgs');
     expect(pageEvent.replace).to.equal(false);
     expect(pageEvent.state.page).to.equal(2);
+    // list position stays out of the address-bar URL — it restores
+    // from the history stash instead
+    expect(pageEvent.url).to.not.contain('page=');
 
     // committed search — also pushes a new entry
     events.length = 0;

--- a/components/test/temba-content-list.test.ts
+++ b/components/test/temba-content-list.test.ts
@@ -1635,6 +1635,12 @@ describe('temba-content-list', () => {
     (list as any).page = 3;
     expect((list as any).cursorMode).to.equal(false);
     expect((list as any).buildBrowserUrl()).to.not.contain('page=');
+
+    // except in urlState mode, which has no history stash — there the
+    // URL is the only position store, so page keeps round-tripping
+    list.urlState = true;
+    expect((list as any).buildBrowserUrl()).to.contain('page=3');
+    list.urlState = false;
   });
 
   it('re-stashes its state onto the history entry after restoring from it', async () => {
@@ -2093,8 +2099,10 @@ describe('temba-content-list', () => {
     expect((list as any).sort).to.equal('-name');
     expect((list as any).search).to.equal('b');
 
-    // Simulate browser back to an entry with different list state.
-    history.replaceState({ msgs: { page: 1, sort: 'name', search: '' } }, '');
+    // Simulate browser back to an entry with different list state —
+    // several pages in, as a page-counted list's stash would be after
+    // paging (this is the only position store; the URL carries none).
+    history.replaceState({ msgs: { page: 3, sort: 'name', search: '' } }, '');
     const onFetch = new Promise<void>((resolve) => {
       list.addEventListener(CustomEventType.FetchComplete, () => resolve(), {
         once: true
@@ -2105,6 +2113,9 @@ describe('temba-content-list', () => {
 
     expect((list as any).sort).to.equal('name');
     expect((list as any).search).to.equal('');
+    // the page came back from the stash and was re-sent to the endpoint
+    expect((list as any).page).to.equal(3);
+    expect((list as any).currentUrl).to.contain('page=3');
   });
 
   it('falls back to URL params when history has no stash for the key', async () => {

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -667,9 +667,16 @@ document.addEventListener('DOMContentLoaded', function () {
   if (container) {
     container.classList.remove('initial-load');
 
-    // set initial history state so back button works for the first page
+    // set initial history state so back button works for the first page —
+    // merged into whatever state the entry already carries rather than
+    // overwriting it: components stash their own restorable state on the
+    // entry (e.g. a list's page/sort/search, via temba-history-change) and
+    // browsers preserve history.state across reloads, so clobbering it here
+    // would make that stash survive only a single refresh
     window.history.replaceState(
-      { url: document.location.href },
+      Object.assign({}, window.history.state, {
+        url: document.location.href
+      }),
       '',
       document.location.href
     );


### PR DESCRIPTION
## Summary

Two fixes to how the list component pages. The pager now blocks stepping again until the in-flight page request comes back (or fails), and list position no longer leaks into the address-bar URL on the app's list pages — it restores from history state instead, so refreshing a paged list always lands back on the same page, on every list page.

## Changes

**`components/src/list/ContentList.ts`**
- `handlePage` ignores clicks while a fetch is loading, and both pager buttons render disabled until the request settles. Without this, a rapid second click on next would re-follow the same stale cursor URL and land on the wrong slice (cursor-paginated lists only hand out `next`/`previous` one response at a time).
- In history-state mode (all in-repo list pages), `buildBrowserUrl` never writes `page=` — a cursor slice has no meaningful page number (the messages API ignores `?page=N`), and page-counted lists (contacts, flows, broadcasts, …) restore their position from the history stash, so every list page keeps the same clean URL while paging. A stale `page=` arriving on an old bookmarked URL is scrubbed; `readUrlState` still honors one on load for compatibility.
- The `urlState` mode is the exception: it has no history stash — the URL is its only position store — so page-counted lists there keep round-tripping `page=N`. (Public property; no in-repo template uses it.)
- A fetch that follows a `restoreUrl` out of history state now re-bubbles a replacing stash onto the freshly loaded entry, so restoration no longer depends on the component happening to read its stash before the SPA frame's history bootstrap rebuilds the entry state.

**`static/js/frame.js`**
- The `DOMContentLoaded` history bootstrap merges `{url}` into whatever state the entry already carries instead of overwriting it. Components stash restorable state (page/sort/search, cursor URL) on the entry and browsers preserve `history.state` across reloads — previously the bootstrap clobbered that stash on every load, so restoring worked on the first refresh (mount read the stash before the wipe) but never the second.

## Behavior

| Action | Before | After |
|---|---|---|
| Double-click next quickly | second request re-follows stale cursor, wrong slice | second click ignored until the first settles |
| Page forward, refresh once | restores the slice | restores the slice |
| Refresh again (and again) | snaps back to page one | keeps restoring the same slice |
| URL while on page 3 of contacts | `?page=3` | clean URL, position in history state |

## Test plan

- New test: a repeat click during an in-flight page fetch fires no second request, and the pager buttons render disabled while loading
- New test: a page-counted list several pages in bubbles a clean URL (no `page=`), with the `urlState` exception asserted alongside
- New test: restoring from a history-state stash follows the stashed cursor URL and re-bubbles a replacing stash onto the entry
- Popstate-restore test now seeds page 3 and asserts the list comes back on page 3 with `page=3` re-sent to the endpoint
- Existing history-change test now asserts the bubbled URL carries no `page=`
- Full components suite passes (including screenshot tests)

## Review notes

- The `review` job flagged that dropping `page=` regressed the `urlState`-only mode (no history stash, URL is the position store) — fixed by keeping the round-trip there; and asked for coverage of page-counted stash restoration — added to the popstate-restore test.