### PR TITLE
Allow servicing staff to resolve asset names in the flow editor

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -758,6 +758,20 @@ class EndpointsTest(APITestMixin, TembaTest):
             self.assertEqual(200, response.status_code)
             self.assertEqual(expected, response.json()["results"])
 
+        # staff servicing the org can also resolve names - this endpoint's POSTs are reads, so the
+        # GET-only rule for servicing staff doesn't apply
+        self.login(self.customer_support, choose_org=self.org)
+        with self.mockReadOnly(assert_models={Flow}):
+            response = self.client.post(
+                endpoint_url,
+                {"flow": [str(flow.uuid)]},
+                content_type="application/json",
+                HTTP_X_FORWARDED_HTTPS="https",
+            )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual([{"type": "flow", "uuid": str(flow.uuid), "name": "Welcome"}], response.json()["results"])
+        self.client.logout()
+
         # a payload of a single type only queries for that type, and duplicate references are only resolved once
         with self.mockReadOnly(assert_models={Flow}):
             response = self._postJSON(endpoint_url, self.editor, {"flow": [str(flow.uuid), str(flow.uuid)]})

--- a/temba/api/internal/views.py
+++ b/temba/api/internal/views.py
@@ -182,6 +182,10 @@ class AssetsEndpoint(BaseEndpoint):
 
     permission = "flows.flow_editor"
 
+    # this endpoint uses POST purely to carry its payload - it doesn't write anything, so
+    # servicing staff viewing a flow can still resolve names
+    readonly_servicing = False
+
     # the supported asset types, in the order in which they're resolved and returned
     ASSET_TYPES = {
         "channel": _asset_by_field(Channel, "uuid"),

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -86,9 +86,10 @@ class APIPermission(BasePermission):
         if not has_perm:
             return False
 
-        # servicing staff can only ever GET from the API
+        # servicing staff can only ever read from the API - which for most endpoints means GET
+        # only, but endpoints whose POSTs don't write can declare that
         if request.user.is_staff and not role:
-            return request.method == "GET"
+            return request.method == "GET" or not getattr(view, "readonly_servicing", True)
 
         return True
 

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -30,6 +30,10 @@ class BaseAPIView(NonAtomicMixin, generics.GenericAPIView):
     model_manager = "objects"
     lookup_params = {"uuid": "uuid"}
 
+    # whether servicing staff are limited to GET requests - endpoints whose POSTs are actually
+    # reads (e.g. resolving references) can set this to False
+    readonly_servicing = True
+
     def derive_queryset(self):
         return getattr(self.model, self.model_manager).filter(org=self.request.org)
 


### PR DESCRIPTION
## Summary

The flow editor resolves dependency references to their current names via `POST /api/internal/assets`, but the API permission rule that limits servicing staff to GET requests blocked that call. The failure is silent on the client, so for staff servicing a workspace the editor rendered the names embedded in the flow definition — a renamed dependency (e.g. a subflow) showed its stale name after a page refresh, even though live rename events over the websocket still updated it in realtime. Regular workspace members were unaffected.

## Changes

* `APIPermission` now allows servicing staff to use non-GET methods on endpoints that declare `readonly_servicing = False` — mirroring the existing convention on the CRUDL views, where the same flag lets servicing staff use views whose POSTs are safe.
* `BaseAPIView` carries the default (`readonly_servicing = True`), so every endpoint keeps the GET-only restriction unless it opts out.
* The internal assets endpoint opts out, since it only uses POST to carry its lookup payload and doesn't write anything.

## Test plan

* New assertion in `test_assets` that a servicing staff user gets a 200 with resolved names from the endpoint.
* Existing coverage in `temba.api.v2.tests.test_base` still verifies that servicing staff POSTs to regular endpoints are rejected.
* Verified manually that a staff user servicing a workspace now sees a renamed dependency's current name after refreshing the flow editor.