### PR TITLE
Update postcss to 8.5.23

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "autoprefixer": "10.2.5",
         "bower": "1.8.8",
         "jasmine-core": "2.5.0",
-        "postcss": "8.5.18",
+        "postcss": "8.5.23",
         "postcss-cli": "11.0.0",
         "postcss-import": "14.0.2",
         "postcss-loader": "5.3.0",
@@ -257,7 +257,7 @@
 
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
-    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-cli": ["postcss-cli@11.0.0", "", { "dependencies": { "chokidar": "^3.3.0", "dependency-graph": "^0.11.0", "fs-extra": "^11.0.0", "get-stdin": "^9.0.0", "globby": "^14.0.0", "picocolors": "^1.0.0", "postcss-load-config": "^5.0.0", "postcss-reporter": "^7.0.0", "pretty-hrtime": "^1.0.3", "read-cache": "^1.0.0", "slash": "^5.0.0", "yargs": "^17.0.0" }, "bin": { "postcss": "index.js" } }, "sha512-xMITAI7M0u1yolVcXJ9XTZiO9aO49mcoKQy6pCDFdMh9kGqhzLVpWxeD/32M/QBmkhcGypZFFOLNLmIW4Pg4RA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "autoprefixer": "10.2.5",
     "bower": "1.8.8",
     "jasmine-core": "2.5.0",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "postcss-cli": "11.0.0",
     "postcss-import": "14.0.2",
     "postcss-loader": "5.3.0",


### PR DESCRIPTION
## Summary

Updates postcss from 8.5.18 to 8.5.23, replacing #6803 which couldn't regenerate the bun lockfile.

## Changes

- `package.json` / `bun.lock` — postcss 8.5.18 → 8.5.23. Notable upstream fix: 8.5.23 no longer loads source maps without `opts.from`, for security reasons.

## Test plan

- [x] `bun install --frozen-lockfile` passes with the regenerated lockfile
- [x] `bun run tw-build` (the postcss CSS build) runs successfully