### PR TITLE
Add unrestricted_webhooks org feature

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:01+0000\n"
+"POT-Creation-Date: 2026-08-17 21:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -3113,6 +3113,9 @@ msgid "Prometheus"
 msgstr ""
 
 msgid "Shared Channels"
+msgstr ""
+
+msgid "Unrestricted Webhooks"
 msgstr ""
 
 msgid "Sorry, your workspace is currently suspended. To re-enable starting flows and sending messages, please contact support."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:01+0000\n"
+"POT-Creation-Date: 2026-08-17 21:53+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -3140,6 +3140,9 @@ msgstr "Prometheus"
 
 msgid "Shared Channels"
 msgstr "Canales compartidos"
+
+msgid "Unrestricted Webhooks"
+msgstr "Webhooks sin restricciones"
 
 msgid "Sorry, your workspace is currently suspended. To re-enable starting flows and sending messages, please contact support."
 msgstr "Lo sentimos, su workspace está suspendido actualmente. Para volver a habilitar el inicio de flujos y el envío de mensajes, póngase en contacto con el soporte."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:01+0000\n"
+"POT-Creation-Date: 2026-08-17 21:53+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -3140,6 +3140,9 @@ msgstr "Prometheus"
 
 msgid "Shared Channels"
 msgstr "Canaux partagés"
+
+msgid "Unrestricted Webhooks"
+msgstr "Webhooks sans restriction"
 
 msgid "Sorry, your workspace is currently suspended. To re-enable starting flows and sending messages, please contact support."
 msgstr "Désolé, votre espace de travail est actuellement suspendu. Pour réactiver le lancement de flux et l'envoi de messages, veuillez contacter le support."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:01+0000\n"
+"POT-Creation-Date: 2026-08-17 21:53+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -3144,6 +3144,9 @@ msgstr "Prometheus"
 
 msgid "Shared Channels"
 msgstr "Canais compartilhados"
+
+msgid "Unrestricted Webhooks"
+msgstr "Webhooks sem restrições"
 
 msgid "Sorry, your workspace is currently suspended. To re-enable starting flows and sending messages, please contact support."
 msgstr "Desculpe, sua área de trabalho está suspensa no momento. Para voltar a iniciar fluxos e enviar mensagens, por favor entre em contato com o suporte."

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -244,6 +244,7 @@ class Org(LegacyIDMixin, SmartModel):
     FEATURE_PROMETHEUS = "prometheus"  # can create a prometheus token to access metrics
     FEATURE_SHARED_CHANNELS = "shared_channels"  # can share channels between orgs
     FEATURE_AGENTS = "agents"  # can create AI agents to handle contact conversations
+    FEATURE_UNRESTRICTED_WEBHOOKS = "unrestricted_webhooks"  # can call webhooks to otherwise blocked domains
     FEATURES_CHOICES = (
         (FEATURE_USERS, _("Users")),
         (FEATURE_NEW_ORGS, _("New Orgs")),
@@ -252,6 +253,7 @@ class Org(LegacyIDMixin, SmartModel):
         (FEATURE_PROMETHEUS, _("Prometheus")),
         (FEATURE_SHARED_CHANNELS, _("Shared Channels")),
         (FEATURE_AGENTS, _("Agents")),
+        (FEATURE_UNRESTRICTED_WEBHOOKS, _("Unrestricted Webhooks")),
     )
 
     LIMIT_CHANNELS = "channels"


### PR DESCRIPTION
## Summary

Adds a new staff-grantable workspace feature, `unrestricted_webhooks`, which marks a workspace as
exempt from the flow engine's blocked-domain list for webhook calls made from flows.

The engine maintains a list of domains that flow webhook actions may not call directly, and calls to
those domains are now rejected outright. This feature lets an operator grant specific workspaces an
exemption from that list where there's a legitimate reason for a flow to call such a domain.

This is only the flag itself — the enforcement side, where the flow engine is given a reduced
blocked-domain list for exempt workspaces, lands separately in mailroom.

## Changes

- `Org.FEATURE_UNRESTRICTED_WEBHOOKS` constant and its `FEATURES_CHOICES` entry
- Regenerated PO files for the new translatable label, with translations for es/fr/pt_BR

Nothing else needed touching:

- **No migration.** `features` is an untyped `ArrayField` with no `choices` on the model field, so
  adding a choice generates nothing — confirmed with `makemigrations --check`.
- **No staff UI work.** The staff workspace update form builds its `features` field from
  `Org.FEATURES_CHOICES`, so the new option appears in the staff-only picker automatically. Those
  are the only two references to `FEATURES_CHOICES` in the repo.
- **No API work.** Mailroom reads the orgs table directly rather than going through the API.

## Test plan

- `temba.staff` and `temba.orgs` — 95 tests, all passing. The staff tests assert the update form's
  field names rather than the choice list, so no test changes were needed.
- `makemigrations --check --dry-run` — no changes detected.
- `code_check.py` — clean, including the locale check.