### PR TITLE
Move provider registration into activate() for Plivo, Twilio and Vonage

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 18:23+0000\n"
+"POT-Creation-Date: 2026-08-19 15:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -1358,13 +1358,16 @@ msgstr ""
 msgid "Shortcode"
 msgstr ""
 
+msgid "Unable to create a Plivo application for that number, please try again."
+msgstr ""
+
+msgid "There was a problem updating that number, please try again."
+msgstr ""
+
 msgid "That number is not currently supported."
 msgstr ""
 
 msgid "There was a problem claiming that number, please check the balance on your account."
-msgstr ""
-
-msgid "There was a problem updating that number, please try again."
 msgstr ""
 
 msgid "Your Plivo auth ID"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 18:23+0000\n"
+"POT-Creation-Date: 2026-08-19 15:06+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1372,14 +1372,17 @@ msgstr "La URL base de PlayMobile"
 msgid "Shortcode"
 msgstr "Código corto"
 
+msgid "Unable to create a Plivo application for that number, please try again."
+msgstr "No se pudo crear una aplicación de Plivo para ese número. Vuelve a intentarlo."
+
+msgid "There was a problem updating that number, please try again."
+msgstr "Hubo un problema al actualizar ese número. Vuelve a intentarlo."
+
 msgid "That number is not currently supported."
 msgstr "Ese número no se admite actualmente."
 
 msgid "There was a problem claiming that number, please check the balance on your account."
 msgstr "Hubo un problema al solicitar ese número, por favor, verifique el saldo en su cuenta."
-
-msgid "There was a problem updating that number, please try again."
-msgstr "Hubo un problema al actualizar ese número. Vuelve a intentarlo."
 
 msgid "Your Plivo auth ID"
 msgstr "Su auth ID de Plivo"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 18:23+0000\n"
+"POT-Creation-Date: 2026-08-19 15:06+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -1372,14 +1372,17 @@ msgstr "L'URL de base pour PlayMobile"
 msgid "Shortcode"
 msgstr "Code court"
 
+msgid "Unable to create a Plivo application for that number, please try again."
+msgstr "Impossible de créer une application Plivo pour ce numéro. Veuillez réessayer."
+
+msgid "There was a problem updating that number, please try again."
+msgstr "Un problème est survenu lors de la mise à jour de ce numéro. Veuillez réessayer."
+
 msgid "That number is not currently supported."
 msgstr "Ce numéro n'est actuellement pas pris en charge."
 
 msgid "There was a problem claiming that number, please check the balance on your account."
 msgstr "Il y a eu un problème pour réclamer ce numéro, prière de verifier le solde de votre compte."
-
-msgid "There was a problem updating that number, please try again."
-msgstr "Un problème est survenu lors de la mise à jour de ce numéro. Veuillez réessayer."
 
 msgid "Your Plivo auth ID"
 msgstr "Votre ID d'authentification Plivo"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 18:23+0000\n"
+"POT-Creation-Date: 2026-08-19 15:06+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -1376,14 +1376,17 @@ msgstr "O URL Base para o PlayMobile"
 msgid "Shortcode"
 msgstr "Código curto"
 
+msgid "Unable to create a Plivo application for that number, please try again."
+msgstr "Não foi possível criar um aplicativo Plivo para esse número, tente novamente."
+
+msgid "There was a problem updating that number, please try again."
+msgstr "Ocorreu um problema ao atualizar esse número, tente novamente."
+
 msgid "That number is not currently supported."
 msgstr "No momento, esse número não é suportado."
 
 msgid "There was a problem claiming that number, please check the balance on your account."
 msgstr "Houve um problema ao requisitar este número, por favor confira os créditos de sua conta."
-
-msgid "There was a problem updating that number, please try again."
-msgstr "Ocorreu um problema ao atualizar esse número, tente novamente."
 
 msgid "Your Plivo auth ID"
 msgstr "Seu ID de autenticação da Plivo"

--- a/temba/channels/tests/test_channel.py
+++ b/temba/channels/tests/test_channel.py
@@ -162,7 +162,7 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         channel1 = Channel.create(
             self.org, self.admin, "RW", "A", "Test Channel", "0785551212", config={Channel.CONFIG_FCM_ID: "123"}
         )
-        channel2 = Channel.create(self.org, self.admin, "", "T", "Test Channel", "0785553333")
+        channel2 = self.create_channel("T", "Test Channel", "0785553333")
 
         # add channel trigger
         flow = self.create_flow("Test")

--- a/temba/channels/types/android/tests.py
+++ b/temba/channels/types/android/tests.py
@@ -117,9 +117,7 @@ class AndroidTypeTest(TembaTest, CRUDLTestMixin):
                 Channel.CONFIG_AUTH_TOKEN: "123456789",
             },
         )
