### PR TITLE
Don't split ticket analytics response counts by team for orgs without the teams feature

### DIFF
--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -191,6 +191,17 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "Analytics")
         self.assertContains(response, "Tickets Opened")
 
+        # org doesn't have the teams feature so response count chart shouldn't be split by team
+        self.assertFalse(response.context["has_teams"])
+        self.assertNotContains(response, 'dataname="Teams"')
+
+        self.org.features = [Org.FEATURE_TEAMS]
+        self.org.save(update_fields=("features",))
+
+        response = self.assertReadFetch(analytics_url, [self.admin])
+        self.assertTrue(response.context["has_teams"])
+        self.assertContains(response, 'dataname="Teams"')
+
         # should not be able to post to it
         response = self.client.post(analytics_url)
         self.assertEqual(405, response.status_code)

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -299,6 +299,7 @@ class TicketCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
+            context["has_teams"] = Org.FEATURE_TEAMS in self.request.org.features
             return context
 
     class AnalyticsExport(OrgPermsMixin, SmartTemplateView):

--- a/templates/tickets/ticket_analytics.html
+++ b/templates/tickets/ticket_analytics.html
@@ -88,16 +88,28 @@
                single
                requireWindow>
   </temba-chart>
-  <temba-chart class="mt-6"
-               header="{% trans "Response Count" %}"
-               url="{% url 'tickets.ticket_chart' 'replies' %}"
-               dataname="Teams"
-               colorIndex="1"
-               xtype="time"
-               config
-               requireWindow
-               legend>
-  </temba-chart>
+  {% if has_teams %}
+    <temba-chart class="mt-6"
+                 header="{% trans "Response Count" %}"
+                 url="{% url 'tickets.ticket_chart' 'replies' %}"
+                 dataname="Teams"
+                 colorIndex="1"
+                 xtype="time"
+                 config
+                 requireWindow
+                 legend>
+    </temba-chart>
+  {% else %}
+    <temba-chart class="mt-6"
+                 header="{% trans "Response Count" %}"
+                 url="{% url 'tickets.ticket_chart' 'replies' %}"
+                 dataname="Responses"
+                 colorIndex="1"
+                 xtype="time"
+                 single
+                 requireWindow>
+    </temba-chart>
+  {% endif %}
   <div class="leaderboard mt-6" id="leaderboard">
     <h3 style="margin: 0 0 1em 0; font-size: 1.1em; font-weight: 600;">{% trans "Top Responders" %}</h3>
     <table>


### PR DESCRIPTION
Teams are gated by an org feature, but the ticket analytics page always rendered the Response Count chart with team splitting enabled — so orgs without the feature still saw an "All Teams" series and a team selection toggle.

The analytics view now passes whether the org has the teams feature to the template, which renders the Response Count chart as a plain single-series chart (labeled "Responses", no config toggle or legend) when it doesn't.