### PR TITLE
Address triggers and broadcasts by uuid in their modal URLs

### DIFF
--- a/components/src/interfaces.ts
+++ b/components/src/interfaces.ts
@@ -184,11 +184,10 @@ export interface Campaign {
 /** A single row in the trigger CRUDL list
  * (`triggers/trigger_list.html`): what starts the flow (type +
  * per-type details), any channel / group filters, and the flow it
- * starts. Rows key off the uuid; the numeric id is carried for the
- * page's pk-based update modal URL. */
+ * starts. Rows key off the uuid, which also addresses the page's
+ * update modal. */
 export interface Trigger {
   uuid: string;
-  id: number;
   /** Trigger type slug — drives the leading row icon and the
    * details cell (`keyword`, `catch_all`, `schedule`,
    * `inbound_call`, `missed_call`, `new_conversation`, `referral`,
@@ -224,12 +223,11 @@ export interface Trigger {
 
 /** A single row in the broadcast CRUDL lists — both the scheduled
  * list (`msgs/broadcast_scheduled.html`) and the sent list
- * (`msgs/broadcast_list.html`). Rows key off the uuid; the numeric id
- * is carried for the scheduled list's pk-based edit and delete modal
- * URLs. Content fields carry the base-language translation. */
+ * (`msgs/broadcast_list.html`). Rows key off the uuid, which also
+ * addresses the scheduled list's edit and delete modals. Content
+ * fields carry the base-language translation. */
 export interface Broadcast {
   uuid: string;
-  id: number;
   /** Server status slug — `pending`, `queued`, `started`,
    * `completed`, `failed` or `interrupted`. Scheduled broadcasts
    * that haven't fired yet sit at `pending`. */

--- a/components/test/temba-broadcast-list.test.ts
+++ b/components/test/temba-broadcast-list.test.ts
@@ -10,7 +10,7 @@ const getBroadcastList = async (attrs: any = {}, width = 800, height = 0) => {
 
 const broadcast = (over: any = {}) => {
   const item = {
-    id: 201,
+    uuid: 'bcast-201',
     status: 'completed',
     text: 'Your appointment is confirmed for tomorrow at 10am.',
     attachments: [],
@@ -25,13 +25,12 @@ const broadcast = (over: any = {}) => {
     created_by: 'admin@textit.com',
     ...over
   };
-  // rows key off the uuid, so derive one per id unless the caller set one
-  return { uuid: `bcast-${item.id}`, ...item };
+  return item;
 };
 
 const scheduled = (over: any = {}) =>
   broadcast({
-    id: 301,
+    uuid: 'bcast-301',
     status: 'pending',
     msg_count: undefined,
     schedule: {
@@ -183,14 +182,14 @@ describe('temba-broadcast-list', () => {
     await setItems(list, [
       broadcast(),
       broadcast({
-        id: 202,
+        uuid: 'bcast-202',
         status: 'started',
         msg_count: 40,
         progress: { total: 100, started: 40 }
       }),
-      broadcast({ id: 203, status: 'queued', msg_count: 0 }),
-      broadcast({ id: 204, status: 'failed', msg_count: 0 }),
-      broadcast({ id: 205, status: 'wobble' })
+      broadcast({ uuid: 'bcast-203', status: 'queued', msg_count: 0 }),
+      broadcast({ uuid: 'bcast-204', status: 'failed', msg_count: 0 }),
+      broadcast({ uuid: 'bcast-205', status: 'wobble' })
     ]);
 
     const rows = list.shadowRoot.querySelectorAll('tr.row');
@@ -266,7 +265,7 @@ describe('temba-broadcast-list', () => {
 
   it('renders the sent date', async () => {
     const list: BroadcastList = await getBroadcastList();
-    await setItems(list, [broadcast(), broadcast({ id: 202, created_on: '' })]);
+    await setItems(list, [broadcast(), broadcast({ uuid: 'bcast-202', created_on: '' })]);
     const rows = list.shadowRoot.querySelectorAll('tr.row');
     expect(rows[0].querySelectorAll('td')[3].querySelector('temba-date')).to
       .exist;
@@ -278,11 +277,11 @@ describe('temba-broadcast-list', () => {
     await setItems(list, [
       scheduled(),
       scheduled({
-        id: 302,
+        uuid: 'bcast-302',
         schedule: { repeat_period: 'O', display: 'once', next_fire: null }
       }),
       scheduled({
-        id: 303,
+        uuid: 'bcast-303',
         schedule: {
           repeat_period: 'D',
           display: '',
@@ -557,7 +556,7 @@ describe('temba-broadcast-list', () => {
     await list.updateComplete;
     expect(fired).to.have.length(1);
     expect(fired[0].action).to.equal('edit_broadcast');
-    expect(fired[0].broadcast.id).to.equal(301);
+    expect(fired[0].broadcast.uuid).to.equal('bcast-301');
     expect((list as any).detailBroadcast).to.be.null;
 
     // reopen and delete

--- a/components/test/temba-trigger-list.test.ts
+++ b/components/test/temba-trigger-list.test.ts
@@ -31,7 +31,7 @@ const settlePills = async (list: TriggerList) => {
 
 const trigger = (over: any = {}) => {
   const item = {
-    id: 101,
+    uuid: 'trigger-101',
     type: 'keyword',
     flow: { uuid: 'flow-1', name: 'Registration' },
     channel: null,
@@ -43,8 +43,7 @@ const trigger = (over: any = {}) => {
     created_on: '2026-05-11T09:12:00.000000Z',
     ...over
   };
-  // rows key off the uuid, so derive one per id unless the caller set one
-  return { uuid: `trigger-${item.id}`, ...item };
+  return item;
 };
 
 describe('temba-trigger-list', () => {
@@ -98,7 +97,7 @@ describe('temba-trigger-list', () => {
     row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(rowClicks).to.have.length(1);
-    expect(rowClicks[0].item.id).to.equal(101);
+    expect(rowClicks[0].item.uuid).to.equal('trigger-101');
     // no navigation — the host owns what happens next
     expect(redirects).to.have.length(0);
   });
@@ -254,8 +253,8 @@ describe('temba-trigger-list', () => {
   it('states the type name only when there are no details', async () => {
     const list: TriggerList = await getTriggerList();
     (list as any).items = [
-      trigger({ id: 1, type: 'new_conversation', keywords: null }),
-      trigger({ id: 2 })
+      trigger({ uuid: 'trigger-1', type: 'new_conversation', keywords: null }),
+      trigger({ uuid: 'trigger-2' })
     ];
     list.requestUpdate();
     await list.updateComplete;

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -1208,7 +1208,6 @@ class EndpointsTest(APITestMixin, TembaTest):
         # each row carries the columns the component renders
         def check_sent_shape(data):
             row = [r for r in data["results"] if r["uuid"] == str(bcast1.uuid)][0]
-            self.assertEqual(bcast1.id, row["id"])
             self.assertEqual("completed", row["status"])
             self.assertEqual("Hello everyone", row["text"])
             self.assertEqual(["image/jpeg:http://example.com/cat.jpg"], row["attachments"])
@@ -1346,7 +1345,6 @@ class EndpointsTest(APITestMixin, TembaTest):
         # each row carries the columns the component renders
         def check_shape(data):
             first = [r for r in data["results"] if r["uuid"] == str(trigger1.uuid)][0]
-            self.assertEqual(trigger1.id, first["id"])
             self.assertEqual("keyword", first["type"])
             self.assertEqual({"uuid": str(flow1.uuid), "name": "Survey"}, first["flow"])
             self.assertIsNone(first["channel"])

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -379,8 +379,7 @@ class Broadcast(LegacyIDMixin, models.Model):
         """
         Internal API shape, consumed by the temba-broadcast-list component. Content fields carry the base
         translation; `msg_count` relies on BroadcastMsgCount.bulk_annotate having run for the page (falling back to
-        a per-row count). The numeric id is included alongside the uuid for the scheduled list's edit and delete
-        modals, whose URLs are still pk based.
+        a per-row count).
         """
 
         translation = self.get_translation()
@@ -395,7 +394,6 @@ class Broadcast(LegacyIDMixin, models.Model):
 
         return {
             "uuid": str(self.uuid),
-            "id": self.id,
             "status": self.get_status_display().lower(),
             "text": translation["text"],
             "attachments": translation["attachments"],

--- a/temba/msgs/tests/test_broadcastcrudl.py
+++ b/temba/msgs/tests/test_broadcastcrudl.py
@@ -284,7 +284,7 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             ],
         )
 
-        update_url = reverse("msgs.broadcast_update", args=[broadcast.id])
+        update_url = reverse("msgs.broadcast_update", args=[broadcast.uuid])
 
         self.assertRequestDisallowed(update_url, [None, self.agent, self.admin2])
         self.assertUpdateFetch(update_url, [self.editor, self.admin], form_fields=("contact_search",))
@@ -388,11 +388,11 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             contacts=[self.joe],
             schedule=Schedule.create(self.org, timezone.now(), Schedule.REPEAT_DAILY),
         )
-        update_url = reverse("msgs.broadcast_update", args=[broadcast.id])
+        update_url = reverse("msgs.broadcast_update", args=[broadcast.uuid])
 
         self.org.flow_languages = ["eng", "esp"]
         self.org.save()
-        update_url = reverse("msgs.broadcast_update", args=[broadcast.id])
+        update_url = reverse("msgs.broadcast_update", args=[broadcast.uuid])
 
         def get_languages(response):
             return json.loads(response.context["form"]["compose"].field.widget.attrs["languages"])
@@ -656,7 +656,7 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             schedule=schedule,
         )
 
-        delete_url = reverse("msgs.broadcast_scheduled_delete", args=[broadcast.id])
+        delete_url = reverse("msgs.broadcast_scheduled_delete", args=[broadcast.uuid])
 
         self.assertRequestDisallowed(delete_url, [None, self.agent, self.admin2])
 
@@ -710,7 +710,7 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             status=Broadcast.STATUS_PENDING,
         )
 
-        interrupt_url = reverse("msgs.broadcast_interrupt", args=[broadcast.id])
+        interrupt_url = reverse("msgs.broadcast_interrupt", args=[broadcast.uuid])
         self.assertRequestDisallowed(interrupt_url, [None, self.agent])
         self.requestView(interrupt_url, self.admin, post_data={})
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -286,6 +286,10 @@ class BroadcastCRUDL(SmartCRUDL):
 
     class Update(ModalHeaderMixin, OrgObjPermsMixin, SmartWizardUpdateView):
         form_list = [("target", TargetForm), ("compose", ComposeForm), ("schedule", ScheduleForm)]
+        # this wizard view resolves its object through Django's SingleObjectMixin rather than smartmin's, and that
+        # doesn't default `slug_field` to the url kwarg, so both are needed
+        slug_url_kwarg = "uuid"
+        slug_field = "uuid"
         success_url = "@msgs.broadcast_scheduled"
         submit_button_name = _("Save")
         modal_header_bg = "#8e5ea7"
@@ -386,9 +390,10 @@ class BroadcastCRUDL(SmartCRUDL):
 
     class ScheduledDelete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         default_template = "broadcast_scheduled_delete.html"
+        slug_url_kwarg = "uuid"
         success_url = "@msgs.broadcast_scheduled"
         cancel_url = "@msgs.broadcast_scheduled"
-        fields = ("id",)
+        fields = ("uuid",)
         submit_button_name = _("Delete")
 
         def post(self, request, *args, **kwargs):
@@ -533,6 +538,7 @@ class BroadcastCRUDL(SmartCRUDL):
 
     class Interrupt(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         default_template = "smartmin/delete_confirm.html"
+        slug_url_kwarg = "uuid"
         permission = "msgs.broadcast_update"
         fields = ()
         submit_button_name = _("Interrupt")

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -384,13 +384,11 @@ class Trigger(TembaUUIDMixin, SmartModel):
         """
         Internal API shape, consumed by the temba-trigger-list component. The type slug drives the row icon and
         which of the per-type fields (keywords, schedule, referrer) the details cell renders; channel/groups/contacts
-        render as filter pills. The numeric id is included alongside the uuid for the page's update modal, whose URL
-        is still pk based.
+        render as filter pills.
         """
 
         return {
             "uuid": str(self.uuid),
-            "id": self.id,
             "type": self.type.slug,
             "flow": {"uuid": str(self.flow.uuid), "name": self.flow.name},
             "channel": (

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -681,7 +681,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
             match_type=Trigger.MATCH_ONLY_WORD,
         )
 
-        update_url = reverse("triggers.trigger_update", args=[trigger.id])
+        update_url = reverse("triggers.trigger_update", args=[trigger.uuid])
 
         self.assertRequestDisallowed(update_url, [None, self.agent, self.admin2])
         self.assertUpdateFetch(
@@ -753,7 +753,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         trigger = Trigger.create(self.org, self.admin, Trigger.TYPE_INBOUND_CALL, flow2, channel=call_channel)
 
-        update_url = reverse("triggers.trigger_update", args=[trigger.id])
+        update_url = reverse("triggers.trigger_update", args=[trigger.uuid])
 
         self.assertRequestDisallowed(update_url, [None, self.agent, self.admin2])
         self.assertUpdateFetch(
@@ -823,7 +823,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         next_fire = trigger.schedule.calculate_next_fire(datetime(2021, 6, 23, 12, 0, 0, 0, tzone.utc))  # Wed 23rd
         self.assertEqual(datetime(2021, 6, 25, 12, 0, 0, 0).replace(tzinfo=tz), next_fire)  # Fri 25th
 
-        update_url = reverse("triggers.trigger_update", args=[trigger.id])
+        update_url = reverse("triggers.trigger_update", args=[trigger.uuid])
 
         self.assertRequestDisallowed(update_url, [None, self.agent, self.admin2])
         self.assertUpdateFetch(

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -358,6 +358,8 @@ class TriggerCRUDL(SmartCRUDL):
         trigger_type = Trigger.TYPE_CLOSED_TICKET
 
     class Update(ModalFormMixin, ComponentFormMixin, OrgObjPermsMixin, SmartUpdateView):
+        slug_url_kwarg = "uuid"
+
         def get_form_class(self):
             return self.object.type.form
 

--- a/templates/msgs/broadcast_list.html
+++ b/templates/msgs/broadcast_list.html
@@ -50,13 +50,13 @@
       list.addEventListener("temba-selection", function(event) {
         var detail = event.detail;
         if (detail.action === "edit_broadcast") {
-          showModax("{{ _("Edit Broadcast")|escapejs }}", "/broadcast/update/" + detail.broadcast.id + "/", {
+          showModax("{{ _("Edit Broadcast")|escapejs }}", "/broadcast/update/" + detail.broadcast.uuid + "/", {
             onSubmit: "handleBroadcastChanged()"
           });
           return;
         }
         if (detail.action === "delete_broadcast") {
-          showModax("{{ _("Delete Broadcast")|escapejs }}", "/broadcast/scheduled_delete/" + detail.broadcast.id + "/", {
+          showModax("{{ _("Delete Broadcast")|escapejs }}", "/broadcast/scheduled_delete/" + detail.broadcast.uuid + "/", {
             onSubmit: "handleBroadcastChanged()"
           });
           return;

--- a/templates/triggers/trigger_list.html
+++ b/templates/triggers/trigger_list.html
@@ -60,8 +60,8 @@
       {% if org_perms.triggers.trigger_update %}
       list.addEventListener("temba-row-click", function(event) {
         var trigger = event.detail.item;
-        if (trigger && trigger.id) {
-          showModax("{{ _("Update Trigger")|escapejs }}", "/trigger/update/" + trigger.id + "/", {
+        if (trigger && trigger.uuid) {
+          showModax("{{ _("Update Trigger")|escapejs }}", "/trigger/update/" + trigger.uuid + "/", {
             onSubmit: "handleTriggerUpdated()"
           });
         }


### PR DESCRIPTION
## Summary

Follow-up to #6854. The trigger and broadcast list pages identify their rows by uuid, but the modals those rows open were still addressed by primary key — which was the only reason either object still serialized its numeric id to the UI. This points those views at the uuid and drops the id.

## Changes

**Views** — `TriggerCRUDL.Update`, `BroadcastCRUDL.Update`, `BroadcastCRUDL.ScheduledDelete` and `BroadcastCRUDL.Interrupt` set `slug_url_kwarg = "uuid"`, so their URLs take a uuid instead of a pk. `Interrupt` isn't reachable from the list, but it addresses the same object by the same means, so it moves with them. `ScheduledDelete`'s `fields` follows from `("id",)` to `("uuid",)`.

`BroadcastCRUDL.Update` also sets `slug_field = "uuid"`: it's a `SmartWizardUpdateView`, which resolves its object through Django's `SingleObjectMixin` rather than smartmin's `SmartSingleObjectView`, and Django's doesn't default `slug_field` to the url kwarg — without it the lookup falls back to a `slug` field the model doesn't have.

**Templates** — `trigger_list.html` and `broadcast_list.html` build those modal URLs from the row's uuid.

**Serialization** — `Trigger.as_json` and `Broadcast.as_json` drop `id`; the `Trigger` and `Broadcast` component interfaces drop it too. Every list payload is now uuid-only.

## Behavior examples

| | Before | After |
|---|---|---|
| Trigger update modal | `/trigger/update/12345/` | `/trigger/update/{uuid}/` |
| Scheduled broadcast edit | `/broadcast/update/12345/` | `/broadcast/update/{uuid}/` |
| Scheduled broadcast delete | `/broadcast/scheduled_delete/12345/` | `/broadcast/scheduled_delete/{uuid}/` |
| Broadcast interrupt | `/broadcast/interrupt/12345/` | `/broadcast/interrupt/{uuid}/` |
| `as_json` for either object | `{"uuid": ..., "id": 12345, ...}` | `{"uuid": ..., ...}` |

## Test plan

- [x] Full `temba` test suite — 1129 tests, all passing
- [x] Component suite (`bun run test:fast`) — 2927 passing
- [x] `code_check.py` — formatting, lint, migrations and locale checks clean
- [x] Trigger and broadcast CRUDL tests reverse their URLs with uuids; the internal API tests no longer assert an `id` on either payload

## Not included

`BroadcastCRUDL.Status` still filters on `?id=` and returns `id` in its JSON. Nothing in this repo calls it — no template, no component — so it's left alone rather than changed blind.
