### PR TITLE
Report bulk action form validation failures to the user

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:53+0000\n"
+"POT-Creation-Date: 2026-08-17 23:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -3247,6 +3247,9 @@ msgid "Must specify a label"
 msgstr ""
 
 msgid "An error occurred while making your changes. Please try again."
+msgstr ""
+
+msgid "Your selection is no longer valid. Please refresh and try again."
 msgstr ""
 
 msgid "Edit Team"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:53+0000\n"
+"POT-Creation-Date: 2026-08-17 23:39+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -3274,6 +3274,9 @@ msgstr "Debe especificar una etiqueta"
 
 msgid "An error occurred while making your changes. Please try again."
 msgstr "Se produjo un error al realizar los cambios. Inténtalo de nuevo."
+
+msgid "Your selection is no longer valid. Please refresh and try again."
+msgstr "Su selección ya no es válida. Actualice la página y vuelva a intentarlo."
 
 msgid "Edit Team"
 msgstr "Editar equipo"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:53+0000\n"
+"POT-Creation-Date: 2026-08-17 23:39+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -3274,6 +3274,9 @@ msgstr "Vous devez spécifier une étiquette"
 
 msgid "An error occurred while making your changes. Please try again."
 msgstr "Une erreur s'est produite lors de vos modifications. Veuillez réessayer."
+
+msgid "Your selection is no longer valid. Please refresh and try again."
+msgstr "Votre sélection n'est plus valide. Veuillez actualiser la page et réessayer."
 
 msgid "Edit Team"
 msgstr "Modifier l'équipe"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 21:53+0000\n"
+"POT-Creation-Date: 2026-08-17 23:39+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -3278,6 +3278,9 @@ msgstr "É preciso especificar um rótulo"
 
 msgid "An error occurred while making your changes. Please try again."
 msgstr "Um erro ocorreu enquanto realizava suas alterações. Por favor, tente novamente."
+
+msgid "Your selection is no longer valid. Please refresh and try again."
+msgstr "Sua seleção não é mais válida. Por favor atualize a página e tente novamente."
 
 msgid "Edit Team"
 msgstr "Editar equipe"

--- a/temba/campaigns/tests/test_campaigncrudl.py
+++ b/temba/campaigns/tests/test_campaigncrudl.py
@@ -324,9 +324,10 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         campaign1.refresh_from_db()
         self.assertFalse(campaign1.is_archived)
 
-        # a malformed uuid fails form validation rather than erroring
+        # a malformed uuid fails form validation rather than erroring, and the user is told
         response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
+        self.assertToast(response, "error", "Your selection is no longer valid. Please refresh and try again.")
         campaign2.refresh_from_db()
         self.assertFalse(campaign2.is_archived)
 
@@ -335,6 +336,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         other_org_campaign = self.create_campaign(self.org2, "Other Org", other_org_group)
         response = self.client.post(list_url, {"action": "archive", "objects": str(other_org_campaign.uuid)})
         self.assertEqual(200, response.status_code)
+        self.assertToast(response, "error", "Your selection is no longer valid. Please refresh and try again.")
         other_org_campaign.refresh_from_db()
         self.assertFalse(other_org_campaign.is_archived)
 

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -256,6 +256,12 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # a malformed contact uuid in `objects` fails form validation rather than raising (no 500 on garbage input)
         response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
+        self.assertToast(response, "error", "Your selection is no longer valid. Please refresh and try again.")
+
+        # a label action with no label at all is rejected with our own error
+        response = self.client.post(list_url, {"action": "label", "objects": str(frank.uuid)})
+        self.assertEqual(200, response.status_code)
+        self.assertToast(response, "info", "Must specify a label")
 
     @mock_mailroom
     def test_blocked(self, mr_mocks):

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -720,12 +720,14 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # a malformed flow uuid in `objects` fails form validation rather than raising (no 500 on garbage input)
         response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
