### PR TITLE
Enforce org trigger limit when restoring archived triggers

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 23:39+0000\n"
+"POT-Creation-Date: 2026-08-18 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -3742,6 +3742,9 @@ msgstr ""
 
 #, python-format
 msgid "%(type)s is not a valid trigger type"
+msgstr ""
+
+msgid "This workspace has reached its limit of triggers."
 msgstr ""
 
 msgid "Trigger"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 23:39+0000\n"
+"POT-Creation-Date: 2026-08-18 18:23+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -3769,6 +3769,9 @@ msgstr "El mensaje comienza con la palabra clave"
 #, python-format
 msgid "%(type)s is not a valid trigger type"
 msgstr "%(type)s no es un tipo de activador válido"
+
+msgid "This workspace has reached its limit of triggers."
+msgstr "Este workspace ha alcanzado su límite de activadores."
 
 msgid "Trigger"
 msgstr "Activador"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 23:39+0000\n"
+"POT-Creation-Date: 2026-08-18 18:23+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -3769,6 +3769,9 @@ msgstr "Le message commence par le mot clé"
 #, python-format
 msgid "%(type)s is not a valid trigger type"
 msgstr "%(type)s n'est pas un type de déclencheur valide"
+
+msgid "This workspace has reached its limit of triggers."
+msgstr "Cet espace de travail a atteint sa limite de déclencheurs."
 
 msgid "Trigger"
 msgstr "Déclencheur"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 23:39+0000\n"
+"POT-Creation-Date: 2026-08-18 18:23+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -3773,6 +3773,9 @@ msgstr "Mensagem começa com uma palavra-chave"
 #, python-format
 msgid "%(type)s is not a valid trigger type"
 msgstr "%(type)s não é um tipo de disparador válido"
+
+msgid "This workspace has reached its limit of triggers."
+msgstr "Esta área de trabalho atingiu seu limite de disparadores."
 
 msgid "Trigger"
 msgstr "Disparador"

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -376,6 +376,9 @@ class Trigger(TembaUUIDMixin, OrgLimitMixin, SmartModel):
     def apply_action_restore(cls, user, triggers):
         # work through all the restored triggers in order of most recent used
         for trigger in triggers.order_by("-modified_on"):
+            if cls.is_limit_reached(trigger.org):
+                raise ValidationError(_("This workspace has reached its limit of triggers."))
+
             trigger.restore(user)
 
     @classmethod

--- a/temba/triggers/tests/test_trigger.py
+++ b/temba/triggers/tests/test_trigger.py
@@ -369,6 +369,24 @@ class TriggerTest(TembaTest):
         self.assertFalse(Trigger.is_limit_reached(self.org))
 
     @override_settings(ORG_LIMIT_DEFAULTS={"triggers": 1})
+    def test_restore_limit(self):
+        flow = self.create_flow("Test")
+
+        trigger1 = Trigger.create(self.org, self.admin, Trigger.TYPE_CATCH_ALL, flow, is_archived=True)
+        trigger2 = Trigger.create(self.org, self.admin, Trigger.TYPE_INBOUND_CALL, flow, is_archived=True)
+
+        self.assertFalse(Trigger.is_limit_reached(self.org))
+
+        # restoring both would exceed the limit, so we restore what fits and error on the rest
+        with self.assertRaises(ValidationError):
+            Trigger.apply_action_restore(self.admin, self.org.triggers.filter(id__in=[trigger1.id, trigger2.id]))
+
+        # exactly one was restored, the other was blocked by the limit
+        self.assertEqual(1, self.org.triggers.filter(is_archived=False).count())
+        self.assertEqual(1, self.org.triggers.filter(is_archived=True).count())
+        self.assertTrue(Trigger.is_limit_reached(self.org))
+
+    @override_settings(ORG_LIMIT_DEFAULTS={"triggers": 1})
     def test_import_limit(self):
         flow = self.create_flow("Test")
         flow_ref = {"uuid": str(flow.uuid), "name": "Test"}

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -1221,6 +1221,26 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         trigger7.refresh_from_db()
         self.assertTrue(trigger7.is_active)
 
+    def test_archived_restore_limit(self):
+        flow = self.create_flow("Test")
+
+        trigger1 = Trigger.create(self.org, self.admin, Trigger.TYPE_CATCH_ALL, flow, is_archived=True)
+        trigger2 = Trigger.create(self.org, self.admin, Trigger.TYPE_INBOUND_CALL, flow, is_archived=True)
+
+        archived_url = reverse("triggers.trigger_archived")
+        self.login(self.admin)
+
+        # trying to restore more triggers than the limit allows restores what fits and toasts about the rest
+        with override_settings(ORG_LIMIT_DEFAULTS={"triggers": 1}):
+            response = self.client.post(
+                archived_url, {"action": "restore", "objects": [str(trigger1.uuid), str(trigger2.uuid)]}
+            )
+            self.assertToast(response, "info", "This workspace has reached its limit of triggers.")
+
+        # exactly one was restored, the other left archived
+        self.assertEqual(1, self.org.triggers.filter(is_archived=False).count())
+        self.assertEqual(1, self.org.triggers.filter(is_archived=True).count())
+
     def test_folder(self):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")


### PR DESCRIPTION
## Summary

Archived triggers don't count against an org's trigger limit — `Trigger.get_countable_for_org` filters to `is_archived=False`, since archived triggers don't fire. The limit was only enforced on the create path, so an org already at its limit could restore archived triggers from the Archived list and end up over it.

This adds the missing check to the bulk restore action.

## Changes

- `Trigger.apply_action_restore` checks `is_limit_reached` before restoring each trigger and raises a `ValidationError` once the limit is hit. Triggers are restored most-recently-modified first, so a bulk restore fills the available headroom and then stops.
- `BulkActionMixin.post` already catches `ValidationError` from the action and surfaces it via `messages.info`, so the user gets a toast explaining why the rest weren't restored — no new view code needed.
- New translatable string, with fr/pt_BR/es translations authored and the PO files regenerated.

The `Trigger.create` path that restores an exact archived match is deliberately left unchanged: matching an existing trigger is always allowed over the limit, consistent with how the import path behaves.

## Behavior

With a workspace at its trigger limit, selecting several archived triggers and choosing Restore now restores as many as fit and shows "This workspace has reached its limit of triggers." Previously all of them were restored, leaving the workspace over its limit.

## Test plan

- `TriggerTest.test_restore_limit` — model level: asserts the partial restore and the raised `ValidationError`.
- `TriggerCRUDLTest.test_archived_restore_limit` — view level: POSTs the bulk `restore` action over the limit and asserts both the `info` toast and the partial restore, covering the mixin's ValidationError-to-message path end to end.

Both pass locally, along with the existing `test_org_limit` and `test_archived` cases. `code_check.py` is clean.