### PR TITLE
Remove unused broadcast status endpoint

### DIFF
--- a/temba/msgs/tests/test_broadcastcrudl.py
+++ b/temba/msgs/tests/test_broadcastcrudl.py
@@ -674,34 +674,6 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertIsNone(broadcast.schedule)
         self.assertEqual(0, Schedule.objects.count())
 
-    def test_status(self):
-        broadcast = self.create_broadcast(
-            self.admin,
-            {"eng": {"text": "Daily reminder"}},
-            groups=[self.joe_and_frank],
-            status=Broadcast.STATUS_PENDING,
-        )
-
-        status_url = f"{reverse('msgs.broadcast_status')}?id={broadcast.id}&status=P"
-        self.assertRequestDisallowed(status_url, [None, self.agent])
-        response = self.assertReadFetch(status_url, [self.editor, self.admin])
-
-        # status returns json
-        self.assertEqual("Pending", response.json()["results"][0]["status"])
-
-        # broadcasts from other orgs should not be accessible even by id
-        other_broadcast = self.create_broadcast(
-            self.admin2,
-            {"eng": {"text": "Other org reminder"}},
-            contacts=[self.create_contact("Bob", urns=["tel:+250788000001"], org=self.org2)],
-            status=Broadcast.STATUS_PENDING,
-            org=self.org2,
-        )
-        other_status_url = f"{reverse('msgs.broadcast_status')}?id={other_broadcast.id}&status=P"
-        response = self.requestView(other_status_url, self.admin)
-        self.assertEqual(200, response.status_code)
-        self.assertEqual([], response.json()["results"])
-
     def test_interrupt(self):
         broadcast = self.create_broadcast(
             self.admin,

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -137,7 +137,6 @@ class BroadcastCRUDL(SmartCRUDL):
         "scheduled_delete",
         "preview",
         "to_node",
-        "status",
         "interrupt",
     )
     model = Broadcast
@@ -504,37 +503,6 @@ class BroadcastCRUDL(SmartCRUDL):
             )
 
             return self.render_modal_response(form)
-
-    class Status(BaseListView):
-        permission = "msgs.broadcast_list"
-
-        def derive_queryset(self, **kwargs):
-            qs = super().derive_queryset(**kwargs)
-
-            id = self.request.GET.get("id", None)
-            if id:
-                qs = qs.filter(id=id)
-
-            status = self.request.GET.get("status", None)
-            if status:
-                qs = qs.filter(status=status)
-
-            return qs.order_by("-created_on")
-
-        def render_to_response(self, context, **response_kwargs):
-            results = []
-            for obj in context["object_list"]:
-                # created_on as an iso date
-                results.append(
-                    {
-                        "id": obj.id,
-                        "status": obj.get_status_display(),
-                        "created_on": obj.created_on.isoformat(),
-                        "modified_on": obj.modified_on.isoformat(),
-                        "progress": {"total": obj.contact_count, "current": obj.get_message_count()},
-                    }
-                )
-            return JsonResponse({"results": results})
 
     class Interrupt(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         default_template = "smartmin/delete_confirm.html"


### PR DESCRIPTION
## Summary

Removes `BroadcastCRUDL.Status`, the JSON polling endpoint served at `/broadcast/status/`.

It was added to drive a `temba-start-progress` bar on the server-rendered broadcast list, returning each broadcast's status and a `progress` object keyed off a `?id=` query param. That server-rendered list has since been replaced by the `temba-broadcast-list` component, which fetches from the internal broadcasts API and already gets `status` and `progress` in each row from `Broadcast.as_json()`. Nothing polls the endpoint any more.

## Changes

- **`temba/msgs/views.py`** — drops `"status"` from `BroadcastCRUDL.actions` and deletes the view class.
- **`temba/msgs/tests/test_broadcastcrudl.py`** — deletes `test_status`, which was the endpoint's only remaining reference.

## Notes for reviewers

- **The `temba-start-progress` component stays.** It's generic — driven entirely by its `statusendpoint`/`interruptendpoint` attributes, and it reads only `status`, `progress` and `modified_on` from the response. Broadcasts were one of several things pointed at it; the flow start read page still uses it, so neither the component nor its tests are touched.
- **`flows.flowstart_status` is unaffected** and still has a live caller in `flowstart_read.html`.
- No permission config changes: broadcast permissions are granted via the `msgs.broadcast.*` wildcard, with no action-specific entry for `status`.
- No migration, and no other view reverses `msgs.broadcast_status`.

## Test plan

- `temba.msgs` (56 tests) and `temba.orgs` (88 tests) pass in the devcontainer
- `code_check.py` passes (migrations check, locale files, ruff format + lint)