### PR TITLE
Route dialog button clicks by button type instead of display name

### DIFF
--- a/components/src/flow/Editor.ts
+++ b/components/src/flow/Editor.ts
@@ -59,7 +59,7 @@ import {
 import { CanvasNode } from './CanvasNode';
 import { DragManager } from './DragManager';
 import { ZoomManager } from './ZoomManager';
-import { Dialog } from '../layout/Dialog';
+import { ButtonType, Dialog } from '../layout/Dialog';
 
 import { CanvasMenu, CanvasMenuSelection } from './CanvasMenu';
 import { NodeTypeSelector, NodeTypeSelection } from './NodeTypeSelector';
@@ -1964,7 +1964,7 @@ export class Editor extends RapidElement {
       // Cancel/Escape route through this same event; tear the dialog down.
       // Ignore cancel while a swap is in flight — the request can't be recalled,
       // so closing here would let the change land after an apparent cancel.
-      if (event.detail.button.name !== updateName) {
+      if (event.detail.detail.type !== ButtonType.PRIMARY) {
         if (submitting) {
           return;
         }
@@ -2444,9 +2444,10 @@ export class Editor extends RapidElement {
     dialog.appendChild(content);
 
     dialog.addEventListener('temba-button-clicked', (event: any) => {
-      // matched by name, not the primary flag: on a destructive dialog the
-      // primary button carries destructive instead of primary
-      if (event.detail.button.name === deleteName) {
+      // matched by DialogButton type, not the element's primary flag: on a
+      // destructive dialog the rendered button carries destructive instead of
+      // primary, but its type stays primary
+      if (event.detail.detail.type === ButtonType.PRIMARY) {
         this.deleteSelectedItems();
         dialog.open = false;
       }

--- a/components/src/flow/NodeEditor.ts
+++ b/components/src/flow/NodeEditor.ts
@@ -21,7 +21,7 @@ import {
   SPLIT_GROUP_METADATA
 } from './types';
 import { CustomEventType } from '../interfaces';
-import { Dialog } from '../layout/Dialog';
+import { ButtonType, Dialog } from '../layout/Dialog';
 import { formatCount, generateUUID } from '../utils';
 import {
   formatIssueMessage,
@@ -979,11 +979,11 @@ export class NodeEditor extends RapidElement {
   }
 
   private handleDialogButtonClick(event: CustomEvent): void {
-    const button = event.detail.button;
+    const button = event.detail.detail;
 
-    if (button.name === msg('Save')) {
+    if (button.type === ButtonType.PRIMARY) {
       this.handleSave();
-    } else if (button.name === msg('Cancel')) {
+    } else if (button.type === ButtonType.SECONDARY) {
       this.handleCancel();
     }
   }

--- a/components/src/live/AliasEditor.ts
+++ b/components/src/live/AliasEditor.ts
@@ -2,6 +2,7 @@ import { css, html, LitElement, TemplateResult } from 'lit';
 import { FeatureProperties } from '../interfaces';
 import { getUrl, postJSON, WebResponse } from '../utils';
 import { TextInput } from '../form/TextInput';
+import { ButtonType } from '../layout/Dialog';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import { Icon } from '../Icons';
 
@@ -317,8 +318,8 @@ export class AliasEditor extends LitElement {
   }
 
   private handleDialogClick(evt: CustomEvent) {
-    const button = evt.detail.button;
-    if (button.name === 'Save') {
+    const button = evt.detail.detail;
+    if (button.type === ButtonType.PRIMARY) {
       const textarea = this.shadowRoot.getElementById(
         this.editFeature.osm_id
       ) as TextInput;
@@ -332,7 +333,7 @@ export class AliasEditor extends LitElement {
       });
     }
 
-    if (button.name === 'Cancel') {
+    if (button.type === ButtonType.SECONDARY) {
       this.hideAliasDialog();
     }
   }

--- a/components/test/temba-localization.test.ts
+++ b/components/test/temba-localization.test.ts
@@ -2157,7 +2157,10 @@ describe('Localization Editing', () => {
       const dialog = document.body.querySelector('temba-dialog') as any;
       dialog.dispatchEvent(
         new CustomEvent('temba-button-clicked', {
-          detail: { button: { name: 'Update' } }
+          detail: {
+            button: { name: 'Update' },
+            detail: { name: 'Update', type: 'primary' }
+          }
         })
       );
       await aTimeout(10);
@@ -2267,7 +2270,10 @@ describe('Localization Editing', () => {
       const dialog = document.body.querySelector('temba-dialog') as any;
       dialog.dispatchEvent(
         new CustomEvent('temba-button-clicked', {
-          detail: { button: { name: 'Update' } }
+          detail: {
+            button: { name: 'Update' },
+            detail: { name: 'Update', type: 'primary' }
+          }
         })
       );
       await aTimeout(0);
@@ -2277,7 +2283,10 @@ describe('Localization Editing', () => {
       expect(dialog.cancelButtonName).to.equal('');
       dialog.dispatchEvent(
         new CustomEvent('temba-button-clicked', {
-          detail: { button: { name: 'Cancel' } }
+          detail: {
+            button: { name: 'Cancel' },
+            detail: { name: 'Cancel', type: 'secondary', closes: true }
+          }
         })
       );
       await aTimeout(0);

--- a/components/test/temba-node-editor.test.ts
+++ b/components/test/temba-node-editor.test.ts
@@ -246,7 +246,10 @@ describe('temba-node-editor', () => {
 
     // Test Save button by dispatching event on the dialog
     const saveEvent = new CustomEvent('temba-button-clicked', {
-      detail: { button: { name: 'Save' } },
+      detail: {
+        button: { name: 'Save' },
+        detail: { name: 'Save', type: 'primary' }
+      },
       bubbles: true
     });
     dialog!.dispatchEvent(saveEvent);
@@ -257,7 +260,10 @@ describe('temba-node-editor', () => {
 
     // Test Cancel button
     const cancelEvent = new CustomEvent('temba-button-clicked', {
-      detail: { button: { name: 'Cancel' } },
+      detail: {
+        button: { name: 'Cancel' },
+        detail: { name: 'Cancel', type: 'secondary', closes: true }
+      },
       bubbles: true
     });
     dialog!.dispatchEvent(cancelEvent);
@@ -341,7 +347,10 @@ describe('temba-node-editor', () => {
     const dialog = el.shadowRoot!.querySelector('temba-dialog');
     dialog!.dispatchEvent(
       new CustomEvent('temba-button-clicked', {
-        detail: { button: { name: 'Save' } },
+        detail: {
+          button: { name: 'Save' },
+          detail: { name: 'Save', type: 'primary' }
+        },
         bubbles: true
       })
     );
@@ -429,7 +438,10 @@ describe('temba-node-editor', () => {
     const dialog = el.shadowRoot!.querySelector('temba-dialog');
     dialog!.dispatchEvent(
       new CustomEvent('temba-button-clicked', {
-        detail: { button: { name: 'Save' } },
+        detail: {
+          button: { name: 'Save' },
+          detail: { name: 'Save', type: 'primary' }
+        },
         bubbles: true
       })
     );


### PR DESCRIPTION
Dialog button click handlers routed save vs cancel by comparing the button's display name — against `msg()`-localized strings in the flow editor and node editor, and against raw English literals in the alias editor — which is fragile now that dialog button labels are localized.

`Dialog` already builds its buttons with a stable `type` (`ButtonType.PRIMARY` / `ButtonType.SECONDARY`) and includes the full button object in the `temba-button-clicked` event detail, so handlers now route on that instead, as `Modax` already does. Button labels themselves stay localized.

- `NodeEditor`, `AliasEditor` and both `Editor` dialog handlers (change default language, delete confirmation) now route on `type`
- On a destructive dialog the rendered button carries the `destructive` flag instead of `primary`, but its `type` stays `primary`, so type-based routing also removes the delete-confirmation handler's need to match by name
- Tests that dispatch synthetic `temba-button-clicked` events updated to the real event shape (which includes the `DialogButton` as `detail.detail`)

No dialog has more than one button of a given type (only `Dialog.updateButtons()` and `Modax` construct buttons), so `type` is a sufficient discriminator; display-only uses of `button.name` are unchanged.