### PR TITLE
Extract org limit functionality into its own mixin and use for triggers

### DIFF
--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -15,7 +15,7 @@ from temba import mailroom
 from temba.api.support import InvalidQueryError
 from temba.contacts.models import URN
 from temba.orgs.views.base import BaseDeleteModal, BaseListView
-from temba.utils.models import TembaModel
+from temba.utils.models import OrgLimitMixin, TembaModel
 from temba.utils.views.mixins import ContextMenuMixin, NonAtomicMixin, SpaMixin
 
 from .models import APIToken, BulkActionFailure
@@ -205,7 +205,7 @@ class WriteAPIMixin:
         else:
             instance = None
 
-            if issubclass(self.model, TembaModel):
+            if issubclass(self.model, OrgLimitMixin):
                 if self.model.is_limit_reached(request.org):
                     return Response(
                         {"detail": "Cannot create object because workspace has reached limit."},

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -265,6 +265,7 @@ class Org(LegacyIDMixin, SmartModel):
     LIMIT_LLMS = "llms"
     LIMIT_TOPICS = "topics"
     LIMIT_TEAMS = "teams"
+    LIMIT_TRIGGERS = "triggers"
 
     DELETE_DELAY_DAYS = 7  # how many days after releasing that an org is deleted
     OUTBOX_WARNING_THRESHOLD = 10_000

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -894,6 +894,7 @@ ORG_LIMIT_DEFAULTS = {
     "llms": 10,
     "teams": 50,
     "topics": 50,
+    "triggers": 500,
 }
 
 RETENTION_PERIODS = {

--- a/temba/staff/tests.py
+++ b/temba/staff/tests.py
@@ -85,6 +85,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
                 "llms_limit",
                 "teams_limit",
                 "topics_limit",
+                "triggers_limit",
                 "loc",
             ],
             list(response.context["form"].fields.keys()),

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -10,7 +10,7 @@ from temba.channels.models import Channel
 from temba.contacts.models import Contact, ContactGroup
 from temba.flows.models import Flow
 from temba.orgs.models import Org
-from temba.utils.models import TembaUUIDMixin
+from temba.utils.models import OrgLimitMixin, TembaUUIDMixin
 
 
 class TriggerType:
@@ -73,11 +73,13 @@ class ChannelTriggerType(TriggerType):
     export_fields = TriggerType.export_fields + ("channel",)
 
 
-class Trigger(TembaUUIDMixin, SmartModel):
+class Trigger(TembaUUIDMixin, OrgLimitMixin, SmartModel):
     """
     A Trigger is used to start a user in a flow based on an event. For example, triggers might fire for missed calls,
     inbound messages starting with a keyword, or on a repeating schedule.
     """
+
+    org_limit_key = Org.LIMIT_TRIGGERS
 
     TYPE_KEYWORD = "K"
     TYPE_SCHEDULE = "S"
@@ -113,6 +115,11 @@ class Trigger(TembaUUIDMixin, SmartModel):
     match_type = models.CharField(max_length=1, choices=MATCH_TYPES, null=True)
     referrer_id = models.CharField(max_length=255, null=True)
     schedule = models.OneToOneField("schedules.Schedule", on_delete=models.PROTECT, null=True, related_name="trigger")
+
+    @classmethod
+    def get_countable_for_org(cls, org):
+        # archived triggers don't fire, so they don't count against the org limit
+        return super().get_countable_for_org(org).filter(is_archived=False)
 
     @classmethod
     def create(
@@ -321,6 +328,9 @@ class Trigger(TembaUUIDMixin, SmartModel):
                 exact_match.restore(user)
 
             return exact_match
+        elif cls.is_limit_reached(org):
+            # matching an existing trigger is always allowed, but we can't create new ones over the limit
+            return None
         else:
             return cls.create(
                 org,

--- a/temba/triggers/tests/test_trigger.py
+++ b/temba/triggers/tests/test_trigger.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 from django.utils import timezone
 
 from temba.channels.models import Channel
@@ -341,6 +342,63 @@ class TriggerTest(TembaTest):
 
         trigger = Trigger.objects.get(trigger_type="C")
         self.assertIsNone(trigger.keywords)
+
+    @override_settings(ORG_LIMIT_DEFAULTS={"triggers": 2})
+    def test_org_limit(self):
+        flow = self.create_flow("Test")
+
+        self.assertFalse(Trigger.is_limit_reached(self.org))
+
+        trigger1 = Trigger.create(self.org, self.admin, Trigger.TYPE_CATCH_ALL, flow)
+        Trigger.create(self.org, self.admin, Trigger.TYPE_INBOUND_CALL, flow)
+
+        self.assertTrue(Trigger.is_limit_reached(self.org))
+
+        # limits are per org
+        self.assertFalse(Trigger.is_limit_reached(self.org2))
+
+        # archived triggers don't fire so they don't count
+        trigger1.archive(self.admin)
+        self.assertFalse(Trigger.is_limit_reached(self.org))
+
+        # and neither do released ones
+        trigger1.restore(self.admin)
+        self.assertTrue(Trigger.is_limit_reached(self.org))
+
+        trigger1.release(self.admin)
+        self.assertFalse(Trigger.is_limit_reached(self.org))
+
+    @override_settings(ORG_LIMIT_DEFAULTS={"triggers": 1})
+    def test_import_limit(self):
+        flow = self.create_flow("Test")
+        flow_ref = {"uuid": str(flow.uuid), "name": "Test"}
+
+        def unarchived_count():
+            return Trigger.objects.filter(org=self.org, is_active=True, is_archived=False).count()
+
+        self._import_trigger({"trigger_type": "C", "flow": flow_ref, "groups": []})
+        catchall = Trigger.objects.get(trigger_type="C")
+        self.assertEqual(1, unarchived_count())
+
+        # at the limit, so a new trigger isn't created
+        self._import_trigger({"trigger_type": "V", "flow": flow_ref, "groups": []})
+        self.assertEqual(1, unarchived_count())
+        self.assertFalse(Trigger.objects.filter(trigger_type="V").exists())
+
+        # but an import which matches an existing trigger is still allowed
+        self._import_trigger({"trigger_type": "C", "flow": flow_ref, "groups": []})
+        self.assertEqual([catchall], list(Trigger.objects.filter(trigger_type="C")))
+
+        # archiving frees up room again
+        catchall.archive(self.admin)
+        self._import_trigger({"trigger_type": "V", "flow": flow_ref, "groups": []})
+        self.assertEqual(1, unarchived_count())
+
+        # and a matching import can restore an archived trigger even tho that puts us over the limit
+        self._import_trigger({"trigger_type": "C", "flow": flow_ref, "groups": []})
+        catchall.refresh_from_db()
+        self.assertFalse(catchall.is_archived)
+        self.assertEqual(2, unarchived_count())
 
     def test_export_import_keyword(self):
         flow = self.create_flow("Test")

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone as tzone
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.urls import reverse
 
 from temba.channels.models import Channel
@@ -52,6 +53,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # the archived trigger not counted
         self.assertPageMenu(menu_url, self.editor, ["Active (1)", "Archived (1)", "New Trigger", "Messages (1)"])
+
+        # at the org limit there's no way to create a new one (the archived trigger doesn't count towards it)
+        with override_settings(ORG_LIMIT_DEFAULTS={"triggers": 1}):
+            self.assertPageMenu(menu_url, self.editor, ["Active (1)", "Archived (1)", "Messages (1)"])
 
     @mock_mailroom
     def test_create(self, mr_mocks):

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -220,9 +220,10 @@ class TriggerCRUDL(SmartCRUDL):
                 )
             )
 
-            menu.append(
-                self.create_menu_item(name=_("New Trigger"), icon="trigger_new", href="triggers.trigger_create")
-            )
+            if not Trigger.is_limit_reached(org):
+                menu.append(
+                    self.create_menu_item(name=_("New Trigger"), icon="trigger_new", href="triggers.trigger_create")
+                )
 
             menu.append(self.create_divider())
 
@@ -436,7 +437,7 @@ class TriggerCRUDL(SmartCRUDL):
         }
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("triggers.trigger_create"):
+            if self.has_org_perm("triggers.trigger_create") and not self.is_limit_reached():
                 menu.add_link(_("New Trigger"), reverse("triggers.trigger_create"), as_button=True)
 
         def derive_queryset(self, *args, **kwargs):