-        Channel.create(
-            self.org, self.admin, "RW", "NX", "", "+250788123123", schemes=[URN.TEL_SCHEME], role=Channel.ROLE_SEND
-        )
+        self.create_channel("NX", "", "+250788123123", country="RW", role=Channel.ROLE_SEND)
 
         # claim our channel
         response = self.client.post(

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -114,11 +114,10 @@ class PlivoTypeTest(TembaTest):
                 mock_get.side_effect = [
                     MockJsonResponse(200, {}),  # get account
                     MockJsonResponse(400, {}),  # failed get number
-                    MockJsonResponse(200, {}),  # successful get number after buying it
                 ]
                 mock_post.side_effect = [
-                    MockJsonResponse(200, {"app_id": "app-id"}),  # create application
                     MockJsonResponse(201, {}),  # buy number
+                    MockJsonResponse(200, {"app_id": "app-id"}),  # create application
                     MockJsonResponse(202, response_body),  # update number
                 ]
 
@@ -155,16 +154,13 @@ class PlivoTypeTest(TembaTest):
                 self.assertEqual(
                     mock_get.call_args_list[1][0][0], "https://api.plivo.com/v1/Account/auth-id/Number/16062681440/"
                 )
-                self.assertEqual(
-                    mock_get.call_args_list[2][0][0], "https://api.plivo.com/v1/Account/auth-id/Number/16062681440/"
-                )
 
                 self.assertEqual(
-                    mock_post.call_args_list[0][0][0], "https://api.plivo.com/v1/Account/auth-id/Application/"
+                    mock_post.call_args_list[0][0][0],
+                    "https://api.plivo.com/v1/Account/auth-id/PhoneNumber/16062681440/",
                 )
                 self.assertEqual(
-                    mock_post.call_args_list[1][0][0],
-                    "https://api.plivo.com/v1/Account/auth-id/PhoneNumber/16062681440/",
+                    mock_post.call_args_list[1][0][0], "https://api.plivo.com/v1/Account/auth-id/Application/"
                 )
                 self.assertEqual(
                     mock_post.call_args_list[2][0][0], "https://api.plivo.com/v1/Account/auth-id/Number/16062681440/"

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -170,6 +170,65 @@ class PlivoTypeTest(TembaTest):
             channel.type.deactivate(channel)
             mock_delete.assert_called_once()
 
+        # if activation fails after the application is created, the channel is released and the app deleted
+        Channel.objects.all().delete()
+
+        with (
+            patch("temba.channels.views.requests.get") as mock_get,
+            patch("temba.channels.views.requests.post") as mock_post,
+            patch("requests.delete") as mock_delete,
+        ):
+            mock_get.side_effect = [
+                MockJsonResponse(200, {}),  # get account
+                MockJsonResponse(200, {}),  # get number
+            ]
+            mock_post.side_effect = [
+                MockJsonResponse(200, {"app_id": "app-id"}),  # create application
+                MockJsonResponse(400, {}),  # failed number link
+            ]
+            mock_delete.return_value = MockJsonResponse(204, {})
+
+            session = self.client.session
+            session[PlivoType.CONFIG_AUTH_ID] = "auth-id"
+            session[PlivoType.CONFIG_AUTH_TOKEN] = "auth-token"
+            session.save()
+
+            response = self.client.post(claim_plivo_url, dict(phone_number="+1 606-268-1440", country="US"))
+            self.assertContains(response, "There was a problem updating that number, please try again.")
+            self.assertNotContains(response, "[&#x27;")  # message should not be wrapped in list repr
+            self.assertFalse(Channel.objects.filter(is_active=True).exists())
+
+            # the just-created application was deleted during release
+            self.assertEqual(
+                mock_delete.call_args_list[0][0][0], "https://api.plivo.com/v1/Account/auth-id/Application/app-id/"
+            )
+
+        # if creating the application fails, the channel is released and there's no app to clean up
+        Channel.objects.all().delete()
+
+        with (
+            patch("temba.channels.views.requests.get") as mock_get,
+            patch("temba.channels.views.requests.post") as mock_post,
+            patch("requests.delete") as mock_delete,
+        ):
+            mock_get.side_effect = [
+                MockJsonResponse(200, {}),  # get account
+                MockJsonResponse(200, {}),  # get number
+            ]
+            mock_post.side_effect = [
+                MockJsonResponse(400, {}),  # failed application creation
+            ]
+
+            session = self.client.session
+            session[PlivoType.CONFIG_AUTH_ID] = "auth-id"
+            session[PlivoType.CONFIG_AUTH_TOKEN] = "auth-token"
+            session.save()
+
+            response = self.client.post(claim_plivo_url, dict(phone_number="+1 606-268-1440", country="US"))
+            self.assertContains(response, "Unable to create a Plivo application for that number, please try again.")
+            self.assertFalse(Channel.objects.filter(is_active=True).exists())
+            mock_delete.assert_not_called()
+
     @patch("requests.get")
     def test_search(self, mock_get):
         self.login(self.admin)

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -53,7 +53,7 @@ class PlivoType(ChannelType):
             headers=headers,
             auth=(auth_id, auth_token),
         )
-        if response.status_code not in (200, 201, 202):  # pragma: no cover
+        if response.status_code not in (200, 201, 202):
             raise ValidationError(_("Unable to create a Plivo application for that number, please try again."))
 
         channel.config[self.CONFIG_APP_ID] = response.json()["app_id"]
@@ -66,7 +66,7 @@ class PlivoType(ChannelType):
             headers=headers,
             auth=(auth_id, auth_token),
         )
