### PR TITLE
Add search button to the tickets menu

### DIFF
--- a/components/src/form/KeyValueEditor.ts
+++ b/components/src/form/KeyValueEditor.ts
@@ -24,12 +24,13 @@ export class KeyValueEditor extends BaseListEditor<KeyValueItem> {
   @state()
   private keyErrors: { [index: number]: string } = {};
 
-  // Configure to maintain empty items
-  maintainEmptyItem = true;
-
   constructor() {
     super();
     this._items = [];
+    // maintain an empty item. Set in the constructor, not as a class field - a field
+    // would shadow the reactive accessor under define semantics (see lit
+    // class-field-shadowing)
+    this.maintainEmptyItem = true;
   }
 
   // External API uses array format to preserve duplicate keys

--- a/components/src/list/TembaMenu.ts
+++ b/components/src/list/TembaMenu.ts
@@ -1025,7 +1025,7 @@ export class TembaMenu extends ResizeElement {
       return;
     }
 
-    if (menuItem.type === 'modax-button') {
+    if (menuItem.type === 'modax-button' || menuItem.type === 'button') {
       this.fireCustomEvent(CustomEventType.ButtonClicked, {
         item: menuItem,
         selection: this.getSelection(),
@@ -1275,7 +1275,7 @@ export class TembaMenu extends ResizeElement {
       return html`<div class="sub-section">${menuItem.name}</div>`;
     }
 
-    if (menuItem.type === 'modax-button') {
+    if (menuItem.type === 'modax-button' || menuItem.type === 'button') {
       return html`<temba-button
         name=${menuItem.name}
         lined

--- a/components/src/live/TicketSearch.ts
+++ b/components/src/live/TicketSearch.ts
@@ -76,13 +76,18 @@ export class TicketSearch extends SearchModal<TicketSearchResult> {
   @property({ type: String })
   endpoint = '/ticket/search/';
 
-  // searching hits an endpoint, so wait for Enter
-  searchOnEnter = true;
-
   // how many matches the last search found in tickets this user can't access,
   // so an empty result set can say why it's empty
   @state()
   private dropped = 0;
+
+  constructor() {
+    super();
+    // searching hits an endpoint, so wait for Enter. Set in the constructor, not as a
+    // class field - a field would shadow the reactive accessor under define semantics
+    // (see lit class-field-shadowing)
+    this.searchOnEnter = true;
+  }
 
   // the in-flight request, aborted when it's superseded or the modal closes
   private abortController: AbortController = null;

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 19:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -3699,6 +3699,9 @@ msgstr ""
 msgid "Analytics"
 msgstr ""
 
+msgid "Search"
+msgstr ""
+
 msgid "New Topic"
 msgstr ""
 
@@ -4320,9 +4323,6 @@ msgid "Once you connect a number you will immediately be able to send and receiv
 msgstr ""
 
 msgid "Pattern"
-msgstr ""
-
-msgid "Search"
 msgstr ""
 
 msgid "Existing Numbers"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 19:39+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -3725,6 +3725,9 @@ msgstr "Temas"
 msgid "Analytics"
 msgstr "Analítica"
 
+msgid "Search"
+msgstr "Buscar"
+
 msgid "New Topic"
 msgstr "Nuevo tema"
 
@@ -4354,9 +4357,6 @@ msgstr "Una vez que conecte un número, inmediatamente podrá enviar y recibir m
 
 msgid "Pattern"
 msgstr "Patrón"
-
-msgid "Search"
-msgstr "Buscar"
 
 msgid "Existing Numbers"
 msgstr "Números existentes"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 19:39+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -3725,6 +3725,9 @@ msgstr "Sujets"
 msgid "Analytics"
 msgstr "Analytique"
 
+msgid "Search"
+msgstr "Recherche"
+
 msgid "New Topic"
 msgstr "Nouveau sujet"
 
@@ -4354,9 +4357,6 @@ msgstr "Une fois que vous connectez un numéro, vous pourrez immédiatement envo
 
 msgid "Pattern"
 msgstr "Pattern"
-
-msgid "Search"
-msgstr "Recherche"
 
 msgid "Existing Numbers"
 msgstr "Numéros existants"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 15:29+0000\n"
+"POT-Creation-Date: 2026-08-13 19:39+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -3729,6 +3729,9 @@ msgstr "Tópicos"
 msgid "Analytics"
 msgstr "Análises"
 
+msgid "Search"
+msgstr "Pesquisar"
+
 msgid "New Topic"
 msgstr "Novo tópico"
 
@@ -4358,9 +4361,6 @@ msgstr "Depois de conectar um número, você poderá enviar e receber mensagens 
 
 msgid "Pattern"
 msgstr "Padrão"
-
-msgid "Search"
-msgstr "Pesquisar"
 
 msgid "Existing Numbers"
 msgstr "Números Existentes"

--- a/temba/orgs/views/base.py
+++ b/temba/orgs/views/base.py
@@ -200,6 +200,16 @@ class BaseMenuView(OrgPermsMixin, SmartTemplateView):
 
         return menu_item
 
+    def create_event_button(self, name, event, icon=None):
+        """
+        A button (rendered like a modax button) whose click dispatches the given custom event on the document
+        """
+        menu_item = {"id": slugify(name), "name": name, "type": "button", "event": event}
+        if icon:
+            menu_item["icon"] = icon
+
+        return menu_item
+
     def create_menu_item(
         self,
         menu_id=None,

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -216,6 +216,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
                 "All (4)",
                 "Shortcuts (0)",
                 "Analytics",
+                "Search",
                 "Export",
                 "New Topic",
                 ("Topics", ["General (2)", "Sales (2)", "Support (0)"]),
@@ -233,14 +234,23 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
                 "All (4)",
                 ("Topics", ["General (2)", "Sales (2)", "Support (0)"]),
                 "Analytics",
+                "Search",
                 "Export",
                 "New Topic",
             ],
         )
+
+        # agent isn't topic restricted so gets search, but no export
         self.assertPageMenu(
             menu_url,
             self.agent,
-            ["My Tickets (0)", "Unassigned (1)", "All (4)", ("Topics", ["General (2)", "Sales (2)", "Support (0)"])],
+            [
+                "My Tickets (0)",
+                "Unassigned (1)",
+                "All (4)",
+                ("Topics", ["General (2)", "Sales (2)", "Support (0)"]),
+                "Search",
+            ],
         )
         self.assertPageMenu(
             menu_url, self.agent2, ["My Tickets (0)", "Unassigned (0)", "All (2)", ("Topics", ["Sales (2)"])]

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -270,6 +270,11 @@ class TicketCRUDL(SmartCRUDL):
                 )
 
             menu.append(self.create_space())
+
+            # cross-ticket search is only available to users who can access all topics (see TicketCRUDL.Search)
+            if self.has_org_perm("tickets.ticket_list") and Topic.get_restriction(org, user) is None:
+                menu.append(self.create_event_button(_("Search"), "temba-ticket-search-show", icon="search"))
+
             menu.append(self.create_modax_button(_("Export"), "tickets.ticket_export", icon="export"))
             if not Topic.is_limit_reached(org):
                 menu.append(

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -646,9 +646,10 @@
       }
     }
 
-    // cmd/ctrl+F opens ticket search while this page is loaded (the handler is
-    // stored on window so SPA navigations back here don't stack up listeners).
-    // it's a no-op for users without search - the modal isn't mounted for them
+    // cmd/ctrl+F and the menu's search button (see TicketCRUDL.Menu) open
+    // ticket search while this page is loaded (the handlers are stored on
+    // window so SPA navigations back here don't stack up listeners).
+    // they're no-ops for users without search - the modal isn't mounted for them
     if (window.handleTicketSearchHotkey) {
       document.removeEventListener("keydown", window.handleTicketSearchHotkey);
     }
@@ -663,6 +664,17 @@
       }
     };
     document.addEventListener("keydown", window.handleTicketSearchHotkey);
+
+    if (window.handleTicketSearchShow) {
+      document.removeEventListener("temba-ticket-search-show", window.handleTicketSearchShow);
+    }
+    window.handleTicketSearchShow = function() {
+      const search = document.querySelector("temba-ticket-search");
+      if (search) {
+        search.show();
+      }
+    };
+    document.addEventListener("temba-ticket-search-show", window.handleTicketSearchShow);
 
     onSpload(function() {
       const details = document.querySelector("temba-contact-details");


### PR DESCRIPTION
## Summary

Cross-ticket search was only reachable via Cmd/Ctrl+F on the ticket page, with nothing in the UI to surface it. This adds a Search button to the tickets menu, above Export, that opens the same search modal. It also fixes a class-field shadowing bug that was preventing the search modal (and the key-value editor) from rendering at all when bundled with define semantics.

## Changes

**Search button**
- `temba/tickets/views.py` — `Menu.derive_menu` adds a Search button above Export, only for users who can use cross-ticket search (same rule as `TicketCRUDL.Search`: not topic-restricted)
- `temba/orgs/views/base.py` — new `BaseMenuView.create_event_button` helper: a button-styled menu item that dispatches a custom DOM event on the document when clicked (`frame.js` already dispatches `item.event` for menu items)
- `components/src/list/TembaMenu.ts` — menu items with `type: "button"` render and behave like `modax-button` (a lined `temba-button`), minus the modax
- `templates/tickets/ticket_list.html` — listens for `temba-ticket-search-show` and opens the modal, using the same window-stored-handler pattern as the Cmd+F hotkey so SPA navigations don't stack listeners

**Rendering fixes**
- `components/src/live/TicketSearch.ts` — `searchOnEnter = true` was a bare class field overriding the reactive `@property` inherited from `SearchModal`; under class-field define semantics it shadows Lit's accessor and dev-mode Lit hard-errors in `performUpdate`, so the modal never rendered (Cmd+F silently did nothing). Now set in the constructor.
- `components/src/form/KeyValueEditor.ts` — same bug with `maintainEmptyItem`, found by sweeping all registered components for shadowing errors. Same fix.

**Locale files** — regenerated; "Search" already had translations in every locale, the entry just moved to its new first occurrence.

## Test plan

- [x] `temba.tickets` and `temba.orgs` suites pass; menu test updated: admins see Search before Export in both menu variants, unrestricted agents get Search (but no Export), topic-restricted agents get neither
- [x] `code_check.py` clean (locale files, ruff)
- [x] components `tsc --noEmit` clean
- [x] Verified in-browser: button click opens the rendered modal; instantiated all 94 registered components and confirmed no remaining class-field shadowing errors

## Screenshots

_(captured and handed off for pasting — see PR author)_
