### PR TITLE
Use RedBeat as the celery beat scheduler so beat can be embedded in workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "dj-database-url ~= 0.5.0",
     "smartmin>=6.1.0,<7.0.0",
     "celery[redis] ~= 5.5.3",
+    "celery-redbeat ~= 2.4.2",
     "boto3>=1.42.24,<2.0.0",
     "cryptography~=50.0.0",
     "pyotp ~= 2.4.1",

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -683,13 +683,13 @@ CELERY_TASK_TRACK_STARTED = True
 CELERY_BROKER_TRANSPORT_OPTIONS = {"socket_timeout": 5}
 
 # valkey-backed beat scheduler which can be embedded in every worker (celery worker --beat) - a distributed lock
-# ensures only one instance actually schedules, and another takes over if it dies
+# ensures only one instance actually schedules, and if it stops refreshing the lock another takes over on expiry
+# (the redbeat settings themselves are derived from the broker settings in temba_celery.py)
 CELERY_BEAT_SCHEDULER = "redbeat.RedBeatScheduler"
-CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # max sleep between beat ticks - must stay well below the lock timeout
-CELERY_REDBEAT_REDIS_URL = _valkey_url
-CELERY_REDBEAT_REDIS_OPTIONS = {"socket_timeout": 5}
-CELERY_REDBEAT_LOCK_TIMEOUT = 90  # how long before another instance can take over if the lock holder dies uncleanly
+CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # max sleep between beat ticks - each tick refreshes the scheduler lock
 