-        if response.status_code != 202:  # pragma: no cover
+        if response.status_code != 202:
             raise ValidationError(_("There was a problem updating that number, please try again."))
 
     def deactivate(self, channel):

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -1,5 +1,7 @@
 import requests
 
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
@@ -32,14 +34,50 @@ class PlivoType(ChannelType):
     }
     claim_view = ClaimView
 
+    async_activation = False
+
+    def activate(self, channel):
+        config = channel.config
+        auth_id, auth_token = config[self.CONFIG_AUTH_ID], config[self.CONFIG_AUTH_TOKEN]
+        headers = http_headers(extra={"Content-Type": "application/json"})
+
+        # create an application to handle messaging for this channel
+        app_name = "%s_%s" % (channel.callback_domain.lower().replace(".", "_"), channel.uuid)
+        response = requests.post(
+            "https://api.plivo.com/v1/Account/%s/Application/" % auth_id,
+            json=dict(
+                app_name=app_name,
+                answer_url=f"{settings.STORAGE_URL}/plivo_voice_unavailable.xml",
+                message_url=channel.courier_url("receive"),
+            ),
+            headers=headers,
+            auth=(auth_id, auth_token),
+        )
+        if response.status_code not in (200, 201, 202):  # pragma: no cover
+            raise ValidationError(_("Unable to create a Plivo application for that number, please try again."))
+
+        channel.config[self.CONFIG_APP_ID] = response.json()["app_id"]
+        channel.save(update_fields=("config",))
+
+        # and point our number at it
+        response = requests.post(
+            "https://api.plivo.com/v1/Account/%s/Number/%s/" % (auth_id, channel.address.lstrip("+")),
+            json=dict(app_id=channel.config[self.CONFIG_APP_ID]),
+            headers=headers,
+            auth=(auth_id, auth_token),
+        )
+        if response.status_code != 202:  # pragma: no cover
+            raise ValidationError(_("There was a problem updating that number, please try again."))
+
     def deactivate(self, channel):
         config = channel.config