--- a/temba/utils/models/base.py
+++ b/temba/utils/models/base.py
@@ -155,7 +155,34 @@ class TembaNameMixin(models.Model):
         abstract = True
 
 
-class TembaModel(TembaUUIDMixin, TembaNameMixin, SmartModel):
+class OrgLimitMixin:
+    """
+    Mixin for things which are limited per org. Deliberately not a model mixin - it adds no fields of its own, so it
+    can be mixed into models which don't have the rest of the `TembaModel` machinery (e.g. things without a name).
+    """
+
+    org_limit_key = None
+
+    @classmethod
+    def get_countable_for_org(cls, org):
+        """
+        The objects which count against this org's limit. Override to narrow it further.
+        """
+        return cls._default_manager.filter(org=org, is_active=True)
+
+    @classmethod
+    def is_limit_reached(cls, org) -> bool:
+        """
+        Returns whether we've reached the org limit for this model
+        """
+
+        if cls.org_limit_key:
+            return cls.get_countable_for_org(org).count() >= org.get_limit(cls.org_limit_key)
+
+        return False
+
+
+class TembaModel(TembaUUIDMixin, TembaNameMixin, OrgLimitMixin, SmartModel):
     """
     Base for models which have UUID, name and smartmin auditing fields
     """
@@ -167,8 +194,6 @@ class TembaModel(TembaUUIDMixin, TembaNameMixin, SmartModel):
         IGNORED_INVALID = 4  # import ignored because it's invalid
         IGNORED_LIMIT_REACHED = 5  # import ignored because workspace has reached limit
 
