### PR TITLE
Have the list pages identify their objects by uuid throughout

### DIFF
--- a/components/src/interfaces.ts
+++ b/components/src/interfaces.ts
@@ -184,7 +184,8 @@ export interface Campaign {
 /** A single row in the trigger CRUDL list
  * (`triggers/trigger_list.html`): what starts the flow (type +
  * per-type details), any channel / group filters, and the flow it
- * starts. Rows still key off the numeric id. */
+ * starts. Rows key off the uuid; the numeric id is carried for the
+ * page's pk-based update modal URL. */
 export interface Trigger {
   uuid: string;
   id: number;
@@ -223,9 +224,11 @@ export interface Trigger {
 
 /** A single row in the broadcast CRUDL lists — both the scheduled
  * list (`msgs/broadcast_scheduled.html`) and the sent list
- * (`msgs/broadcast_list.html`). Broadcasts key off the numeric id;
- * content fields carry the base-language translation. */
+ * (`msgs/broadcast_list.html`). Rows key off the uuid; the numeric id
+ * is carried for the scheduled list's pk-based edit and delete modal
+ * URLs. Content fields carry the base-language translation. */
 export interface Broadcast {
+  uuid: string;
   id: number;
   /** Server status slug — `pending`, `queued`, `started`,
    * `completed`, `failed` or `interrupted`. Scheduled broadcasts
@@ -273,9 +276,12 @@ export interface Broadcast {
 }
 
 export interface Msg {
-  /** Numeric id — present on persisted messages (the CRUDL list
-   * keys rows off it); absent on outbound drafts. */
+  /** Numeric id — present on persisted messages; absent on outbound
+   * drafts and on the messages CRUDL endpoint, which identifies
+   * messages by uuid. */
   id?: number;
+  /** Message uuid — how the CRUDL list keys and selects rows. */
+  uuid?: string;
   text: string;
   status: string;
   channel: ObjectReference;

--- a/components/src/list/BroadcastList.ts
+++ b/components/src/list/BroadcastList.ts
@@ -361,7 +361,7 @@ export class BroadcastList extends ContentList<Broadcast> {
 
   constructor() {
     super();
-    this.valueKey = 'id';
+    this.valueKey = 'uuid';
     this.syncColumns();
   }
 

--- a/components/src/list/MsgList.ts
+++ b/components/src/list/MsgList.ts
@@ -105,7 +105,7 @@ export class MsgList extends ContentList<Msg> {
 
   constructor() {
     super();
-    this.valueKey = 'id';
+    this.valueKey = 'uuid';
     // Messages page 100 at a time, matching rapidpro's msg list.
     this.pageSize = 100;
     // Auto layout so the Contact / Sent columns size to their content

--- a/components/src/list/TriggerList.ts
+++ b/components/src/list/TriggerList.ts
@@ -174,7 +174,7 @@ export class TriggerList extends ContentList<Trigger> {
 
   constructor() {
     super();
-    this.valueKey = 'id';
+    this.valueKey = 'uuid';
     this.columns = [
       { key: 'trigger', label: 'Trigger', grow: true, minWidth: '260px' },
       {

--- a/components/test/temba-broadcast-list.test.ts
+++ b/components/test/temba-broadcast-list.test.ts
@@ -8,22 +8,26 @@ const getBroadcastList = async (attrs: any = {}, width = 800, height = 0) => {
   return (await getComponent(TAG, attrs, '', width, height)) as BroadcastList;
 };
 
-const broadcast = (over: any = {}) => ({
-  id: 201,
-  status: 'completed',
-  text: 'Your appointment is confirmed for tomorrow at 10am.',
-  attachments: [],
-  quick_replies: [],
-  groups: [{ uuid: 'group-1', name: 'Patients' }],
-  contacts: [],
-  query: null,
-  exclusions: [],
-  schedule: null,
-  msg_count: 1250,
-  created_on: '2026-07-14T14:32:00.000000Z',
-  created_by: 'admin@textit.com',
-  ...over
-});
+const broadcast = (over: any = {}) => {
+  const item = {
+    id: 201,
+    status: 'completed',
+    text: 'Your appointment is confirmed for tomorrow at 10am.',
+    attachments: [],
+    quick_replies: [],
+    groups: [{ uuid: 'group-1', name: 'Patients' }],
+    contacts: [],
+    query: null,
+    exclusions: [],
+    schedule: null,
+    msg_count: 1250,
+    created_on: '2026-07-14T14:32:00.000000Z',
+    created_by: 'admin@textit.com',
+    ...over
+  };
+  // rows key off the uuid, so derive one per id unless the caller set one
+  return { uuid: `bcast-${item.id}`, ...item };
+};
 
 const scheduled = (over: any = {}) =>
   broadcast({
@@ -56,8 +60,8 @@ describe('temba-broadcast-list', () => {
   it('can be created', async () => {
     const list: BroadcastList = await getBroadcastList();
     assert.instanceOf(list, BroadcastList);
-    // broadcasts have no exposed uuid — rows key off the numeric id
-    expect(list.valueKey).to.equal('id');
+    // rows key off the broadcast uuid
+    expect(list.valueKey).to.equal('uuid');
   });
 
   it('keeps rows event-only (no row href)', async () => {

--- a/components/test/temba-trigger-list.test.ts
+++ b/components/test/temba-trigger-list.test.ts
@@ -29,26 +29,30 @@ const settlePills = async (list: TriggerList) => {
   }
 };
 
-const trigger = (over: any = {}) => ({
-  id: 101,
-  type: 'keyword',
-  flow: { uuid: 'flow-1', name: 'Registration' },
-  channel: null,
-  groups: [{ uuid: 'group-1', name: 'Farmers' }],
-  exclude_groups: [],
-  contacts: [],
-  keywords: ['join', 'start'],
-  match_type: 'F',
-  created_on: '2026-05-11T09:12:00.000000Z',
-  ...over
-});
+const trigger = (over: any = {}) => {
+  const item = {
+    id: 101,
+    type: 'keyword',
+    flow: { uuid: 'flow-1', name: 'Registration' },
+    channel: null,
+    groups: [{ uuid: 'group-1', name: 'Farmers' }],
+    exclude_groups: [],
+    contacts: [],
+    keywords: ['join', 'start'],
+    match_type: 'F',
+    created_on: '2026-05-11T09:12:00.000000Z',
+    ...over
+  };
+  // rows key off the uuid, so derive one per id unless the caller set one
+  return { uuid: `trigger-${item.id}`, ...item };
+};
 
 describe('temba-trigger-list', () => {
   it('can be created', async () => {
     const list: TriggerList = await getTriggerList();
     assert.instanceOf(list, TriggerList);
-    // triggers have no uuid — rows key off the numeric id
-    expect(list.valueKey).to.equal('id');
+    // rows key off the trigger uuid
+    expect(list.valueKey).to.equal('uuid');
   });
 
   it('keeps rows event-only (no row href)', async () => {

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -103,7 +103,6 @@ class EndpointsTest(APITestMixin, TembaTest):
             [self.admin],
             results=[
                 {
-                    "id": msg2.id,
                     "uuid": str(msg2.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact2.uuid), "name": "Bob"},
@@ -115,7 +114,6 @@ class EndpointsTest(APITestMixin, TembaTest):
                     "logs_url": msg2_logs_url,
                 },
                 {
-                    "id": msg1.id,
                     "uuid": str(msg1.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact1.uuid), "name": "Ann"},
@@ -135,7 +133,6 @@ class EndpointsTest(APITestMixin, TembaTest):
             [self.editor],
             results=[
                 {
-                    "id": msg2.id,
                     "uuid": str(msg2.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact2.uuid), "name": "Bob"},
@@ -147,7 +144,6 @@ class EndpointsTest(APITestMixin, TembaTest):
                     "logs_url": None,
                 },
                 {
-                    "id": msg1.id,
                     "uuid": str(msg1.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact1.uuid), "name": "Ann"},
@@ -1211,7 +1207,8 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         # each row carries the columns the component renders
         def check_sent_shape(data):
-            row = [r for r in data["results"] if r["id"] == bcast1.id][0]
+            row = [r for r in data["results"] if r["uuid"] == str(bcast1.uuid)][0]
+            self.assertEqual(bcast1.id, row["id"])
             self.assertEqual("completed", row["status"])
             self.assertEqual("Hello everyone", row["text"])
             self.assertEqual(["image/jpeg:http://example.com/cat.jpg"], row["attachments"])
@@ -1230,13 +1227,13 @@ class EndpointsTest(APITestMixin, TembaTest):
         # a scheduled row carries the schedule instead of a message count, and a paused schedule's stale
         # next_fire reads as not scheduled
         def check_scheduled_shape(data):
-            row = [r for r in data["results"] if r["id"] == bcast3.id][0]
+            row = [r for r in data["results"] if r["uuid"] == str(bcast3.uuid)][0]
             self.assertEqual("D", row["schedule"]["repeat_period"])
             self.assertTrue(row["schedule"]["display"].startswith("each day at"))
             self.assertIsNotNone(row["schedule"]["next_fire"])
             self.assertIsNone(row["msg_count"])
             self.assertIsNone(row["progress"])
-            paused_row = [r for r in data["results"] if r["id"] == bcast5.id][0]
+            paused_row = [r for r in data["results"] if r["uuid"] == str(bcast5.uuid)][0]
             self.assertIsNone(paused_row["schedule"]["next_fire"])
             return True
 
@@ -1329,7 +1326,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertGet(endpoint_url + "?folder=archived", [self.admin], results=[trigger7, trigger4])
 
         def check_archived_schedule(data):
-            scheduled = [r for r in data["results"] if r["id"] == trigger7.id][0]
+            scheduled = [r for r in data["results"] if r["uuid"] == str(trigger7.uuid)][0]
             self.assertEqual(Schedule.REPEAT_DAILY, scheduled["schedule"]["repeat_period"])
             self.assertIsNone(scheduled["schedule"]["next_fire"])
             return True
@@ -1348,8 +1345,8 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         # each row carries the columns the component renders
         def check_shape(data):
-            first = [r for r in data["results"] if r["id"] == trigger1.id][0]
-            self.assertEqual(str(trigger1.uuid), first["uuid"])
+            first = [r for r in data["results"] if r["uuid"] == str(trigger1.uuid)][0]
+            self.assertEqual(trigger1.id, first["id"])
             self.assertEqual("keyword", first["type"])
             self.assertEqual({"uuid": str(flow1.uuid), "name": "Survey"}, first["flow"])
             self.assertIsNone(first["channel"])
@@ -1361,13 +1358,13 @@ class EndpointsTest(APITestMixin, TembaTest):
             self.assertIsNone(first["schedule"])
             self.assertEqual(matchers.ISODatetime(), first["created_on"])
 
-            missed_call = [r for r in data["results"] if r["id"] == trigger3.id][0]
+            missed_call = [r for r in data["results"] if r["uuid"] == str(trigger3.uuid)][0]
             self.assertEqual(
                 {"uuid": str(self.channel.uuid), "name": "Test Channel", "icon": "channel_a"},
                 missed_call["channel"],
             )
 
-            scheduled = [r for r in data["results"] if r["id"] == trigger5.id][0]
+            scheduled = [r for r in data["results"] if r["uuid"] == str(trigger5.uuid)][0]
             self.assertEqual("schedule", scheduled["type"])
             self.assertEqual(Schedule.REPEAT_DAILY, scheduled["schedule"]["repeat_period"])
             self.assertEqual(matchers.ISODatetime(), scheduled["schedule"]["next_fire"])

--- a/temba/campaigns/tests/test_campaigncrudl.py
+++ b/temba/campaigns/tests/test_campaigncrudl.py
@@ -314,7 +314,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertNotEqual("", response.context["list_subtitle"])
         self.assertEqual(["restore"], [a["key"] for a in response.context["list_bulk_actions"]])
 
-        # the component posts campaign uuids in `objects`; the view translates them to ids so the bulk action applies
+        # the component posts campaign uuids in `objects`
         self.client.post(list_url, {"action": "archive", "objects": str(campaign1.uuid)})
         campaign1.refresh_from_db()
         self.assertTrue(campaign1.is_archived)
@@ -324,7 +324,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         campaign1.refresh_from_db()
         self.assertFalse(campaign1.is_archived)
 
-        # a malformed uuid is dropped rather than erroring
+        # a malformed uuid fails form validation rather than erroring
         response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
         campaign2.refresh_from_db()

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -204,9 +204,6 @@ class CampaignCRUDL(SmartCRUDL):
             "restore": {"label": _("Restore"), "icon": "restore"},
         }
 
-        def derive_bulk_action_objects(self, uuids: list):
-            return super().derive_bulk_action_objects(uuids).filter(is_active=True)
-
     class List(BaseList):
         title = _("Active")
         bulk_actions = ("archive",)

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -174,7 +174,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertContentMenu(list_url, self.admin, ["New Contact", "New Group", "Export"])
 
         # bulk actions apply to the posted contacts
-        self.client.post(list_url, {"action": "archive", "objects": joe.id})
+        self.client.post(list_url, {"action": "archive", "objects": str(joe.uuid)})
 
         joe.refresh_from_db()
         self.assertEqual(Contact.STATUS_ARCHIVED, joe.status)
@@ -222,7 +222,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(reverse("contacts.contact_group", args=[smart.uuid]))
         self.assertEqual(smart.query, response.context["list_subtitle"])
 
-        # the component posts contact uuids in `objects`; the view translates them to ids so the bulk action applies
+        # the component posts contact uuids in `objects`
         self.client.post(list_url, {"action": "archive", "objects": str(joe.uuid)})
         joe.refresh_from_db()
         self.assertEqual(Contact.STATUS_ARCHIVED, joe.status)
@@ -238,9 +238,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         )
         self.assertNotIn(frank, newsletter.contacts.all())
 
-        # a label posted as a numeric id is passed through untranslated
+        # a group posted as a numeric id is rejected
         self.client.post(list_url, {"action": "label", "objects": str(frank.uuid), "label": str(newsletter.id)})
-        self.assertIn(frank, newsletter.contacts.all())
+        self.assertNotIn(frank, newsletter.contacts.all())
 
         # on a group page, an "unlabel" with a group we can't resolve is rejected rather than falling back to the
         # current group - only an absent group means "Remove from group"
@@ -253,7 +253,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.client.post(group_url, {"action": "unlabel", "objects": str(frank.uuid)})
         self.assertNotIn(frank, group.contacts.all())
 
-        # a malformed contact uuid in `objects` is ignored rather than raising (no 500 on hostile/garbage input)
+        # a malformed contact uuid in `objects` fails form validation rather than raising (no 500 on garbage input)
         response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
 
@@ -276,13 +276,13 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertContentMenu(blocked_url, self.admin, ["Export"])
 
         # try restore bulk action
-        self.client.post(blocked_url, {"action": "restore", "objects": billy.id})
+        self.client.post(blocked_url, {"action": "restore", "objects": str(billy.uuid)})
 
         billy.refresh_from_db()
         self.assertEqual(Contact.STATUS_ACTIVE, billy.status)
 
         # try archive bulk action
-        self.client.post(blocked_url, {"action": "archive", "objects": frank.id})
+        self.client.post(blocked_url, {"action": "archive", "objects": str(frank.uuid)})
 
         frank.refresh_from_db()
         self.assertEqual(Contact.STATUS_ARCHIVED, frank.status)
@@ -306,13 +306,13 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertContentMenu(stopped_url, self.admin, ["Export"])
 
         # try restore bulk action
-        self.client.post(stopped_url, {"action": "restore", "objects": billy.id})
+        self.client.post(stopped_url, {"action": "restore", "objects": str(billy.uuid)})
 
         billy.refresh_from_db()
         self.assertEqual(Contact.STATUS_ACTIVE, billy.status)
 
         # try archive bulk action
-        self.client.post(stopped_url, {"action": "archive", "objects": frank.id})
+        self.client.post(stopped_url, {"action": "archive", "objects": str(frank.uuid)})
 
         frank.refresh_from_db()
         self.assertEqual(Contact.STATUS_ARCHIVED, frank.status)
@@ -339,13 +339,13 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertContentMenu(archived_url, self.admin, ["Export", "Delete All"])
 
         # try restore bulk action
-        self.client.post(archived_url, {"action": "restore", "objects": billy.id})
+        self.client.post(archived_url, {"action": "restore", "objects": str(billy.uuid)})
 
         billy.refresh_from_db()
         self.assertEqual(Contact.STATUS_ACTIVE, billy.status)
 
         # try delete bulk action
-        self.client.post(archived_url, {"action": "delete", "objects": frank.id})
+        self.client.post(archived_url, {"action": "delete", "objects": str(frank.uuid)})
 
         frank.refresh_from_db()
         self.assertFalse(frank.is_active)
@@ -406,7 +406,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertBulkActions(response, ["block", "send", "start-flow", "archive"])
 
         # try unlabel bulk action
-        self.client.post(group1_url, {"action": "unlabel", "objects": frank.id, "label": group1.id})
+        self.client.post(group1_url, {"action": "unlabel", "objects": str(frank.uuid), "label": str(group1.uuid)})
         self.assertEqual({joe}, set(group1.contacts.all()))
 
         # can access system group like any other except no options to edit or delete

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -105,16 +105,15 @@ class ContactListView(BaseListComponentView):
             return f"folder={self.FOLDER_BY_SYSTEM_GROUP[self.system_group]}"
         return f"group={self.group.uuid}"
 
-    def resolve_posted_uuids(self, data):
-        data = super().resolve_posted_uuids(data)
-
+    def post(self, request, *args, **kwargs):
         # A fixed "unlabel" with no group (the group view's "Remove from group") falls back to the current group.
         # Gated on the key being absent, which is what that action posts — a present-but-unresolvable group must
         # still be rejected rather than silently removing the selection from the current group.
-        if "label" not in data and data.get("action") == "unlabel" and self.group is not None:
-            data["label"] = str(self.group.id)
+        if "label" not in request.POST and request.POST.get("action") == "unlabel" and self.group is not None:
+            request.POST = request.POST.copy()
+            request.POST["label"] = str(self.group.uuid)
 
-        return data
+        return super().post(request, *args, **kwargs)
 
     @cached_property
     def group(self):

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -576,7 +576,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertListFetch(list_url, [self.editor, self.admin])
 
         # try to archive flow used by campaign
-        response = self.client.post(list_url, {"action": "archive", "objects": flow3.id})
+        response = self.client.post(list_url, {"action": "archive", "objects": str(flow3.uuid)})
         self.assertToast(
             response,
             "info",
@@ -592,7 +592,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         flow4.counts.create(scope=f"status:{FlowRun.STATUS_WAITING}", count=10)
 
         # try to archive flow with ongoing runs
-        response = self.client.post(list_url, {"action": "archive", "objects": flow4.id})
+        response = self.client.post(list_url, {"action": "archive", "objects": str(flow4.uuid)})
         self.assertToast(
             response,
             "info",
@@ -604,7 +604,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(flow4.is_archived)
 
         # archive first flow
-        response = self.client.post(list_url, {"action": "archive", "objects": flow1.id})
+        response = self.client.post(list_url, {"action": "archive", "objects": str(flow1.uuid)})
         self.assertEqual(200, response.status_code)
 
         flow1.refresh_from_db()
@@ -614,7 +614,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertBulkActions(response, ["label", "export-results", "archive"])
 
         # unarchive it
-        response = self.client.post(reverse("flows.flow_archived"), {"action": "restore", "objects": flow1.id})
+        response = self.client.post(reverse("flows.flow_archived"), {"action": "restore", "objects": str(flow1.uuid)})
         self.assertEqual(200, response.status_code)
 
         flow1.refresh_from_db()
@@ -627,7 +627,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         label1 = FlowLabel.create(self.org, self.admin, "Important")
 
         response = self.client.post(
-            reverse("flows.flow_list"), {"action": "label", "objects": flow1.id, "label": label1.id}
+            reverse("flows.flow_list"), {"action": "label", "objects": str(flow1.uuid), "label": str(label1.uuid)}
         )
 
         self.assertEqual(200, response.status_code)
@@ -636,7 +636,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # and unlabel
         response = self.client.post(
-            reverse("flows.flow_list"), {"action": "label", "objects": flow1.id, "label": label1.id, "add": False}
+            reverse("flows.flow_list"),
+            {"action": "label", "objects": str(flow1.uuid), "label": str(label1.uuid), "add": False},
         )
 
         self.assertEqual(200, response.status_code)
@@ -697,7 +698,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(reverse("flows.flow_filter", args=[label.uuid]))
         self.assertEqual(f"{reverse('api.internal.flows')}.json?label={label.uuid}", response.context["list_url"])
 
-        # the component posts flow uuids in `objects`; the view translates them to ids so the bulk action applies
+        # the component posts flow uuids in `objects`
         self.client.post(list_url, {"action": "archive", "objects": str(flow1.uuid)})
         flow1.refresh_from_db()
         self.assertTrue(flow1.is_archived)
@@ -712,18 +713,17 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         self.assertEqual(set(), set(flow2.labels.all()))
 
-        # a label posted as a numeric id is passed through untranslated
+        # a label posted as a numeric id is rejected
         self.client.post(list_url, {"action": "label", "objects": str(flow2.uuid), "label": str(label.id)})
-        self.assertEqual({label}, set(flow2.labels.all()))
-        label.toggle_label([flow2], add=False)
+        self.assertEqual(set(), set(flow2.labels.all()))
 
-        # a malformed flow uuid in `objects` is ignored rather than raising (no 500 on hostile/garbage input)
+        # a malformed flow uuid in `objects` fails form validation rather than raising (no 500 on garbage input)
         response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
         flow2.refresh_from_db()
         self.assertFalse(flow2.is_archived)
 
-        # a malformed label uuid is likewise ignored rather than raising
+        # a malformed label uuid is likewise a form error rather than a raise
         response = self.client.post(list_url, {"action": "label", "objects": str(flow2.uuid), "label": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
         self.assertEqual(set(), set(flow2.labels.all()))

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -595,9 +595,6 @@ class FlowCRUDL(SmartCRUDL):
             "restore": {"label": _("Restore"), "icon": "restore"},
         }
 
-        def derive_bulk_action_objects(self, uuids: list):
-            return super().derive_bulk_action_objects(uuids).filter(is_active=True)
-
         def derive_bulk_action_config(self, key: str) -> dict:
             cfg = super().derive_bulk_action_config(key)
             if key == "label":

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -379,7 +379,8 @@ class Broadcast(LegacyIDMixin, models.Model):
         """
         Internal API shape, consumed by the temba-broadcast-list component. Content fields carry the base
         translation; `msg_count` relies on BroadcastMsgCount.bulk_annotate having run for the page (falling back to
-        a per-row count). Broadcasts key rows off the numeric id since their uuid isn't exposed to the UI.
+        a per-row count). The numeric id is included alongside the uuid for the scheduled list's edit and delete
+        modals, whose URLs are still pk based.
         """
 
         translation = self.get_translation()
@@ -393,6 +394,7 @@ class Broadcast(LegacyIDMixin, models.Model):
                 msg_count = self.get_message_count()
 
         return {
+            "uuid": str(self.uuid),
             "id": self.id,
             "status": self.get_status_display().lower(),
             "text": translation["text"],
@@ -639,7 +641,6 @@ class Msg(models.Model):
         retention-gated.
         """
         return {
-            "id": self.id,
             "uuid": str(self.uuid),
             "type": self.TYPE_SLUGS.get(self.msg_type),
             "contact": {"uuid": str(self.contact.uuid), "name": self.contact.get_display(self.org)},

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -77,11 +77,16 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.create_label("label2")
         label3 = self.create_label("label3")
 
-        # editors can label messages - the component posts the label by uuid
+        # editors can label messages - the component posts both the messages and the label by uuid
         response = self.requestView(
             inbox_url,
             self.editor,
-            post_data={"action": "label", "objects": [msg1.id, msg2.id], "label": str(label1.uuid), "add": True},
+            post_data={
+                "action": "label",
+                "objects": [str(msg1.uuid), str(msg2.uuid)],
+                "label": str(label1.uuid),
+                "add": True,
+            },
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual({msg1, msg2}, set(label1.msgs.all()))
@@ -90,7 +95,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.requestView(
             inbox_url,
             self.editor,
-            post_data={"action": "label", "objects": [msg2.id], "label": str(label1.uuid), "add": False},
+            post_data={"action": "label", "objects": [str(msg2.uuid)], "label": str(label1.uuid), "add": False},
         )
         self.assertEqual({msg1}, set(label1.msgs.all()))
 
@@ -98,21 +103,38 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.requestView(
             inbox_url,
             self.editor,
-            post_data={"action": "label", "objects": [msg2.id], "add": False},
+            post_data={"action": "label", "objects": [str(msg2.uuid)], "add": False},
         )
         self.assertEqual({msg1}, set(label1.msgs.all()))
 
-        # labels can also be posted by id, as the other message folders still do
+        # a label posted by id is rejected
         self.requestView(
             inbox_url,
             self.admin,
-            post_data={"action": "label", "objects": [msg1.id, msg2.id, msg3.id], "label": label3.id, "add": True},
+            post_data={
+                "action": "label",
+                "objects": [str(msg1.uuid), str(msg2.uuid), str(msg3.uuid)],
+                "label": label3.id,
+                "add": True,
+            },
+        )
+        self.assertEqual(set(), set(label3.msgs.all()))
+
+        self.requestView(
+            inbox_url,
+            self.admin,
+            post_data={
+                "action": "label",
+                "objects": [str(msg1.uuid), str(msg2.uuid), str(msg3.uuid)],
+                "label": str(label3.uuid),
+                "add": True,
+            },
         )
         self.assertEqual({msg1}, set(label1.msgs.all()))
         self.assertEqual({msg1, msg2, msg3}, set(label3.msgs.all()))
 
         # test archiving a msg
-        self.client.post(inbox_url, {"action": "archive", "objects": msg1.id})
+        self.client.post(inbox_url, {"action": "archive", "objects": str(msg1.uuid)})
         self.assertEqual({msg1, msg5}, set(Msg.objects.filter(visibility=Msg.VISIBILITY_ARCHIVED)))
 
         # archiving doesn't remove labels
@@ -164,12 +186,16 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertBulkActions(response, ["restore", "label", "delete"])
 
         # editors can restore messages
-        response = self.requestView(archived_url, self.editor, post_data={"action": "restore", "objects": [msg1.id]})
+        response = self.requestView(
+            archived_url, self.editor, post_data={"action": "restore", "objects": [str(msg1.uuid)]}
+        )
         self.assertEqual(200, response.status_code)
         self.assertEqual({msg2, msg3}, set(Msg.objects.filter(visibility=Msg.VISIBILITY_ARCHIVED)))
 
         # can also delete messages
-        response = self.requestView(archived_url, self.admin, post_data={"action": "delete", "objects": [msg2.id]})
+        response = self.requestView(
+            archived_url, self.admin, post_data={"action": "delete", "objects": [str(msg2.uuid)]}
+        )
         self.assertEqual(200, response.status_code)
         self.assertEqual([call(self.org, self.admin, [msg2])], mr_mocks.calls["msg_delete"])
 
@@ -256,7 +282,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertBulkActions(response, ["resend"])
 
         # resend some messages
-        self.client.post(failed_url, {"action": "resend", "objects": [msg2.id]})
+        self.client.post(failed_url, {"action": "resend", "objects": [str(msg2.uuid)]})
 
         self.assertEqual([call(self.org, self.admin, [msg2])], mr_mocks.calls["msg_resend"])
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -59,9 +59,6 @@ class MsgListView(BaseListComponentView):
     folder = None
     list_endpoint = "api.internal.messages"
 
-    # the msg list posts message ids in `objects`, but its label dropdown still posts the label by uuid
-    list_posts_uuids = False
-
     BULK_ACTION_CONFIG = {
         "label": {"label": _("Label"), "icon": "tag-01", "labelsEndpoint": "/api/v2/labels.json"},
         "archive": {"label": _("Archive"), "icon": "archive"},

--- a/temba/orgs/views/base.py
+++ b/temba/orgs/views/base.py
@@ -23,7 +23,6 @@ from django.utils.translation import gettext_lazy as _
 from temba.contacts.models import ContactField, ContactGroup
 from temba.utils import on_transaction_commit
 from temba.utils.fields import SelectMultipleWidget, TembaDateField
-from temba.utils.uuid import is_uuid
 from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalFormMixin, SpaMixin
 
 from .mixins import BulkActionMixin, DependencyMixin, OrgObjPermsMixin, OrgPermsMixin
@@ -170,14 +169,11 @@ class BaseListComponentView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseLis
     """
     Base list view for pages rendered by a list component. The component fetches and pages the objects itself from
     the internal API, so this view only renders the page shell, serves its content menu, and applies bulk actions
-    posted back to it.
+    posted back to it. Selections and labels are posted by uuid - see BulkActionMixin.
     """
 
     # the internal API endpoint the component fetches from, e.g. "api.internal.contacts"
     list_endpoint = None
-
-    # whether the component posts object uuids rather than ids in `objects`
-    list_posts_uuids = True
 
     # bulk action key -> config consumed by the component: a label and icon, plus optionally `clientOnly` (the action
     # opens a modal seeded with the selection rather than posting back here), `destructive`/`confirm`, or a
@@ -204,42 +200,6 @@ class BaseListComponentView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseLis
         Gets the config for the given bulk action. Views can override to vary it by requesting user.
         """
         return dict(self.BULK_ACTION_CONFIG.get(key, {}))
-
-    def derive_bulk_action_objects(self, uuids: list):
-        """
-        Gets the objects the component posted by uuid, so they can be matched to the ids BulkActionMixin expects.
-        """
-        return self.model._default_manager.filter(org=self.request.org, uuid__in=uuids)
-
-    def resolve_posted_uuids(self, data):
-        """
-        Translates the uuids the component posts to the ids BulkActionMixin matches on.
-        """
-        if self.list_posts_uuids:
-            objects = data.getlist("objects")
-            uuids = [o for o in objects if is_uuid(o)]
-            if uuids:
-                # Only look up well-formed uuids — `uuid__in` runs each value through UUIDField.get_prep_value, so a
-                # single malformed value (a hostile post) would otherwise raise ValueError (500). Anything that isn't
-                # a uuid is left alone so an id-based post still works.
-                ids = self.derive_bulk_action_objects(uuids).values_list("id", flat=True)
-                data.setlist("objects", [str(i) for i in ids] + [o for o in objects if not is_uuid(o)])
-
-        # the label dropdown posts its target by uuid whatever the list posts for `objects`. Only touch the label
-        # field on label/unlabel actions so an unrelated post that happens to carry a `label` key isn't rewritten.
-        if data.get("action") in ("label", "unlabel"):
-            label = data.get("label")
-            labels = self.get_bulk_action_labels()
-            if label and is_uuid(label) and labels is not None:
-                obj = labels.filter(uuid=label).first()
-                data["label"] = str(obj.id) if obj else ""
-
-        return data
-
-    def post(self, request, *args, **kwargs):
-        request.POST = self.resolve_posted_uuids(request.POST.copy())
-
-        return super().post(request, *args, **kwargs)
 
     def get_queryset(self, **kwargs):
         # the component fetches and pages the objects itself, so a GET page needs no object list. A POST still needs

--- a/temba/orgs/views/mixins.py
+++ b/temba/orgs/views/mixins.py
@@ -159,7 +159,9 @@ class InferUserMixin:
 
 class BulkActionMixin:
     """
-    Mixin for list views which have bulk actions
+    Mixin for list views which have bulk actions. The list components which post these actions identify both the
+    selection and any label by uuid, so the form matches on uuid rather than pk - which also means a malformed value
+    is a form error rather than an uncaught ValueError from the database layer.
     """
 
     bulk_actions = ()
@@ -170,12 +172,14 @@ class BulkActionMixin:
             super().__init__(*args, **kwargs)
 
             self.fields["action"] = forms.ChoiceField(choices=[(a, a) for a in actions], required=True)
-            self.fields["objects"] = forms.ModelMultipleChoiceField(queryset=queryset, required=False)
+            self.fields["objects"] = forms.ModelMultipleChoiceField(
+                queryset=queryset, to_field_name="uuid", required=False
+            )
             self.fields["all"] = forms.BooleanField(required=False)
             self.fields["add"] = forms.BooleanField(required=False)
 
             if label_queryset:
-                self.fields["label"] = forms.ModelChoiceField(label_queryset, required=False)
+                self.fields["label"] = forms.ModelChoiceField(label_queryset, to_field_name="uuid", required=False)
 
         def clean(self):
             cleaned_data = super().clean()

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -384,7 +384,8 @@ class Trigger(TembaUUIDMixin, SmartModel):
         """
         Internal API shape, consumed by the temba-trigger-list component. The type slug drives the row icon and
         which of the per-type fields (keywords, schedule, referrer) the details cell renders; channel/groups/contacts
-        render as filter pills. The numeric id is still included for the component's current row key.
+        render as filter pills. The numeric id is included alongside the uuid for the page's update modal, whose URL
+        is still pk based.
         """
 
         return {

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -949,7 +949,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertBulkActions(response, ["archive"])
 
         # can archive it
-        self.client.post(list_url, {"action": "archive", "objects": trigger3.id})
+        self.client.post(list_url, {"action": "archive", "objects": str(trigger3.uuid)})
 
         trigger3.refresh_from_db()
         self.assertTrue(trigger3.is_archived)
@@ -957,7 +957,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         # test when archiving fails
         mock_deactivate_trigger.side_effect = ValueError("boom")
 
-        response = self.client.post(list_url, {"action": "archive", "objects": trigger4.id})
+        response = self.client.post(list_url, {"action": "archive", "objects": str(trigger4.uuid)})
         # TODO: Convert to temba-toast
         # self.assertEqual("An error occurred while making your changes. Please try again.", response["Temba-Toast"])
 
@@ -1008,13 +1008,13 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(reverse("triggers.trigger_folder", kwargs={"folder": "messages"}))
         self.assertEqual(f"{reverse('api.internal.triggers')}.json?folder=messages", response.context["list_url"])
 
-        # the component posts trigger ids in `objects` — bulk actions apply as-is
-        self.client.post(list_url, {"action": "archive", "objects": trigger1.id})
+        # the component posts trigger uuids in `objects`
+        self.client.post(list_url, {"action": "archive", "objects": str(trigger1.uuid)})
         trigger1.refresh_from_db()
         self.assertTrue(trigger1.is_archived)
 
         # restore from the archived view
-        self.client.post(reverse("triggers.trigger_archived"), {"action": "restore", "objects": trigger2.id})
+        self.client.post(reverse("triggers.trigger_archived"), {"action": "restore", "objects": str(trigger2.uuid)})
         trigger2.refresh_from_db()
         self.assertFalse(trigger2.is_archived)
 
@@ -1077,7 +1077,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertBulkActions(response, ["restore", "delete"])
 
         # can restore it
-        self.client.post(archived_url, {"action": "restore", "objects": trigger1.id})
+        self.client.post(archived_url, {"action": "restore", "objects": str(trigger1.uuid)})
 
         trigger1.refresh_from_db()
         self.assertFalse(trigger1.is_archived)
@@ -1097,7 +1097,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(trigger.pk == other_trigger.pk)
 
         # restoring it leaves one archived and the other active
-        self.client.post(archived_url, {"action": "restore", "objects": trigger.id})
+        self.client.post(archived_url, {"action": "restore", "objects": str(trigger.uuid)})
 
         self.assertEqual(1, Trigger.objects.filter(keywords=["start"], is_archived=False).count())
         self.assertNotEqual(other_trigger, Trigger.objects.filter(keywords=["start"], is_archived=False)[0])
@@ -1184,13 +1184,15 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
             return {t.keywords[0] for t in Trigger.objects.filter(org=self.org, is_active=True, is_archived=True)}
 
         # cannot bulk delete an active trigger
-        self.client.post(archived_url, {"action": "delete", "objects": trigger7.id})
+        self.client.post(archived_url, {"action": "delete", "objects": str(trigger7.uuid)})
 
         trigger7.refresh_from_db()
         self.assertTrue(trigger7.is_active)
 
         # cannot bulk delete a mix of active and archived triggers
-        self.client.post(archived_url, {"action": "delete", "objects": [trigger3.id, trigger4.id, trigger7.id]})
+        self.client.post(
+            archived_url, {"action": "delete", "objects": [str(trigger3.uuid), str(trigger4.uuid), str(trigger7.uuid)]}
+        )
         self.assertTrue(
             {trigger3.keywords[0], trigger4.keywords[0], trigger5.keywords[0], trigger6.keywords[0]}
             <= archived_keywords()
@@ -1199,7 +1201,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertTrue(trigger7.is_active)
 
         # can bulk delete archived triggers
-        self.client.post(archived_url, {"action": "delete", "objects": [trigger3.id, trigger4.id]})
+        self.client.post(archived_url, {"action": "delete", "objects": [str(trigger3.uuid), str(trigger4.uuid)]})
         remaining = archived_keywords()
         self.assertNotIn(trigger3.keywords[0], remaining)
         self.assertNotIn(trigger4.keywords[0], remaining)

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -421,9 +421,6 @@ class TriggerCRUDL(SmartCRUDL):
         search_fields = ("keywords__icontains", "flow__name__icontains", "channel__name__icontains")
         list_endpoint = "api.internal.triggers"
 
-        # triggers post their numeric ids in `objects`, matching BulkActionMixin's pk matching
-        list_posts_uuids = False
-
         BULK_ACTION_CONFIG = {
             "archive": {"label": _("Archive"), "icon": "archive"},
             "restore": {"label": _("Restore"), "icon": "restore"},


### PR DESCRIPTION
## Summary

The list pages rendered by a list component translated the uuids their component posted into the ids the bulk action form matched on, with a per-view opt out for the two lists whose objects had no uuid to post. Triggers have a uuid now, and broadcasts can expose theirs, so that translation layer has nothing left to bridge — this removes it and has the bulk action form match on uuid directly.

## Changes

**`BulkActionMixin`** (`temba/orgs/views/mixins.py`) — the `objects` and `label` fields now match on `to_field_name="uuid"`. Django validates each posted value individually, so a malformed uuid raises a form error rather than an uncaught `ValueError` from `UUIDField.get_prep_value`. The mixin is only used by `BaseListComponentView`, so nothing else sees the change.

**`BaseListComponentView`** (`temba/orgs/views/base.py`) — drops `list_posts_uuids`, `derive_bulk_action_objects`, `resolve_posted_uuids` and the `post()` override that drove them.

**The six list views** — the trigger and message lists lose their `list_posts_uuids = False` opt out; the flow and campaign lists lose `derive_bulk_action_objects` overrides that only re-applied an `is_active` filter `BaseListView.derive_queryset` already applies. The contact list's "Remove from group" fallback moves to a plain `post()` and fills in the group's uuid.

**Serialization** — `Broadcast.as_json` exposes `uuid`; `Msg.as_json` drops the `id` that nothing reads any more. Triggers and broadcasts keep `id` alongside `uuid` because the update and delete modals opened from those two pages still have pk-based URLs.

**Components** — `TriggerList`, `MsgList` and `BroadcastList` key rows off `uuid` like the other three lists; the `Msg` and `Broadcast` interfaces gain it.

## Behavior examples

Bulk action posts, for every list:

| | Before | After |
|---|---|---|
| Contacts / flows / campaigns | uuids | uuids |
| Triggers / messages | ids | uuids |
| `label` on a label/group dropdown | uuid, or id passed through | uuid |
| Malformed uuid in `objects` | dropped, action applied to the rest of the selection | form error, whole post rejected |
| Unresolvable (e.g. other-org) uuid | dropped, action applied to the rest | form error, whole post rejected |

The broadcasts internal API endpoint gains a `uuid` on each row; the messages endpoint drops `id`.

## Test plan

- [x] `temba.msgs temba.contacts temba.flows temba.campaigns temba.triggers temba.api temba.orgs` — 562 tests, all passing
- [x] Full `temba` test suite
- [x] Component suite (`bun run test:fast`) — 2927 passing
- [x] `code_check.py` — formatting, lint, migrations and locale checks clean
- [x] Tests updated to post uuids throughout, including the cases that previously asserted an id was accepted, which now assert rejection

## Review notes

Review raised that an unresolvable value now invalidates the whole post, and that `BulkActionMixin.post()` has no `else` on `form.is_valid()`, so an invalid form falls through with no message to the user.

That silent path is pre-existing rather than introduced here. `post()` is untouched by this change, and most stale-row cases were already all-or-nothing: the message and trigger lists posted numeric ids straight into pk matching, and on the uuid pages the translated ids were still validated against the folder/group-scoped `get_queryset()`, so a concurrently archived flow or a contact removed from the group failed there too. The only case this change actually alters is a uuid that resolves to nothing under org scope at all.

Surfacing that error is worth doing, but the smallest correct fix changes behaviour for every bulk-action view and their tests, so it belongs in a follow-up.