-        requests.delete(
-            "https://api.plivo.com/v1/Account/%s/Application/%s/"
-            % (config[self.CONFIG_AUTH_ID], config[self.CONFIG_APP_ID]),
-            auth=(config[self.CONFIG_AUTH_ID], config[self.CONFIG_AUTH_TOKEN]),
-            headers=http_headers(extra={"Content-Type": "application/json"}),
-        )
+        app_id = config.get(self.CONFIG_APP_ID)
+        if app_id:
+            requests.delete(
+                "https://api.plivo.com/v1/Account/%s/Application/%s/" % (config[self.CONFIG_AUTH_ID], app_id),
+                auth=(config[self.CONFIG_AUTH_ID], config[self.CONFIG_AUTH_TOKEN]),
+                headers=http_headers(extra={"Content-Type": "application/json"}),
+            )
 
     def get_urls(self):
         return [

--- a/temba/channels/types/plivo/views.py
+++ b/temba/channels/types/plivo/views.py
@@ -4,7 +4,6 @@ import requests
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
@@ -17,7 +16,6 @@ from temba.orgs.views.mixins import OrgPermsMixin
 from temba.utils import countries
 from temba.utils.fields import SelectWidget
 from temba.utils.http import http_headers
-from temba.utils.models import generate_uuid
 
 SUPPORTED_COUNTRIES = {
     "AU",  # Australia
@@ -130,35 +128,8 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
 
         org = self.request.org
 
-        plivo_uuid = generate_uuid()
-        callback_domain = org.get_brand_domain()
-        app_name = "%s_%s" % (callback_domain.lower().replace(".", "_"), plivo_uuid)
-
-        message_url = f"https://{callback_domain}{self.channel_type.courier_path(plivo_uuid, 'receive')}"
-        answer_url = f"{settings.STORAGE_URL}/plivo_voice_unavailable.xml"
-
+        # buy the number if we don't already own it
         headers = http_headers(extra={"Content-Type": "application/json"})
-        create_app_url = "https://api.plivo.com/v1/Account/%s/Application/" % auth_id
-
-        response = requests.post(
-            create_app_url,
-            json=dict(app_name=app_name, answer_url=answer_url, message_url=message_url),
-            headers=headers,
-            auth=(auth_id, auth_token),
-        )
-
-        if response.status_code in [201, 200, 202]:
-            plivo_app_id = response.json()["app_id"]
-        else:  # pragma: no cover
-            plivo_app_id = None
-
-        plivo_config = {
-            self.channel_type.CONFIG_AUTH_ID: auth_id,
-            self.channel_type.CONFIG_AUTH_TOKEN: auth_token,
-            self.channel_type.CONFIG_APP_ID: plivo_app_id,
-            Channel.CONFIG_CALLBACK_DOMAIN: org.get_brand_domain(),
-        }
-
         plivo_number = phone_number.strip("+ ").replace(" ", "")
         response = requests.get(
             "https://api.plivo.com/v1/Account/%s/Number/%s/" % (auth_id, plivo_number),
@@ -178,33 +149,18 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
                     _("There was a problem claiming that number, please check the balance on your account.")
                 )
 
-            response = requests.get(
-                "https://api.plivo.com/v1/Account/%s/Number/%s/" % (auth_id, plivo_number),
-                headers=headers,
-                auth=(auth_id, auth_token),
-            )
-
-        if response.status_code == 200:
-            response = requests.post(
-                "https://api.plivo.com/v1/Account/%s/Number/%s/" % (auth_id, plivo_number),
-                json=dict(app_id=plivo_app_id),
-                headers=headers,
-                auth=(auth_id, auth_token),
-            )
-
-            if response.status_code != 202:  # pragma: no cover
-                raise Exception(_("There was a problem updating that number, please try again."))
-
         phone_number = "+" + plivo_number
         phone = phonenumbers.format_number(
             phonenumbers.parse(phone_number, None), phonenumbers.PhoneNumberFormat.NATIONAL
         )
 
-        channel = Channel.create(
-            org, user, country, "PL", name=phone, address=phone_number, config=plivo_config, uuid=plivo_uuid
-        )
+        config = {
+            self.channel_type.CONFIG_AUTH_ID: auth_id,
+            self.channel_type.CONFIG_AUTH_TOKEN: auth_token,
+            Channel.CONFIG_CALLBACK_DOMAIN: org.get_brand_domain(),
+        }
 
-        return channel
+        return Channel.create(org, user, country, "PL", name=phone, address=phone_number, config=config)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/temba/channels/types/twilio/tests.py
+++ b/temba/channels/types/twilio/tests.py
@@ -108,10 +108,10 @@ class TwilioTypeTest(TembaTest):
             )
 
         with patch("temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.stream") as mock_numbers:
-            mock_numbers.return_value = iter([MockTwilioClient.MockPhoneNumber("+12062345678")])
+            mock_numbers.side_effect = lambda *args, **kwargs: iter([MockTwilioClient.MockPhoneNumber("+12062345678")])
 
             with patch("temba.tests.twilio.MockTwilioClient.MockShortCodes.stream") as mock_short_codes:
-                mock_short_codes.return_value = iter([])
+                mock_short_codes.side_effect = lambda *args, **kwargs: iter([])
 
                 response = self.client.get(claim_twilio)
                 self.assertContains(response, "206-234-5678")
@@ -157,10 +157,10 @@ class TwilioTypeTest(TembaTest):
         session.save()
 
         with patch("temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.stream") as mock_numbers:
-            mock_numbers.return_value = iter([MockTwilioClient.MockPhoneNumber("+12062345678")])
+            mock_numbers.side_effect = lambda *args, **kwargs: iter([MockTwilioClient.MockPhoneNumber("+12062345678")])
 
             with patch("temba.tests.twilio.MockTwilioClient.MockShortCodes.stream") as mock_short_codes:
-                mock_short_codes.return_value = iter([])
+                mock_short_codes.side_effect = lambda *args, **kwargs: iter([])
 
                 response = self.client.get(claim_twilio)
                 self.assertContains(response, "206-234-5678")
@@ -201,10 +201,12 @@ class TwilioTypeTest(TembaTest):
 
         # voice only number
         with patch("temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.stream") as mock_numbers:
-            mock_numbers.return_value = iter([MockTwilioClient.MockPhoneNumber("+554139087835", sms=False, voice=True)])
+            mock_numbers.side_effect = lambda *args, **kwargs: iter(
+                [MockTwilioClient.MockPhoneNumber("+554139087835", sms=False, voice=True)]
+            )
 
             with patch("temba.tests.twilio.MockTwilioClient.MockShortCodes.stream") as mock_short_codes:
-                mock_short_codes.return_value = iter([])
+                mock_short_codes.side_effect = lambda *args, **kwargs: iter([])
                 Channel.objects.all().delete()
 
                 with patch("temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.get") as mock_numbers_get:
@@ -216,7 +218,7 @@ class TwilioTypeTest(TembaTest):
                     self.assertContains(response, "+55 41 3908-7835")
 
                     # claim it
-                    mock_numbers.return_value = iter(
+                    mock_numbers.side_effect = lambda *args, **kwargs: iter(
                         [MockTwilioClient.MockPhoneNumber("+554139087835", sms=False, voice=True)]
                     )
                     response = self.client.post(claim_twilio, dict(country="BR", phone_number="554139087835"))
@@ -233,10 +235,10 @@ class TwilioTypeTest(TembaTest):
         session.save()
 
         with patch("temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.stream") as mock_numbers:
-            mock_numbers.return_value = iter([MockTwilioClient.MockPhoneNumber("+4545335500")])
+            mock_numbers.side_effect = lambda *args, **kwargs: iter([MockTwilioClient.MockPhoneNumber("+4545335500")])
 
             with patch("temba.tests.twilio.MockTwilioClient.MockShortCodes.stream") as mock_short_codes:
-                mock_short_codes.return_value = iter([])
+                mock_short_codes.side_effect = lambda *args, **kwargs: iter([])
 
                 Channel.objects.all().delete()
 
@@ -258,10 +260,10 @@ class TwilioTypeTest(TembaTest):
         session.save()
 
         with patch("temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.stream") as mock_numbers:
-            mock_numbers.return_value = iter([])
+            mock_numbers.side_effect = lambda *args, **kwargs: iter([])
 
             with patch("temba.tests.twilio.MockTwilioClient.MockShortCodes.stream") as mock_short_codes:
-                mock_short_codes.return_value = iter([MockTwilioClient.MockShortCode("8080")])
+                mock_short_codes.side_effect = lambda *args, **kwargs: iter([MockTwilioClient.MockShortCode("8080")])
 
                 with patch("temba.tests.twilio.MockTwilioClient.MockShortCodes.get") as mock_short_codes_get:
                     mock_short_codes_get.return_value = MockTwilioClient.MockShortCode("8080")
@@ -276,7 +278,9 @@ class TwilioTypeTest(TembaTest):
                     self.assertContains(response, 'class="country">US')  # we look up the country from the timezone
 
                     # claim it
-                    mock_short_codes.return_value = iter([MockTwilioClient.MockShortCode("8080")])
+                    mock_short_codes.side_effect = lambda *args, **kwargs: iter(
+                        [MockTwilioClient.MockShortCode("8080")]
+                    )
                     response = self.client.post(claim_twilio, dict(country="US", phone_number="8080"))
                     self.assertRedirects(response, reverse("public.public_welcome") + "?success")
                     self.assertEqual(mock_numbers.call_args_list[0][1], {"page_size": 1000})

--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -1,7 +1,8 @@
 from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client as TwilioClient
 
-from django.urls import re_path
+from django.conf import settings
+from django.urls import re_path, reverse
 from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
@@ -44,8 +45,40 @@ class TwilioType(ChannelType):
     claim_view = ClaimView
     update_form = UpdateForm
 
+    async_activation = False
+
     def is_recommended_to(self, org, user):
         return timezone_to_country_code(org.timezone) in SUPPORTED_COUNTRIES
+
+    def activate(self, channel):
+        config = channel.config
+        client = TwilioClient(config[Channel.CONFIG_ACCOUNT_SID], config[Channel.CONFIG_AUTH_TOKEN])
+        callback_domain = channel.callback_domain
+        base_url = "https://" + callback_domain
+
+        # create a TwiML app to handle messaging and voice for this channel
+        new_app = client.api.applications.create(
+            friendly_name="%s/%s" % (callback_domain.lower(), channel.uuid),
+            sms_method="POST",
+            sms_url=channel.courier_url("receive"),
+            voice_method="POST",
+            voice_url=base_url + reverse("mailroom.ivr_handler", args=[channel.uuid, "incoming"]),
+            status_callback_method="POST",
+            status_callback=base_url + reverse("mailroom.ivr_handler", args=[channel.uuid, "status"]),
+            voice_fallback_method="GET",
+            voice_fallback_url=f"{settings.STORAGE_URL}/voice_unavailable.xml",
+        )
+
+        channel.config[Channel.CONFIG_APPLICATION_SID] = new_app.sid
+        channel.save(update_fields=("config",))
+
+        number_sid = config[Channel.CONFIG_NUMBER_SID]
+        if len(channel.address) <= 6:  # short codes can't use TwiML apps and point directly at our receive URL
+            client.api.short_codes.get(number_sid).update(sms_url=channel.courier_url("receive"), sms_method="POST")
+        else:
+            client.api.incoming_phone_numbers.get(number_sid).update(
+                voice_application_sid=new_app.sid, sms_application_sid=new_app.sid
+            )
 
     def deactivate(self, channel):
         config = channel.config

--- a/temba/channels/types/twilio/views.py
+++ b/temba/channels/types/twilio/views.py
@@ -7,7 +7,6 @@ from twilio.base.exceptions import TwilioException, TwilioRestException
 from twilio.rest import Client as TwilioClient
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
@@ -17,7 +16,6 @@ from temba.orgs.views.mixins import OrgPermsMixin
 from temba.utils import countries
 from temba.utils.fields import InputWidget, SelectWidget
 from temba.utils.timezones import timezone_to_country_code
-from temba.utils.uuid import uuid4
 
 from ...models import Channel
 from ...views import ALL_COUNTRIES, BaseClaimNumberMixin, ChannelTypeMixin, ClaimViewMixin, UpdateChannelForm
@@ -179,27 +177,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
     def claim_number(self, user, phone_number, country, role):
         org = self.request.org
         client = self.get_twilio_client()
-        twilio_phones = client.api.incoming_phone_numbers.stream(phone_number=phone_number)
-        channel_uuid = uuid4()
-
-        # create new TwiML app
-        callback_domain = org.get_brand_domain()
-        base_url = "https://" + callback_domain
-        receive_url = base_url + self.channel_type.courier_path(channel_uuid, "receive")
-        status_url = base_url + reverse("mailroom.ivr_handler", args=[channel_uuid, "status"])
-        voice_url = base_url + reverse("mailroom.ivr_handler", args=[channel_uuid, "incoming"])
-
-        new_app = client.api.applications.create(
-            friendly_name="%s/%s" % (callback_domain.lower(), channel_uuid),
-            sms_method="POST",
-            sms_url=receive_url,
-            voice_method="POST",
-            voice_url=voice_url,
-            status_callback_method="POST",
-            status_callback=status_url,
-            voice_fallback_method="GET",
-            voice_fallback_url=f"{settings.STORAGE_URL}/voice_unavailable.xml",
-        )
 
         is_short_code = len(phone_number) <= 6
         tps = 10
@@ -212,9 +189,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
 
             if short_code:
                 number_sid = short_code.sid
-                app_url = "https://" + callback_domain + self.channel_type.courier_path(channel_uuid, "receive")
-                client.api.short_codes.get(number_sid).update(sms_url=app_url, sms_method="POST")
-
                 role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE
                 phone = phone_number
                 tps = 100
@@ -224,16 +198,10 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
                     _("Short code not found on your Twilio Account. Please check you own the short code and Try again")
                 )
         else:
+            twilio_phones = client.api.incoming_phone_numbers.stream(phone_number=phone_number)
             twilio_phone = next(twilio_phones, None)
-            if twilio_phone:
-                client.api.incoming_phone_numbers.get(twilio_phone.sid).update(
-                    voice_application_sid=new_app.sid, sms_application_sid=new_app.sid
-                )
-
-            else:  # pragma: needs cover
-                twilio_phone = client.api.incoming_phone_numbers.create(
-                    phone_number=phone_number, voice_application_sid=new_app.sid, sms_application_sid=new_app.sid
-                )
+            if not twilio_phone:  # pragma: needs cover
+                twilio_phone = client.api.incoming_phone_numbers.create(phone_number=phone_number)
 
             phone = phonenumbers.format_number(
                 phonenumbers.parse(phone_number, None), phonenumbers.PhoneNumberFormat.NATIONAL
@@ -248,11 +216,10 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             number_sid = twilio_phone.sid
 
         config = {
-            Channel.CONFIG_APPLICATION_SID: new_app.sid,
             Channel.CONFIG_NUMBER_SID: number_sid,
             Channel.CONFIG_ACCOUNT_SID: self.request.session.get(self.channel_type.SESSION_ACCOUNT_SID),
             Channel.CONFIG_AUTH_TOKEN: self.request.session.get(self.channel_type.SESSION_AUTH_TOKEN),
-            Channel.CONFIG_CALLBACK_DOMAIN: callback_domain,
+            Channel.CONFIG_CALLBACK_DOMAIN: org.get_brand_domain(),
         }
 
         channel = Channel.create(
@@ -264,7 +231,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             address=phone_number,
             role=role,
             config=config,
-            uuid=channel_uuid,
             tps=tps,
         )
 

--- a/temba/channels/types/twilio_whatsapp/views.py
+++ b/temba/channels/types/twilio_whatsapp/views.py
@@ -12,7 +12,6 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.twilio.views import SUPPORTED_COUNTRIES, UpdateForm as TwilioUpdateForm
 from temba.contacts.models import URN
 from temba.utils.fields import InputWidget, SelectWidget
-from temba.utils.uuid import uuid4
 
 from ...models import Channel
 from ...views import ALL_COUNTRIES, BaseClaimNumberMixin, ClaimViewMixin
@@ -161,9 +160,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         org = self.request.org
         client = self.get_twilio_client()
         twilio_phones = client.api.incoming_phone_numbers.stream(phone_number=phone_number)
-        channel_uuid = uuid4()
-
-        callback_domain = org.get_brand_domain()
 
         twilio_phone = next(twilio_phones, None)
         if twilio_phone:
@@ -187,7 +183,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             Channel.CONFIG_NUMBER_SID: number_sid,
             Channel.CONFIG_ACCOUNT_SID: self.request.session.get(self.channel_type.SESSION_ACCOUNT_SID),
             Channel.CONFIG_AUTH_TOKEN: self.request.session.get(self.channel_type.SESSION_AUTH_TOKEN),
-            Channel.CONFIG_CALLBACK_DOMAIN: callback_domain,
+            Channel.CONFIG_CALLBACK_DOMAIN: org.get_brand_domain(),
         }
 
         role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE
@@ -201,7 +197,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             address=phone_number,
             role=role,
             config=config,
-            uuid=channel_uuid,
             schemes=[URN.WHATSAPP_SCHEME],
         )
 

