### PR TITLE
Interrupt a contact's waiting session before deleting their runs

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1183,12 +1183,17 @@ class Contact(LegacyIDMixin, LegacyUUIDMixin, SmartModel):
         Contact.bulk_change_status(user, [self], modifiers.Status.ACTIVE)
         self.refresh_from_db()
 
-    def release(self, user, *, immediately=False, deindex=True) -> dict:
+    def release(self, user, *, immediately=False, deindex=True, interrupt=True) -> dict:
         """
         Releases this contact. Note that we clear all identifying data but don't hard delete the contact because we need
         to expose deleted contacts over the API to allow external systems to know that contacts have been deleted.
         """
         from .tasks import full_release_contact
+
+        # end any waiting session so that its runs are exited rather than being deleted whilst still active, and has to
+        # happen before we deactivate this contact because mailroom only loads active contacts
+        if interrupt:
+            self.interrupt(user)
 
         # do de-indexing first so if it fails for some reason, we don't go through with the delete
         if deindex:

--- a/temba/contacts/tests/test_contact.py
+++ b/temba/contacts/tests/test_contact.py
@@ -13,7 +13,7 @@ from temba import mailroom
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import ChannelEvent
 from temba.contacts.models import URN, Contact, ContactField, ContactFire, ContactGroup, ContactURN
-from temba.flows.models import Flow
+from temba.flows.models import Flow, FlowRun
 from temba.locations.models import AdminBoundary
 from temba.mailroom import modifiers
 from temba.msgs.models import Msg, MsgFolder
@@ -293,6 +293,51 @@ class ContactTest(TembaTest):
         Flow.objects.get(id=msg_flow.id)
         Flow.objects.get(id=ivr_flow.id)
         self.assertEqual(1, Ticket.objects.count())
+
+    @mock_mailroom
+    def test_release_interrupts_waiting_runs(self, mr_mocks):
+        flow = self.create_flow("Test")
+        contact = self.create_contact("Joe", phone="+12065551212")
+
+        MockSessionWriter(contact, flow).wait().save()
+
+        self.assertEqual({"status:W": 1}, flow.counts.prefix("status:").scope_totals())
+
+        with patch("temba.contacts.models.Contact._full_release"):
+            contact.release(self.admin)
+
+        self.assertEqual([call(self.org, self.admin, [contact])], mr_mocks.calls["contact_interrupt"])
+
+        # run is now interrupted rather than still waiting
+        self.assertEqual({FlowRun.STATUS_INTERRUPTED}, {r.status for r in flow.runs.all()})
+        self.assertEqual({"status:W": 0, "status:I": 1}, flow.counts.prefix("status:").scope_totals())
+
+        # and deleting it leaves that as the historical record
+        contact.refresh_from_db()
+        contact._full_release()
+
+        self.assertEqual(0, flow.runs.count())
+        self.assertEqual({"status:W": 0, "status:I": 1}, flow.counts.prefix("status:").scope_totals())
+
+    @mock_mailroom
+    def test_release_without_interrupt(self, mr_mocks):
+        flow = self.create_flow("Test")
+        contact = self.create_contact("Joe", phone="+12065551212")
+
+        MockSessionWriter(contact, flow).wait().save()
+
+        # org deletion releases contacts without interrupting as flows have already been released
+        with patch("temba.contacts.models.Contact._full_release"):
+            contact.release(self.admin, interrupt=False)
+
+        self.assertEqual([], mr_mocks.calls["contact_interrupt"])
+        self.assertEqual({FlowRun.STATUS_WAITING}, {r.status for r in flow.runs.all()})
+
+        # so the db trigger is left to decrement the waiting count when the run is deleted
+        contact.refresh_from_db()
+        contact._full_release()
+
+        self.assertEqual({"status:W": 0}, flow.counts.prefix("status:").scope_totals())
 
     @mock_mailroom
     def test_status_changes_and_release(self, mr_mocks):

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -126,7 +126,7 @@ class MailroomClient:
 
         return {c: resp[str(c.id)] for c in contacts}
 
-    def contact_interrupt(self, org, user, contacts) -> int:
+    def contact_interrupt(self, org, user, contacts):
         self._request(
             "contact/interrupt", {"org_id": org.id, "user_id": user.id, "contact_ids": [c.id for c in contacts]}
         )

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1149,8 +1149,9 @@ class Org(LegacyIDMixin, SmartModel):
 
         # delete our contacts
         for contact in self.contacts.all():
-            # release synchronously and don't deindex as that will happen for the whole org
-            counts_for_contact = contact.release(user, immediately=True, deindex=False)
+            # release synchronously and don't deindex as that will happen for the whole org, or interrupt as we don't
+            # want to fire mailroom tasks for flows we've already released
+            counts_for_contact = contact.release(user, immediately=True, deindex=False, interrupt=False)
             contact.delete()
 
             counts.update(counts_for_contact)


### PR DESCRIPTION
## Summary

Releasing a contact deleted their runs whilst those runs were still active or waiting, so they never became interrupted — they simply disappeared from the flow's status counts. This ends the contact's waiting session first, so their runs are exited properly and counted as interrupted, which is what would have happened had the contact been interrupted rather than deleted.

This builds on the delete trigger added in #6860, which stops deleted active/waiting runs from leaving their counts behind. That trigger now serves as a backstop rather than the mechanism: it only has to cover runs which aren't attached to the contact's current session, and the deletion of an org's runs.

## Changes

**`temba/contacts/models.py`** — `Contact.release` gains an `interrupt=True` keyword and interrupts the contact before doing anything else. This has to happen before the contact is deactivated, because mailroom only loads active contacts and the interrupt would otherwise be a silent no-op. It reuses `Contact.interrupt`, whose `current_flow` guard matches mailroom's own precondition that only contacts with waiting sessions be passed to it.

**`temba/orgs/models.py`** — org deletion passes `interrupt=False`, alongside its existing `deindex=False`, because its flows have already been released and we don't want to fire mailroom tasks for them.

**`temba/mailroom/client/client.py`** — `contact_interrupt` was annotated `-> int` but returns nothing.

**`temba/contacts/tests/test_contact.py`** — tests for both paths.

## Behavior

Deleting a contact who is waiting in a flow, from the flow's point of view:

| Flow status count | Before | After |
|---|---|---|
| `status:W` | 1 → 0 | 1 → 0 |
| `status:I` | unchanged | 0 → 1 |
| total runs | drops by one | unchanged |

The run's exit is now recorded the same way as any other interruption, so a flow's total run count and its completion rate stay stable when a contact is deleted mid-flow. Deleting a contact with only exited runs is unaffected — those counts stay as the historical record they already were.

## Notes

Both bulk delete paths (`Contact.apply_action_delete` and the `release_contacts` task) release one contact at a time, so each deleted contact who is mid-flow now costs its own interrupt request. That mirrors the per-contact deindex request already made in the same method, and keeps each call on mailroom's synchronous single-contact path rather than its queued batch task, which is what makes the interrupt reliably precede the run deletion.

## Test plan

- [x] New test asserts a waiting run is interrupted on release, and that the interrupted count survives the run being deleted
- [x] New test asserts `interrupt=False` leaves the run waiting, so the db trigger decrements the waiting count on delete
- [x] `temba.contacts`, `temba.orgs`, `temba.flows`, `temba.api` pass locally (444 tests)
- [x] `code_check.py` clean; no new migrations