-    org_limit_key = None
-
     is_system = models.BooleanField(default=False)  # not user created, doesn't count against limits
 
     @classmethod
@@ -176,17 +201,8 @@ class TembaModel(TembaUUIDMixin, TembaNameMixin, SmartModel):
         return cls._default_manager.filter(org=org, is_active=True)
 
     @classmethod
-    def is_limit_reached(cls, org) -> bool:
-        """
-        Returns whether we've reached the org limit for this model
-        """
-
-        if cls.org_limit_key:
-            limit = org.get_limit(cls.org_limit_key)
-            count = cls.get_active_for_org(org).filter(is_system=False).count()
-            return count >= limit
-
-        return False
+    def get_countable_for_org(cls, org):
+        return cls.get_active_for_org(org).filter(is_system=False)  # system objects don't count against limits
 
     @classmethod
     def import_def(cls, org, user, definition: dict, preview: bool = False) -> tuple:


### PR DESCRIPTION
## Summary

The per-org limit logic lived on `TembaModel`, so a model had to take on uuid, name and the whole import machinery just to be limited. It moves to a standalone `OrgLimitMixin`, and triggers — which have no name field and so can't be a `TembaModel` — become the first user of it, gaining a workspace limit.

## Changes

**`temba/utils/models/base.py`** — new `OrgLimitMixin` holding `org_limit_key`, `get_countable_for_org()` and `is_limit_reached()`. It's deliberately a plain mixin rather than an abstract model: the limit logic needs no fields of its own, so nothing moves between bases and no migrations are generated.

`TembaModel` composes it and overrides `get_countable_for_org()` to exclude system objects, keeping that filter where the `is_system` field actually lives. Existing limited models (globals, topics, teams, fields, groups, labels, knowledge, LLMs, channels) are untouched and behave identically.

**`temba/api/views.py`** — the create-time limit check now tests `issubclass(self.model, OrgLimitMixin)` instead of `TembaModel`. Strictly broader, since every `TembaModel` is now an `OrgLimitMixin`.

**`temba/triggers/`** — `Trigger` gains `OrgLimitMixin` and `org_limit_key`, plus a `get_countable_for_org()` override so archived triggers don't count (they don't fire, so limiting them would only penalise tidying up).

Enforcement follows the existing pattern for limited models:
- the nav menu and list context menu drop their *New Trigger* entries at the limit
- `Trigger.import_def()` won't create a new trigger over the limit, but an import that *matches* an existing trigger is still allowed, and can still restore an archived one — mirroring `TembaModel.import_def()`, where `MATCHED`/`UPDATED` are resolved before the limit is consulted

**`temba/orgs/models.py`, `temba/settings_common.py`** — new `triggers` limit, default 500.

## Behavior examples

| Workspace state (limit 500) | Before | After |
|---|---|---|
| 400 active triggers | can create | can create |
| 500 active triggers | can create | *New Trigger* hidden; import won't add new ones |
| 500 active + 400 archived | can create | same as above — archived don't count |
| 500 active, import matches an existing trigger | created/matched | still matched, and still restored if archived |

## Upgrade note for operators

This introduces a limit where there was none, so the default is deliberately set high enough that existing workspaces are very unlikely to be affected on first deploy. It can be tightened afterwards once an operator knows their own distribution.

Before lowering it, check which workspaces would land over the new value and give those an explicit per-workspace override (editable in the staff area, which now exposes a *Triggers* limit field):

```sql
SELECT org_id, count(*) AS n
FROM triggers_trigger
WHERE is_active = TRUE AND is_archived = FALSE
GROUP BY org_id HAVING count(*) >= 500   -- the value being considered
ORDER BY n DESC;
```

Note the query counts the way the limit does: active and unarchived. Archived triggers can dominate a workspace's raw total, so counting them would give a misleadingly high figure.

Being over the limit never breaks existing triggers — they keep firing, and can still be edited, archived and restored. It only prevents creating new ones.

Also worth knowing for anyone adding a limit in future: the staff workspace-update form builds its fields from `ORG_LIMIT_DEFAULTS`, so a new limit changes that form's field list and the test asserting it.

## Test plan

- [x] Full test suite passes (1131 tests)
- [x] `temba.triggers` (34 tests) passes
- [x] New `test_org_limit` covers the limit being reached, per-workspace isolation, and that archived and released triggers don't count
- [x] New `test_import_limit` covers creates blocked at the limit, matching imports still allowed, archiving freeing room, and a matching import restoring an archived trigger even when that puts the workspace over
- [x] Menu test covers *New Trigger* disappearing at the limit
- [x] `makemigrations --check` reports no changes — confirming the mixin moves no fields
- [x] `code_check.py` clean — no missing migrations, no locale drift

## Follow-up

Trigger import still has its own `import_def()`/`clean_import_def()` rather than using `TembaModel`'s hooks, which is why the limit check here is hand-written instead of coming through as `IGNORED_LIMIT_REACHED`. Converging those would also give trigger imports the result reporting that the `TODO` in `Org.clean_import()` asks for. Tracked separately.