### PR TITLE
Fix locale check in code_check.py for projects with a nested locale directory

### DIFF
--- a/code_check.py
+++ b/code_check.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 import subprocess
 import tempfile
 import tomllib
@@ -42,7 +43,11 @@ if __name__ == "__main__":
 
     packages = " ".join(config["packages"])
     locale_dir = config["locale"]
-    ignores = " ".join(f"--ignore='{i}'" for i in config.get("ignore", []))
+
+    # makemessages only ever writes to a `locale` directory directly under its working directory, so it has to be
+    # run from the parent of the configured locale directory - with the ignore globs rebased to be relative to it
+    msg_dir = os.path.dirname(locale_dir) or "."
+    ignores = " ".join(f"--ignore='{i.removeprefix(msg_dir + '/')}'" for i in config.get("ignore", []))
 
     if config.get("migrations", False):
         status("Check for missing migrations")
@@ -58,6 +63,7 @@ if __name__ == "__main__":
         # run without django settings so makemessages only sees locale directories under the current directory -
         # with settings configured, LOCALE_PATHS could pull other projects' catalogs into scope
         cmd(
+            f"cd '{msg_dir}' && "
             f"DJANGO_SETTINGS_MODULE= django-admin makemessages -a -e haml,html,txt,py --no-location --no-wrap "
             f"{ignores} 2>&1"
         )


### PR DESCRIPTION
## Summary

The "Check locale files are up to date" step in `code_check.py` silently did nothing for projects that configure a nested locale directory. Django's `makemessages` only ever writes to a `locale` directory directly under its working directory, so when a project's `[tool.code_check]` `locale` setting points somewhere nested (e.g. `<package>/locale`), the command exited 0 without regenerating anything, the diff was always empty, and the check always passed — even when translatable strings had changed.

## Changes

- `code_check.py` now derives the parent of the configured locale directory and runs `makemessages` from there, so the regeneration actually targets the configured catalog.
- The configured `--ignore` globs are rebased to be relative to that directory (a leading `<parent>/` prefix is stripped). For projects whose locale directory sits at the repo root (like this one), the parent is `.` and behavior is unchanged.

## Test plan

- ✅ `code_check.py` passes unchanged on this repo (locale at repo root).
- ✅ Adding a temporary translatable string to this repo makes the check fail with the expected PO diff, leaving the regenerated files ready to commit.
- ✅ On a downstream project with a nested locale directory, the check previously passed despite new translatable strings; with this fix it regenerates the nested catalogs, fails on the stale POs, and passes once they're up to date.