### PR TITLE
Fix cron_task decorator losing configured lock_timeout after first invocation

### DIFF
--- a/temba/utils/crons/decorator.py
+++ b/temba/utils/crons/decorator.py
@@ -16,6 +16,11 @@ def cron_task(*task_args, **task_kwargs):
     Decorator to create an task suitable for a cron schedule, whose executions are prevented from overlapping by a lock.
     """
 
+    # lock timeout can be provided or defaults to task hard time limit
+    lock_timeout = task_kwargs.pop("lock_timeout", None)
+    if lock_timeout is None:
+        lock_timeout = task_kwargs.get("time_limit", DEFAULT_TASK_LOCK_TIMEOUT)
+
     def _cron_task(task_func):
         @wraps(task_func)
         def wrapper(*exec_args, **exec_kwargs):
@@ -23,11 +28,6 @@ def cron_task(*task_args, **task_kwargs):
 
             task_name = task_kwargs.get("name", task_func.__name__)
             lock_key = "celery-task-lock:" + task_name
-
-            # lock timeout can be provided or defaults to task hard time limit
-            lock_timeout = task_kwargs.pop("lock_timeout", None)
-            if lock_timeout is None:
-                lock_timeout = task_kwargs.get("time_limit", DEFAULT_TASK_LOCK_TIMEOUT)
 
             start = timezone.now()
             result = None

--- a/temba/utils/crons/tests.py
+++ b/temba/utils/crons/tests.py
@@ -49,6 +49,19 @@ class CronsTest(TembaTest):
 
         self.assertEqual(task_calls, ["1-11-12", "2-21-22", "3-31-32"])
 
+        # run tasks again and check that lock timeouts are unchanged (configured values aren't lost after first use)
+        mock_valkey_lock.reset_mock()
+
+        test_task1(11, 12)
+        test_task2(21, bar=22)
+        test_task3(foo=31, bar=32)
+
+        mock_valkey_lock.assert_any_call("celery-task-lock:test_task1", timeout=900)
+        mock_valkey_lock.assert_any_call("celery-task-lock:task2", timeout=100)
+        mock_valkey_lock.assert_any_call("celery-task-lock:task3", timeout=55)
+
+        self.assertEqual(task_calls, ["1-11-12", "2-21-22", "3-31-32", "1-11-12", "2-21-22", "3-31-32"])
+
         # simulate task being already running
         mock_valkey_get.reset_mock()
         mock_valkey_get.return_value = "xyz"
@@ -60,4 +73,4 @@ class CronsTest(TembaTest):
         # check that task is skipped
         mock_valkey_get.assert_called_once_with("celery-task-lock:test_task1")
         self.assertEqual(mock_valkey_lock.call_count, 0)
-        self.assertEqual(task_calls, ["1-11-12", "2-21-22", "3-31-32"])
+        self.assertEqual(task_calls, ["1-11-12", "2-21-22", "3-31-32", "1-11-12", "2-21-22", "3-31-32"])


### PR DESCRIPTION
## What

Fixes a bug in the `cron_task` decorator where `lock_timeout` was `pop()`ed from the closed-over `task_kwargs` dict inside the task wrapper. That mutation meant the configured value was only honored on the first invocation of the task in a process — every subsequent run silently fell back to `time_limit` or the 900s default, discarding explicit values like the long lock timeouts on squash tasks and `delete_released_orgs`.

## How

`lock_timeout` is now resolved (and popped) once at decoration time, so the wrapper closes over the resolved value. As a side benefit it's no longer passed through to `shared_task()` as a stray option.

The test now invokes each task a second time and asserts the lock is still acquired with the configured timeout — the explicit `lock_timeout` assertion fails against the old code.