### PR TITLE
Enforce channel type availability when claiming a channel

### DIFF
--- a/temba/channels/tests/test_channelcrudl.py
+++ b/temba/channels/tests/test_channelcrudl.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -5,6 +7,7 @@ from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
 from temba.utils.views.mixins import TEMBA_MENU_SELECTION
 
 from ..models import Channel, ChannelLog
+from ..types.external.type import ExternalType
 
 
 class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
@@ -87,6 +90,25 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][2].code, "IG")
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][-2].code, "WAC")
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][-1].code, "ZVW")
+
+    def test_claim_view_availability(self):
+        claim_url = reverse("channels.types.external.claim")
+
+        self.login(self.admin)
+
+        # a type which isn't available to the org at all can't be claimed
+        with patch.object(ExternalType, "is_available_to", lambda self, org, user: (False, False)):
+            self.assertEqual(404, self.client.get(claim_url).status_code)
+            self.assertEqual(404, self.client.post(claim_url, {}).status_code)
+
+        # but a type which is only unavailable because of the org's region is still claimable, because the claim all
+        # page lists those
+        with patch.object(ExternalType, "is_available_to", lambda self, org, user: (False, True)):
+            self.assertEqual(200, self.client.get(claim_url).status_code)
+
+        # e.g. SMSCentral is only available to orgs in Nepal but this org is in Rwanda
+        self.assertEqual("Africa/Kigali", str(self.org.timezone))
+        self.assertEqual(200, self.client.get(reverse("channels.types.smscentral.claim")).status_code)
 
     def test_configuration(self):
         config_url = reverse("channels.channel_configuration", args=[self.ex_channel.uuid])

--- a/temba/channels/tests/test_channelcrudl.py
+++ b/temba/channels/tests/test_channelcrudl.py
@@ -96,10 +96,14 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.admin)
 
+        num_channels = self.org.channels.count()
+
         # a type which isn't available to the org at all can't be claimed
         with patch.object(ExternalType, "is_available_to", lambda self, org, user: (False, False)):
             self.assertEqual(404, self.client.get(claim_url).status_code)
             self.assertEqual(404, self.client.post(claim_url, {}).status_code)
+
+        self.assertEqual(num_channels, self.org.channels.count())
 
         # but a type which is only unavailable because of the org's region is still claimable, because the claim all
         # page lists those

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -15,7 +15,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template import Context, Engine, TemplateDoesNotExist
 from django.urls import reverse
@@ -85,8 +85,16 @@ class ClaimViewMixin(ChannelTypeMixin, OrgPermsMixin, ComponentFormMixin):
             return super().clean()
 
     def pre_process(self, request, *args, **kwargs):
-        if request.org and Channel.is_limit_reached(request.org):
-            return HttpResponseRedirect(reverse("orgs.org_workspace"))
+        if request.org:
+            # only the region ignoring flag is a real gate - the region aware one just decides whether the type is
+            # listed on the default claim page, and the claim all page deliberately lists types which fail it
+            # note that staff aren't exempt - types which want to allow servicing staff do so in is_available_to
+            available = self.channel_type.is_available_to(request.org, request.user)[1]
+            if not available:
+                raise Http404()
+
+            if Channel.is_limit_reached(request.org):
+                return HttpResponseRedirect(reverse("orgs.org_workspace"))
 
         return super().pre_process(request, *args, **kwargs)
 


### PR DESCRIPTION
## Summary

`ChannelType.is_available_to()` was only consulted when building the list of claimable types on the claim pages, so any user with the `channels.channel_claim` permission could still create a channel of a type not available to their workspace by going directly to that type's claim URL. This makes availability a real gate rather than just a listing hint.

## Changes

**`temba/channels/views.py`** — `ClaimViewMixin.pre_process` now checks `is_available_to()` for the view's channel type and raises `Http404` when the type isn't available to the requesting org and user. The check runs ahead of the existing channel-limit check, and is skipped when there's no org on the request, matching how that check is already guarded.

The check reads the **second** element of the `is_available_to()` tuple (the region-ignoring flag), not the first. The first is region/timezone filtering that only decides whether a type appears on the default claim page; the claim-all page deliberately lists types that fail it. Enforcing the region-aware flag would make every `available_timezones`-restricted type (mtarget, hormuud, signalwire, clicksend, messagebird, telesom, globe, africastalking, and others) unclaimable from the show-all page.

Staff are not exempt from the gate. Channel types that want to allow staff already opt in through `is_available_to()`, which receives the user, so a blanket exemption would reopen the hole. This is orthogonal to `readonly_servicing`, which governs whether servicing staff may POST at all.

All six claim views that override `pre_process` (twilio, twilio_whatsapp, twilio_messaging_service, vonage, plivo, whatsapp) call `super()`, so none bypass the check, and `BaseClaimNumberMixin` extends `ClaimViewMixin` so the number-search claim views are covered too. The provider `Connect` views are not claim views — they exchange OAuth credentials and create no channel — and are unchanged; the `ClaimView` each leads to is gated.

**`temba/channels/tests/test_channelcrudl.py`** — adds `test_claim_view_availability`, covering both tuple positions against the same claim URL, plus a real timezone-restricted type as a regression guard.

## Behavior examples

For a user with permission to claim channels, requesting a type's claim URL directly:

| `is_available_to()` returns | Before | After |
|---|---|---|
| `(True, True)` — available | claim form | claim form |
| `(False, True)` — wrong region, listed on claim-all | claim form | claim form |
| `(False, False)` / `(True, False)` — not available | claim form, channel creatable | 404 on GET and POST |

## Test plan

- [x] `temba.channels` suite passes (185 tests)
- [x] Every `available_timezones`-restricted type's existing claim test still passes, confirming the region-aware flag is not the one being enforced
- [x] New test asserts a type returning `(False, False)` 404s on both GET and POST of its claim URL, and that the org's channel count is unchanged across the rejected POST
- [x] New test asserts a type returning `(False, True)` still serves its claim form
- [x] New test asserts SMSCentral (restricted to `Asia/Kathmandu`) is still claimable by an org in `Africa/Kigali`
- [x] `code_check.py` clean; no migrations or locale changes needed

## Review notes

- Review flagged that the test plan claimed a no-channel-created assertion the test didn't actually make. Fixed in 18f72da27 — the test now captures the org's channel count before the rejected POST and asserts it's unchanged.
- Worth knowing for future work: with the chip type removed, no channel type currently returns `False` for the region-ignoring flag, so this gate rejects nothing today. It's enforcement in the mixin so the next type with a real availability condition can't silently re-open the hole.