### PR TITLE
Fix error listing existing Plivo numbers when a region isn't a known country

### DIFF
--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -50,6 +50,7 @@ class PlivoTypeTest(TembaTest):
                         objects=[
                             dict(number="16062681435", region="California, UNITED STATES"),
                             dict(number="8080", region="GUADALAJARA, MEXICO"),
+                            dict(number="420601123456", region="PRAGUE, CZECH REPUBLIC"),
                             dict(number="88160000000", region="XANADU"),  # not a real country
                         ]
                     ),
@@ -62,6 +63,10 @@ class PlivoTypeTest(TembaTest):
                 self.assertContains(response, "8080")
                 self.assertContains(response, "US")
                 self.assertContains(response, "MX")
+
+                # region names which aren't the ISO name for the country still match
+                self.assertContains(response, "+420 601 123 456")
+                self.assertContains(response, "CZ")
 
                 # the number whose region doesn't match a country is ignored rather than erroring
                 self.assertNotContains(response, "88160000000")

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -50,6 +50,7 @@ class PlivoTypeTest(TembaTest):
                         objects=[
                             dict(number="16062681435", region="California, UNITED STATES"),
                             dict(number="8080", region="GUADALAJARA, MEXICO"),
+                            dict(number="88160000000", region="XANADU"),  # not a real country
                         ]
                     ),
                 )
@@ -61,6 +62,10 @@ class PlivoTypeTest(TembaTest):
                 self.assertContains(response, "8080")
                 self.assertContains(response, "US")
                 self.assertContains(response, "MX")
+
+                # the number whose region doesn't match a country is ignored rather than erroring
+                self.assertNotContains(response, "88160000000")
+                self.assertNotIn("error", response.context)
 
                 # claim it the US number
                 session = self.client.session

--- a/temba/channels/types/plivo/views.py
+++ b/temba/channels/types/plivo/views.py
@@ -111,9 +111,11 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             data = response.json()
             for number_dict in data["objects"]:
                 region = number_dict["region"]
-                country_name = region.split(",")[-1].strip().title()
-                country = pycountry.countries.get(name=country_name)
-                if not country:  # ignore numbers in regions we can't match to a country
+                country_name = region.split(",")[-1].strip()
+                try:
+                    # matches case-insensitively on name, official name or code
+                    country = pycountry.countries.lookup(country_name)
+                except LookupError:  # ignore numbers in regions we can't match to a country
                     continue
 
                 if len(number_dict["number"]) <= 6:

--- a/temba/channels/types/plivo/views.py
+++ b/temba/channels/types/plivo/views.py
@@ -112,13 +112,16 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             for number_dict in data["objects"]:
                 region = number_dict["region"]
                 country_name = region.split(",")[-1].strip().title()
-                country = pycountry.countries.get(name=country_name).alpha_2
+                country = pycountry.countries.get(name=country_name)
+                if not country:  # ignore numbers in regions we can't match to a country
+                    continue
+
                 if len(number_dict["number"]) <= 6:
                     phone_number = number_dict["number"]
                 else:
                     parsed = phonenumbers.parse("+" + number_dict["number"], None)
                     phone_number = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
-                account_numbers.append(dict(number=phone_number, country=country))
+                account_numbers.append(dict(number=phone_number, country=country.alpha_2))
 
         return account_numbers
 


### PR DESCRIPTION
## Summary

The Plivo claim view derives each existing number's country by matching the region name from the Plivo API against ISO country names. That lookup returns `None` for anything that isn't an exact match, and the result was dereferenced unguarded, so a single unrecognized region raised an `AttributeError`.

Because `BaseClaimNumberMixin.get_context_data` catches exceptions from `get_existing_numbers` and replaces the whole list with an error, one bad entry hid *every* number on the account, not just its own.

## Changes

**`temba/channels/types/plivo/views.py`** — replace the unguarded `pycountry.countries.get(name=...)` in `get_existing_numbers` with `pycountry.countries.lookup()`, skipping numbers whose region raises `LookupError`.

Two things fall out of that:

- **No more crash.** A region that matches no country now drops that one number instead of taking the whole listing down with it. Skipping is the right fallback rather than listing the number with an empty country: the claim form's `country` field is a `ChoiceField` restricted to the supported countries, so a number whose region doesn't resolve can't be claimed through this view either way.
- **Fewer regions fail to match at all.** `lookup()` matches case-insensitively across a country's name, official name and codes, where `get(name=...)` only matched the ISO short name exactly. Czechia is the case in point — its ISO name is `Czechia` and `Czech Republic` is only its official name, so a `"PRAGUE, CZECH REPUBLIC"` region previously matched nothing even though `CZ` is a supported country. Case-insensitivity also makes the previous `.title()` normalization of the region redundant, so it's gone.

`lookup()` rather than `search_fuzzy()` is deliberate: fuzzy matching would map an unrecognized region onto *some* country instead of skipping it, which is a worse failure than omitting the number.

**`temba/channels/types/plivo/tests.py`** — extend the mocked account listing with a `"PRAGUE, CZECH REPUBLIC"` region (now resolves to `CZ`) and an unmatchable `"XANADU"` region (dropped), and assert the rest of the list still renders with no error in the context.

## Behavior examples

Given an account listing with these regions:

| Region from Plivo | Before | After |
|---|---|---|
| `California, UNITED STATES` | listing crashed | `US` |
| `GUADALAJARA, MEXICO` | listing crashed | `MX` |
| `PRAGUE, CZECH REPUBLIC` | listing crashed | `CZ` |
| `XANADU` | listing crashed | omitted |

Before, any one unmatched region left the claim page with no numbers at all and an `'NoneType' object has no attribute 'alpha_2'` error banner. After, every resolvable number is listed and only the unresolvable one is omitted.

## Test plan

- [x] `temba.channels.types.plivo` passes (3 tests)
- [x] `temba.channels` passes (184 tests)
- [x] Reverting only the view change makes the new assertions in `test_claim` fail, confirming the test covers the bug
- [x] Checked `lookup()` against the pinned pycountry: `"CZECH REPUBLIC"` → `CZ`, `"UNITED STATES"` → `US`, `"MEXICO"` → `MX`; `"XANADU"` and `"GUADALAJARA"` raise `LookupError`
- [x] `code_check.py` clean (no migrations, locale or lint changes needed)