+        self.assertToast(response, "error", "Your selection is no longer valid. Please refresh and try again.")
         flow2.refresh_from_db()
         self.assertFalse(flow2.is_archived)
 
         # a malformed label uuid is likewise a form error rather than a raise
         response = self.client.post(list_url, {"action": "label", "objects": str(flow2.uuid), "label": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
+        self.assertToast(response, "error", "Your selection is no longer valid. Please refresh and try again.")
         self.assertEqual(set(), set(flow2.labels.all()))
 
         # the export modal accepts uuids as well as ids

--- a/temba/orgs/views/mixins.py
+++ b/temba/orgs/views/mixins.py
@@ -185,7 +185,9 @@ class BulkActionMixin:
             cleaned_data = super().clean()
             action = cleaned_data.get("action")
             label = cleaned_data.get("label")
-            if action in ("label", "unlabel") and not label:
+            # if the label field itself errored then it was specified but didn't resolve, and that's already
+            # reported as a field error
+            if action in ("label", "unlabel") and not label and "label" not in self.errors:
                 raise forms.ValidationError(_("Must specify a label"))
 
             # TODO update frontend to send back unlabel actions
@@ -233,6 +235,15 @@ class BulkActionMixin:
             except Exception:
                 messages.error(request, _("An error occurred while making your changes. Please try again."))
                 logger.exception(f"error applying '{action}' to {self.model.__name__} objects")
+        else:
+            # errors raised by our own clean method (e.g. a missing label) are user facing, but field errors just
+            # mean a posted uuid didn't resolve against the queryset - most likely because the page is stale
+            errors = form.non_field_errors()
+            if errors:
+                for e in errors:
+                    messages.info(request, e)
+            else:
+                messages.error(request, _("Your selection is no longer valid. Please refresh and try again."))
 
         return self.get(request, *args, **kwargs)
 


### PR DESCRIPTION
## Summary

A bulk action posted from a list page that failed form validation silently no-op'd — `BulkActionMixin.post()` only acted inside `if form.is_valid()` and fell straight through to the GET response with no `else`, so the user got back the unchanged list with no indication anything had failed. Now an invalid form always tells the user something happened.

Since the form matches the posted selection and label on `uuid`, this fires in ordinary use: a row archived or deleted by someone else between the list component fetching the page and the user posting the action makes the whole post invalid, so a 50-row selection with one stale row applied to none of them, silently.

## Changes

**`temba/orgs/views/mixins.py`**

- `BulkActionMixin.post()` gains the missing `else` branch. Errors raised by our own `Form.clean()` are user facing and surface as-is via `messages.info` — matching how the `apply_bulk_action` path below already reports its `ValidationError`s. Field errors mean a posted uuid didn't resolve against the view's queryset, so rather than leaking Django's "Select a valid choice…" into the UI, they get a message pointing at the actual cause: the page is stale.
- `Form.clean()` no longer raises "Must specify a label" when the `label` field itself errored. A label that was specified but didn't resolve is already a field error, and reporting it as "must specify a label" was misleading now that the message is actually shown.

Messages reach the list component the same way the existing bulk action messages do — django messages picked up by `ToastMiddleware` and returned in the `X-Temba-Toasts` header.

## Behavior examples

Posting `{"action": "archive", "objects": "<uuid of a row that no longer resolves>"}`:

| | Before | After |
|---|---|---|
| Response | 200, unchanged list | 200, unchanged list |
| User sees | nothing | error toast: "Your selection is no longer valid. Please refresh and try again." |

Posting a `label` action with no label:

| | Before | After |
|---|---|---|
| User sees | nothing | info toast: "Must specify a label" |

Applies to all six list pages using `BaseListComponentView`: contacts, messages, broadcasts, flows, campaigns, triggers.

## Test plan

- Updated the three tests that asserted the old silent 200 (`test_list_component` in the contacts, flows and campaigns CRUDL tests) to assert the toast, including the cross-org case where the posted object can't resolve under org scope.
- Added coverage for a `label` action posted with no label, asserting the "Must specify a label" toast that was previously never shown.
- `temba.contacts`, `temba.flows`, `temba.campaigns`, `temba.msgs` and `temba.triggers` CRUDL suites pass (127 tests).
- `code_check.py` clean; PO files regenerated with hand-authored es/fr/pt_BR translations for the new string.