### PR TITLE
Seed a separate staff user in dev_db instead of making org admins staff

### DIFF
--- a/temba/utils/management/commands/dev_db.py
+++ b/temba/utils/management/commands/dev_db.py
@@ -14,6 +14,9 @@ from temba.users.models import User
 # by default every user (including the admins) gets this password
 USER_PASSWORD = "Qwerty123"
 
+# the staff user, who belongs to no org and services them all
+STAFF_EMAIL = "support@temba.io"
+
 # contact fields created for each org, as (key, label, value_type)
 FIELDS = (
     ("age", "Age", ContactField.TYPE_NUMBER),
@@ -27,7 +30,8 @@ NAMES = ("Ann", "Bob", "Cat", "Dan", "Eve", "Fay", "Gil", "Hal", "Ivy", "Jay")
 class Command(BaseCommand):
     help = (
         "Creates a simple database for local development: N orgs each with an admin, a couple of fields, a group, "
-        "and a share of M contacts spread across them. Requires an empty database (run migrate first)."
+        "and a share of M contacts spread across them, plus a staff user. Requires an empty database (run migrate "
+        "first)."
     )
 
     def add_arguments(self, parser):
@@ -46,15 +50,18 @@ class Command(BaseCommand):
 
         orgs = [self.create_org(i, password) for i in range(num_orgs)]
         self.create_contacts(orgs, num_contacts)
+        self.create_staff(password)
 
         admin = orgs[0].get_admins().first()
-        self._log("\n" + self.style.SUCCESS("Done!") + f" Log in as {admin.email} / {password}\n")
+        self._log(
+            "\n" + self.style.SUCCESS("Done!") + f" Log in as {admin.email} / {password} (or {STAFF_EMAIL} for staff)\n"
+        )
 
     def create_org(self, index, password):
         name = f"Org {index + 1}"
         self._log(f"Creating {name}... ")
 
-        admin = User.objects.create_user(f"admin{index + 1}@temba.io", password, is_staff=True, first_name="Admin")
+        admin = User.objects.create_user(f"admin{index + 1}@temba.io", password, first_name="Admin")
 
         # Org.create adds the admin, sets up system groups/fields, and imports the sample flows
         org = Org.create(admin, name, ZoneInfo("America/Los_Angeles"))
@@ -68,6 +75,14 @@ class Command(BaseCommand):
 
         self._ok()
         return org
+
+    def create_staff(self, password):
+        self._log("Creating staff user... ")
+
+        # staff belong to no org: they get the /staff/ area and read-only servicing access to every workspace
+        User.objects.create_user(STAFF_EMAIL, password, is_staff=True, first_name="Support")
+
+        self._ok()
 
     def create_contacts(self, orgs, num_contacts):
         self._log(f"Creating {num_contacts} contacts... ")


### PR DESCRIPTION
## Summary

`dev_db` created each org's admin with `is_staff=True`, so the only login a local database offered was both an org administrator and a staff user servicing every workspace at once. Those two roles behave differently — staff who aren't members of an org are treated as *servicing* and restricted to GET unless they're superusers ([`orgs/views/mixins.py`](https://github.com/nyaruka/rapidpro/blob/main/temba/orgs/views/mixins.py#L60)) — and conflating them means neither gets exercised as itself.

Create the org admins as ordinary members, and seed one staff user alongside them.

## Changes

- `create_org` no longer passes `is_staff=True` — `admin{N}@temba.io` are now plain org administrators.
- New `create_staff()` step creating `support@temba.io` (first name "Support", `is_staff=True`), belonging to no org — the membership-less part is what makes it a servicing user rather than just a Django-admin login.
- `STAFF_EMAIL` constant next to `USER_PASSWORD`; the staff user takes the same password, including a `--password` override.
- The closing line reports both logins, and the command help mentions the staff user.

## Behavior

```
Creating Org 1... OK
Creating Org 2... OK
Creating 200 contacts... OK
Creating staff user... OK

Done! Log in as admin1@temba.io / Qwerty123 (or support@temba.io for staff)
```

Resulting users (`--orgs 2`):

| email | staff | org role |
|---|---|---|
| `admin1@temba.io` | no | Org 1 — Administrator |
| `admin2@temba.io` | no | Org 2 — Administrator |
| `support@temba.io` | yes | none — services every workspace |

## Test plan

Ran the command against an empty local database and checked the resulting rows: `is_staff` false for both admins, true for `support@temba.io`, and `orgs_orgmembership` unchanged (one administrator per org, the staff user in none). `ruff format` and `ruff check` pass.

Nothing else in the repo references `dev_db`, and it has no test coverage of its own.

## Note for reviewers

Anyone using a seeded database to reach `/staff/` or the Django admin needs to switch to `support@temba.io` — the admin logins no longer get there, which is the point of the split.