### PR TITLE
Use shared pagination and search length mixin for the campaigns list endpoint

### DIFF
--- a/temba/campaigns/api.py
+++ b/temba/campaigns/api.py
@@ -1,23 +1,15 @@
-from rest_framework.pagination import PageNumberPagination
-
 from django.db.models import Count, Q, Sum, Value
 from django.db.models.functions import Coalesce, Lower
-from django.http import HttpResponse
 
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
+from temba.api.support import ListPagination, SearchLengthMixin
 from temba.api.views import ListAPIMixin
 
 from .models import Campaign
 
-# Match BaseListView: 50 rows per page with a cap that keeps an oversized client request from pulling 50k rows, and
-# the same 1000 char search cap (rejected with 413).
-DEFAULT_PAGE_SIZE = 50
-MAX_PAGE_SIZE = 500
-SEARCH_MAX_LENGTH = 1_000
 
-
-class CampaignsEndpoint(ListAPIMixin, BaseEndpoint):
+class CampaignsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     """
     Campaigns for the current org, used by the campaign list component. A folder is selected with the `folder` query
     param (`active` (default) or `archived`). An optional `search` param filters by campaign or group name, and
@@ -25,20 +17,9 @@ class CampaignsEndpoint(ListAPIMixin, BaseEndpoint):
     serialized via Campaign.as_json() (name, group, event / group-member counts).
     """
 
-    class Pagination(PageNumberPagination):
-        page_size = DEFAULT_PAGE_SIZE
-        page_size_query_param = "page_size"
-        max_page_size = MAX_PAGE_SIZE
-
     model = Campaign
     serializer_class = ModelAsJsonSerializer
-    pagination_class = Pagination
-
-    def get(self, request, *args, **kwargs):
-        search = request.query_params.get("search") or ""
-        if len(search) > SEARCH_MAX_LENGTH:
-            return HttpResponse("Search query too long", status=413)
-        return super().get(request, *args, **kwargs)
+    pagination_class = ListPagination
 
     def derive_queryset(self):
         # Build from Campaign.objects rather than the org.campaigns related manager — a related manager would seed


### PR DESCRIPTION
## Summary

The campaigns internal API endpoint had its own copy of the pagination config and search-length guard that the other list component endpoints already get from shared helpers in `temba.api.support`. This swaps the duplicates for the shared versions — no behaviour change, just less to keep in sync.

## Changes

`temba/campaigns/api.py`:

- Dropped the endpoint's nested `Pagination(PageNumberPagination)` class in favour of the shared `ListPagination`, which carries the same 50-row default and 500-row cap.
- Dropped the module-level `DEFAULT_PAGE_SIZE` / `MAX_PAGE_SIZE` / `SEARCH_MAX_LENGTH` constants that only existed to feed it.
- Replaced the hand-rolled `get()` override that rejected an over-long `search=` with a 413 with the shared `SearchLengthMixin`, which applies the same 1000-character cap and returns the same response.
- Removed the now-unused `PageNumberPagination` and `HttpResponse` imports.

`CampaignsEndpoint` is now declared the same way as the triggers, contacts, broadcasts and flows list endpoints.

## Test plan

- [x] `temba.campaigns` and `temba.api.internal` — 53 tests, passing
- [x] `temba.api` — 77 tests, passing
- [x] `code_check.py` clean (migrations, locale files, ruff format, ruff)
- [x] Existing coverage for the campaigns endpoint's paging, sorting, folder filtering and 413-on-long-search is unchanged and still passes, so the shared helpers are verified to behave identically