### PR TITLE
Remove vestigial is_support branches from dashboard views

### DIFF
--- a/temba/dashboard/views.py
+++ b/temba/dashboard/views.py
@@ -33,17 +33,13 @@ class MessageHistory(OrgPermsMixin, ChartViewMixin, SmartTemplateView):
     default_chart_period = (-timedelta(days=30), timedelta(days=1))
 
     def get_chart_data(self, since, until) -> tuple[list, list]:
-        orgs = []
-        org = self.derive_org()
-        if org:
-            orgs = Org.objects.filter(Q(id=org.id) | Q(parent=org))
+        org = self.request.org
+        orgs = Org.objects.filter(Q(id=org.id) | Q(parent=org))
 
         # get all our counts for that period
         daily_counts = ChannelCount.objects.filter(scope__in=[ChannelCount.SCOPE_TEXT_IN, ChannelCount.SCOPE_TEXT_OUT])
         daily_counts = daily_counts.filter(day__gte=since).filter(day__lte=until)
-
-        if orgs or not self.request.user.is_support:
-            daily_counts = daily_counts.filter(channel__org__in=orgs)
+        daily_counts = daily_counts.filter(channel__org__in=orgs)
 
         daily_counts = list(
             daily_counts.values("day", "scope").order_by("day", "scope").annotate(count_sum=Sum("count"))
@@ -94,10 +90,8 @@ class WorkspaceStats(OrgPermsMixin, SmartTemplateView):
         return since, until
 
     def render_to_response(self, context, **response_kwargs):
-        orgs = []
-        org = self.derive_org()
-        if org:
-            orgs = Org.objects.filter(Q(id=org.id) | Q(parent=org))
+        org = self.request.org
+        orgs = Org.objects.filter(Q(id=org.id) | Q(parent=org))
 
         since, until = self.get_period()
 
@@ -110,9 +104,7 @@ class WorkspaceStats(OrgPermsMixin, SmartTemplateView):
         )
 
         daily_counts = daily_counts.filter(day__gte=since).filter(day__lte=until)
-
-        if orgs or not self.request.user.is_support:
-            daily_counts = daily_counts.filter(channel__org__in=orgs)
+        daily_counts = daily_counts.filter(channel__org__in=orgs)
 
         categories = []
         inbound = []


### PR DESCRIPTION
## Summary

Removes dead conditionals in the dashboard views that guarded an org-less code path which can no longer occur. `User.is_support` no longer exists, and `OrgPermsMixin.has_org_perm` already denies access to these views when the request has no org, so the org list is always non-empty.

## Changes

- `MessageHistory.get_chart_data` and `WorkspaceStats.render_to_response` now build the org list (the request org plus its children) unconditionally from `request.org` and always filter channel counts by it.
- Dropped the `orgs = []` / `if org:` scaffolding and the unreachable `if orgs or not self.request.user.is_support:` branches that only existed to support the org-less path.

No behavioral change: the filter that previously applied on every reachable path still applies on every path.

## Test plan

- [x] `temba.dashboard` tests pass in the devcontainer
- [x] `code_check.py` passes (ruff, migrations, locale files)