+# NOTE: entries are synced into valkey when a beat instance starts, so like task signatures, schedule changes need to
+# be backward compatible with the previous version during a rolling deploy
 CELERY_BEAT_SCHEDULE = {
     "check-android-channels": {"task": "check_android_channels", "schedule": timedelta(seconds=300)},
     "delete-released-orgs": {"task": "delete_released_orgs", "schedule": crontab(hour=4, minute=0)},

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -682,6 +682,14 @@ CELERY_TASK_TRACK_STARTED = True
 # by default, celery doesn't have any timeout on our valkey connections, this fixes that
 CELERY_BROKER_TRANSPORT_OPTIONS = {"socket_timeout": 5}
 
+# valkey-backed beat scheduler which can be embedded in every worker (celery worker --beat) - a distributed lock
+# ensures only one instance actually schedules, and another takes over if it dies
+CELERY_BEAT_SCHEDULER = "redbeat.RedBeatScheduler"
+CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # max sleep between beat ticks - must stay well below the lock timeout
+CELERY_REDBEAT_REDIS_URL = _valkey_url
+CELERY_REDBEAT_REDIS_OPTIONS = {"socket_timeout": 5}
+CELERY_REDBEAT_LOCK_TIMEOUT = 90  # how long before another instance can take over if the lock holder dies uncleanly
+
 CELERY_BEAT_SCHEDULE = {
     "check-android-channels": {"task": "check_android_channels", "schedule": timedelta(seconds=300)},
     "delete-released-orgs": {"task": "delete_released_orgs", "schedule": crontab(hour=4, minute=0)},

--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -18,6 +18,19 @@ class TembaCelery(celery.Celery):
 
 app = TembaCelery("temba")
 app.config_from_object("django.conf:settings", namespace="CELERY")
+
+
+@app.on_after_configure.connect
+def configure_redbeat(sender, **kwargs):
+    """
+    RedBeat looks for its settings as un-namespaced keys on the celery conf so they can't come from Django settings.
+    Deriving them from the broker settings here also means they track any deployment overrides of those.
+    """
+    sender.conf.redbeat_redis_url = sender.conf.broker_url
+    sender.conf.redbeat_redis_options = {**sender.conf.broker_transport_options, "retry_period": 60}
+    sender.conf.redbeat_lock_timeout = sender.conf.beat_max_loop_interval * 3
+
+
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 app.autodiscover_tasks(("temba.channels.types.whatsapp_legacy",))
 app.autodiscover_tasks(("temba.channels.types.turn",))

--- a/temba/utils/crons/decorator.py
+++ b/temba/utils/crons/decorator.py
@@ -32,16 +32,18 @@ def cron_task(*task_args, **task_kwargs):
             start = timezone.now()
             result = None
 
-            if r.get(lock_key):
-                result = {"skipped": True}
-            else:
+            # non-blocking acquire so that a duplicate invocation is skipped rather than waiting to run again
+            lock = r.lock(lock_key, timeout=lock_timeout, blocking=False)
+            if lock.acquire():
                 try:
-                    with r.lock(lock_key, timeout=lock_timeout):
-                        result = task_func(*exec_args, **exec_kwargs)
+                    result = task_func(*exec_args, **exec_kwargs)
                 finally:
                     post_cron_exec.send(
                         sender=cron_task, task_name=task_name, started=start, ended=timezone.now(), result=result
                     )
+                    lock.release()
+            else:
+                result = {"skipped": True}
 
             return result
 

--- a/temba/utils/crons/tests.py
+++ b/temba/utils/crons/tests.py
@@ -9,9 +9,8 @@ from . import cron_task
 
 class CronsTest(TembaTest):
     @patch("valkey.client.StrictValkey.lock")
-    @patch("valkey.client.StrictValkey.get")
-    def test_cron_task(self, mock_valkey_get, mock_valkey_lock):
-        mock_valkey_get.return_value = None
+    def test_cron_task(self, mock_valkey_lock):
+        mock_valkey_lock.return_value.acquire.return_value = True
         task_calls = []
 
         @cron_task()
@@ -40,24 +39,19 @@ class CronsTest(TembaTest):
         test_task2(21, bar=22)
         test_task3(foo=31, bar=32)
 
-        mock_valkey_get.assert_any_call("celery-task-lock:test_task1")
-        mock_valkey_get.assert_any_call("celery-task-lock:task2")
-        mock_valkey_get.assert_any_call("celery-task-lock:task3")
-        mock_valkey_lock.assert_any_call("celery-task-lock:test_task1", timeout=900)
-        mock_valkey_lock.assert_any_call("celery-task-lock:task2", timeout=100)
-        mock_valkey_lock.assert_any_call("celery-task-lock:task3", timeout=55)
+        mock_valkey_lock.assert_any_call("celery-task-lock:test_task1", timeout=900, blocking=False)
+        mock_valkey_lock.assert_any_call("celery-task-lock:task2", timeout=100, blocking=False)
+        mock_valkey_lock.assert_any_call("celery-task-lock:task3", timeout=55, blocking=False)
 
         self.assertEqual(task_calls, ["1-11-12", "2-21-22", "3-31-32"])
 
-        # simulate task being already running
-        mock_valkey_get.reset_mock()
-        mock_valkey_get.return_value = "xyz"
+        # simulate task being already running so the lock can't be acquired
         mock_valkey_lock.reset_mock()
+        mock_valkey_lock.return_value.acquire.return_value = False
 
         # try to run again
         test_task1(13, 14)
 
         # check that task is skipped
-        mock_valkey_get.assert_called_once_with("celery-task-lock:test_task1")
-        self.assertEqual(mock_valkey_lock.call_count, 0)
+        mock_valkey_lock.assert_called_once_with("celery-task-lock:test_task1", timeout=900, blocking=False)
         self.assertEqual(task_calls, ["1-11-12", "2-21-22", "3-31-32"])

--- a/uv.lock
+++ b/uv.lock
@@ -234,6 +234,21 @@ redis = [
 ]
 
 [[package]]
+name = "celery-redbeat"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "celery" },
+    { name = "python-dateutil" },
+    { name = "redis" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/13/9aefb6cb39266b28ab2b2a8f24382fd7d82399e20578c5ba2238e63c4445/celery_redbeat-2.4.2.tar.gz", hash = "sha256:a590fef7ef39d7e4511174ce8bafe310e07ef6cdf84a240cd311946815bd90bb", size = 36671, upload-time = "2026-07-27T01:28:09.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/3d/bb4adef34e7691ebd2e80c1e8df1fb3f3bf43b388de714219ac6a580a4d2/celery_redbeat-2.4.2-py2.py3-none-any.whl", hash = "sha256:4124d221a798ad983df0874bfa0d2e9beca41ca9ef91e92d073770bb193da000", size = 16526, upload-time = "2026-07-27T01:28:08.164Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1767,6 +1782,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "boto3" },
     { name = "celery", extra = ["redis"] },
+    { name = "celery-redbeat" },
     { name = "chardet" },
     { name = "colorama" },
     { name = "cryptography" },
@@ -1828,6 +1844,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.54.0,<1.0.0" },
     { name = "boto3", specifier = ">=1.42.24,<2.0.0" },
     { name = "celery", extras = ["redis"], specifier = "~=5.5.3" },
+    { name = "celery-redbeat", specifier = "~=2.4.2" },
     { name = "chardet", specifier = "~=5.2.0" },
     { name = "colorama", specifier = "~=0.4.6" },
     { name = "cryptography", specifier = "~=50.0.0" },


### PR DESCRIPTION
Switches celery beat to [RedBeat](https://github.com/sibson/redbeat), which stores the schedule in Valkey and uses a distributed lock so that only one beat instance actually schedules.

## Summary

This allows beat to be embedded in every worker (`celery worker --beat`) with the lock electing exactly one active scheduler and takeover on lock expiry if the holder stops refreshing it — removing the need to run a dedicated singleton beat process. That simplifies deployment: just web + interchangeable workers.

## Changes

- Added `celery-redbeat ~= 2.4.2` as a dependency.
- Set `CELERY_BEAT_SCHEDULER = "redbeat.RedBeatScheduler"` and `CELERY_BEAT_MAX_LOOP_INTERVAL = 30` (each tick refreshes the scheduler lock).
- The redbeat-specific settings are set on the celery app in `temba_celery.py` rather than in Django settings: RedBeat looks for them as un-namespaced keys on the celery conf, so namespaced `CELERY_REDBEAT_*` Django settings are invisible to its config checks (options silently not forwarded to its redis client, spurious deprecation warnings). Deriving them from the broker settings there also means they track any deployment overrides of the broker URL/options:
  - `redbeat_redis_url` ← `broker_url`
  - `redbeat_redis_options` ← `broker_transport_options` plus `retry_period: 60`, so transient connection errors are retried instead of killing the scheduler
  - `redbeat_lock_timeout` ← `beat_max_loop_interval * 3`, keeping the refresh/expiry ratio fixed by construction
- Made `cron_task` lock acquisition non-blocking: a duplicate invocation is now skipped immediately instead of blocking a worker slot on the lock and then running the task a second time — relevant because multi-scheduler handover makes duplicate dispatch a rare-but-designed-for event.

## Notes for reviewers

- The schedule remains defined in `CELERY_BEAT_SCHEDULE` as before; RedBeat syncs it into Valkey at beat startup and removes entries deleted from settings. Because entries are synced at startup, schedule changes need to be backward compatible across a rolling deploy, like task signatures (noted in a comment).
- This is inert until worker invocations add `--beat`; a standalone `celery -A temba beat` also picks up RedBeat from settings, so this can ship ahead of any process changes.
- The `cron_task` lock remains as the second layer preventing overlapping executions.

## Test plan

- `temba.utils` suite (including crons) and `temba.notifications` pass in the devcontainer.
- Verified empirically that the redbeat config resolves: config keys visible to RedBeat's checks, `socket_timeout` present on its redis client, `RetryingConnection` active, no deprecation warnings (run with `-W error::DeprecationWarning`), and all beat schedule entries sync into Valkey with the expected lock timeout.