### PR TITLE
Suffix-based devcontainer naming for components

### DIFF
--- a/components/.github/devcontainer/devcontainer.json
+++ b/components/.github/devcontainer/devcontainer.json
@@ -10,12 +10,12 @@
   "workspaceFolder": "/workspaces/temba/components",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/temba,type=bind,consistency=cached",
   "runArgs": [
-    // deterministic per-workspace name (DEVCON_WS: the worktree dir name, "main" for
-    // a primary checkout — the fallback also applies in CI), and the label Docker
-    // Desktop groups dev containers on (DEVCON_GROUP lets a launcher choose the
-    // grouping; defaults to one shared "dev" group)
-    "--name", "components-${localEnv:DEVCON_WS:main}",
-    "--label", "com.docker.compose.project=${localEnv:DEVCON_GROUP:dev}",
+    // deterministic per-workspace name — plain "components" by default (also in CI),
+    // with a launcher-supplied suffix (e.g. "-<worktree>") keeping side-by-side
+    // checkouts apart — and the label Docker Desktop groups dev containers on
+    // (default group "dev", suffix letting a launcher split it)
+    "--name", "components${localEnv:DEVCON_NAME_SUFFIX}",
+    "--label", "com.docker.compose.project=dev${localEnv:DEVCON_PROJECT_SUFFIX}",
     // Chromium needs a larger /dev/shm than docker's 64MB default or it crashes
     // rendering big screenshots
     "--shm-size", "1g"

--- a/components/.github/devcontainer/devcontainer.json
+++ b/components/.github/devcontainer/devcontainer.json
@@ -10,10 +10,11 @@
   "workspaceFolder": "/workspaces/temba/components",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/temba,type=bind,consistency=cached",
   "runArgs": [
-    // deterministic per-workspace name, and the label Docker Desktop groups dev
-    // containers on (DEVCON_GROUP lets a launcher choose the grouping; defaults
-    // to one shared "dev" group)
-    "--name", "components-${localWorkspaceFolderBasename}",
+    // deterministic per-workspace name (DEVCON_WS: the worktree dir name, "main" for
+    // a primary checkout — the fallback also applies in CI), and the label Docker
+    // Desktop groups dev containers on (DEVCON_GROUP lets a launcher choose the
+    // grouping; defaults to one shared "dev" group)
+    "--name", "components-${localEnv:DEVCON_WS:main}",
     "--label", "com.docker.compose.project=${localEnv:DEVCON_GROUP:dev}",
     // Chromium needs a larger /dev/shm than docker's 64MB default or it crashes
     // rendering big screenshots

--- a/components/.github/devcontainer/devcontainer.json
+++ b/components/.github/devcontainer/devcontainer.json
@@ -10,10 +10,8 @@
   "workspaceFolder": "/workspaces/temba/components",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/temba,type=bind,consistency=cached",
   "runArgs": [
-    // deterministic per-workspace name — plain "components" by default (also in CI),
-    // with a launcher-supplied suffix (e.g. "-<worktree>") keeping side-by-side
-    // checkouts apart — and the label Docker Desktop groups dev containers on
-    // (default group "dev", suffix letting a launcher split it)
+    // name + grouping label; a launcher may append suffixes to keep side-by-side
+    // checkouts apart
     "--name", "components${localEnv:DEVCON_NAME_SUFFIX}",
     "--label", "com.docker.compose.project=dev${localEnv:DEVCON_PROJECT_SUFFIX}",
     // Chromium needs a larger /dev/shm than docker's 64MB default or it crashes


### PR DESCRIPTION
The container name is now `components${localEnv:DEVCON_NAME_SUFFIX}` and the grouping label `dev${localEnv:DEVCON_PROJECT_SUFFIX}` — both suffixes default empty, so plain use (including CI via devcontainers/ci) yields a container simply named `components` in the `dev` group, while a launcher can append e.g. `-<worktree>` to keep side-by-side checkouts apart. Behavior in CI is otherwise unchanged.