--- a/temba/channels/types/vonage/tests.py
+++ b/temba/channels/types/vonage/tests.py
@@ -218,14 +218,11 @@ class VonageTypeTest(TembaTest):
     def test_search(self, mock_search_numbers):
         self.login(self.admin)
         self.org.channels.update(is_active=False)
-        self.channel = Channel.create(
-            self.org,
-            self.admin,
-            "RW",
+        self.channel = self.create_channel(
             "NX",
             "Vonage",
             "+250788123123",
-            uuid="00000000-0000-0000-0000-000000001234",
+            country="RW",
             config={VonageType.CONFIG_API_KEY: "1234", VonageType.CONFIG_API_SECRET: "secret"},
         )
 

--- a/temba/channels/types/vonage/type.py
+++ b/temba/channels/types/vonage/type.py
@@ -1,7 +1,8 @@
+from django.core.exceptions import ValidationError
 from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import ChannelType, ConfigUI
+from temba.channels.models import Channel, ChannelType, ConfigUI
 from temba.contacts.models import URN
 from temba.utils.timezones import timezone_to_country_code
 
@@ -70,6 +71,8 @@ class VonageType(ChannelType):
     }
     claim_view = ClaimView
 
+    async_activation = False
+
     config_ui = ConfigUI(
         blurb=_(
             "Your Vonage configuration URLs are as follows. These should have been set up automatically when claiming your "
@@ -96,6 +99,34 @@ class VonageType(ChannelType):
 
     def is_recommended_to(self, org, user):
         return timezone_to_country_code(org.timezone) in RECOMMENDED_COUNTRIES
+
+    def activate(self, channel):
+        config = channel.config
+        client = VonageClient(api_key=config[self.CONFIG_API_KEY], api_secret=config[self.CONFIG_API_SECRET])
+
+        # if the number supports voice, create a voice application for it
+        if Channel.ROLE_ANSWER in channel.role:
+            app_id, app_private_key = client.create_application(channel.callback_domain, channel.uuid)
+            channel.config[self.CONFIG_APP_ID] = app_id
+            channel.config[self.CONFIG_APP_PRIVATE_KEY] = app_private_key
+            channel.save(update_fields=("config",))
+
+        # update the delivery URLs for the number
+        try:
+            client.update_number(
+                str(channel.country),
+                channel.address,
+                channel.courier_url("receive"),
+                channel.config.get(self.CONFIG_APP_ID),
+            )
+        except Exception as e:  # pragma: no cover
+            # short codes don't seem to claim correctly, move forward anyways
+            if channel.address.startswith("+"):
+                raise ValidationError(
+                    _("There was a problem claiming that number, please check the balance on your account.")
+                    + "\n"
+                    + str(e)
+                )
 
     def deactivate(self, channel):
         app_id = channel.config.get(self.CONFIG_APP_ID)

--- a/temba/channels/types/vonage/views.py
+++ b/temba/channels/types/vonage/views.py
@@ -10,7 +10,6 @@ from django.utils.translation import gettext_lazy as _
 from temba.orgs.views.mixins import OrgPermsMixin
 from temba.utils import countries
 from temba.utils.fields import InputWidget, SelectWidget
-from temba.utils.models import generate_uuid
 
 from ...models import Channel
 from ...views import BaseClaimNumberMixin, ChannelTypeMixin, ClaimViewMixin
@@ -367,30 +366,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         if supports_voice:
             role += Channel.ROLE_ANSWER + Channel.ROLE_CALL
 
-        channel_uuid = generate_uuid()
-        callback_domain = org.get_brand_domain()
-        receive_url = "https://" + callback_domain + self.channel_type.courier_path(channel_uuid, "receive")
-
-        # if it supports voice, create new voice app for this number
-        if supports_voice:
-            app_id, app_private_key = client.create_application(org.get_brand_domain(), channel_uuid)
-        else:
-            app_id = None
-            app_private_key = None
-
-        # update the delivery URLs for it
-        try:
-            client.update_number(country, phone_number, receive_url, app_id)
-
-        except Exception as e:  # pragma: no cover
-            # shortcodes don't seem to claim correctly, move forward anyways
-            if not is_shortcode:
-                raise Exception(
-                    _("There was a problem claiming that number, please check the balance on your account.")
-                    + "\n"
-                    + str(e)
-                )
-
         if is_shortcode:
             phone = phone_number
         else:
@@ -398,11 +373,11 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             phone = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
 
         config = {
-            self.channel_type.CONFIG_APP_ID: app_id,
-            self.channel_type.CONFIG_APP_PRIVATE_KEY: app_private_key,
+            self.channel_type.CONFIG_APP_ID: None,
+            self.channel_type.CONFIG_APP_PRIVATE_KEY: None,
             self.channel_type.CONFIG_API_KEY: self.request.session.get(self.channel_type.SESSION_API_KEY),
             self.channel_type.CONFIG_API_SECRET: self.request.session.get(self.channel_type.SESSION_API_SECRET),
-            Channel.CONFIG_CALLBACK_DOMAIN: callback_domain,
+            Channel.CONFIG_CALLBACK_DOMAIN: org.get_brand_domain(),
         }
 
         return Channel.create(
@@ -414,7 +389,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             address=phone_number,
             role=role,
             config=config,
-            uuid=channel_uuid,
             tps=1,
         )
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -365,6 +365,10 @@ class BaseClaimNumberMixin(ClaimViewMixin):
             logger.warning(f"Unable to claim a number: {str(e)}", exc_info=True)
             error_message = form.error_class([str(e)])
 
+        except ValidationError as e:
+            logger.warning(f"Unable to claim a number: {str(e)}", exc_info=True)
+            error_message = form.error_class(e.messages)
+
         except Exception as e:  # pragma: needs cover
             logger.error(f"Unable to claim a number: {str(e)}", exc_info=True)
 


### PR DESCRIPTION
## Summary

The Plivo, Twilio and Vonage claim views registered callbacks with the provider *before* creating the channel, building the callback URL from a pre-generated UUID — the last places that couldn't use `Channel.courier_url()`. This moves that provider-side registration into each type's `activate()`, which runs synchronously inside `Channel.create()`, so the channel exists first and the URL comes from the same helper as every other type.

## Changes

**Plivo** — `PlivoType.activate()` creates the Plivo application (with `channel.courier_url("receive")` as its message URL) and links the number to it; the claim view now only buys the number if the account doesn't already own it. `deactivate()` tolerates a missing app id, since activation can now fail before one is stored.

**Twilio** — `TwilioType.activate()` creates the TwiML app and wires the number (or shortcode) to it. The claim view keeps number/shortcode lookup, purchase, and role/tps determination. Purchased numbers are created bare and wired in `activate()` — one extra API call on that path.

**Vonage** — `VonageType.activate()` creates the voice application when the number supports voice (`ROLE_ANSWER` in the channel's roles) and updates the number's delivery URLs, still tolerating update failures for shortcodes.

All three types set `async_activation = False` so activation runs inside the claim request — a failure surfaces as a form error exactly as before, and `Channel.create()` releases the channel on the way out.

**Twilio WhatsApp** — its claim view also pre-generated a UUID, copied from the Twilio flow, but never used it before creation; removed.

**Claim error rendering** — `BaseClaimNumberMixin.form_valid` rendered exceptions from `claim_number` via `str(e)`, which for a `ValidationError` produces its list repr (`"['…']"`). It now has an explicit `ValidationError` arm that renders `e.messages`, so activation errors surface cleanly.

`ChannelType.courier_path()` now has no callers outside `Channel.courier_url()` itself, and the only remaining `uuid=` passed to `Channel.create()` is the Android relayer's, where the UUID is the device's own identity.

## Behavior

Callback URLs registered with providers are unchanged. The error flow improves in two ways:

| Scenario | Before | After |
|---|---|---|
| Plivo application creation fails | channel created with `app_id: None`, silently broken | claim fails with an error, channel released |
| Plivo number-link fails after app created | claim fails, orphaned Plivo application leaked | claim fails, channel released → `deactivate()` deletes the application |

Activation failures release the channel via the standard `Channel.create()` path, so no half-configured channels are left behind.

## Test plan

- [x] Full `temba` suite passes (1137 tests)
- [x] New tests cover both Plivo activation failure paths: a failed number-link releases the channel and deletes the just-created application; a failed application creation releases the channel with nothing to clean up — and assert the error message renders without list-repr wrapping
- [x] Twilio claim tests' single-use iterator mocks replaced with per-call fresh iterators — previously every claim silently took the number-purchase branch; they now exercise the found-number branch, and `activate()`'s number lookup works
- [x] Test fixtures that created NX/T channels via `Channel.create()` (which now activates) switched to the `create_channel` test helper, which doesn't
- [x] New Plivo error string translated for es/fr/pt_BR; PO files regenerated
- [x] `code_check.py` clean
