### PR TITLE
Route custom API prefetch querysets to the same database as the parent queryset

### DIFF
--- a/temba/api/v2/tests/test_runs.py
+++ b/temba/api/v2/tests/test_runs.py
@@ -1,14 +1,40 @@
 import iso8601
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
+from django.db.models import Prefetch
 from django.urls import reverse
 
 from temba.api.v2.serializers import format_datetime
+from temba.api.v2.views import RunsEndpoint
 from temba.tests.engine import MockSessionWriter
 
 from . import APITest
 
 
 class RunsEndpointTest(APITest):
+    def test_readonly_routing(self):
+        # GET requests should route both the main queryset and any custom Prefetch querysets to the readonly
+        # database - Django 6.1 stopped routing custom prefetches by the parent queryset's database, which broke
+        # bulk_urn_cache_initialize by mixing contacts from default with URNs from readonly
+        request = Request(APIRequestFactory().get("/api/v2/runs.json"))
+        request._request.org = self.org
+
+        view = RunsEndpoint()
+        view.request = request
+        view.kwargs = {}
+
+        queryset = view.filter_queryset(view.get_queryset())
+        view.paginate_queryset(queryset)
+
+        self.assertEqual("readonly", queryset.db)
+
+        prefetches = {p.prefetch_through: p for p in queryset._prefetch_related_lookups if isinstance(p, Prefetch)}
+        self.assertEqual({"flow", "contact", "contact__org", "start"}, set(prefetches))
+        for lookup, prefetch in prefetches.items():
+            if prefetch.queryset is not None:
+                self.assertEqual("readonly", prefetch.queryset.db, f"prefetch of {lookup} not routed to readonly")
+
     def test_endpoint(self):
         endpoint_url = reverse("api.v2.runs") + ".json"
 

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from smartmin.views import SmartCRUDL
 
 from django.db import transaction
+from django.db.models import Prefetch
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -168,6 +169,15 @@ class ListAPIMixin(mixins.ListModelMixin):
         return queryset
 
     def paginate_queryset(self, queryset):
+        # Django 6.1 no longer routes custom Prefetch querysets on forward FK/O2O fields to the same database as
+        # the parent queryset (regression from django/django@821619aa87) so route them explicitly
+        queryset._prefetch_related_lookups = tuple(
+            Prefetch(lookup.prefetch_through, queryset=lookup.queryset.using(queryset.db), to_attr=lookup.to_attr)
+            if isinstance(lookup, Prefetch) and lookup.queryset is not None and lookup.queryset._db is None
+            else lookup
+            for lookup in queryset._prefetch_related_lookups
+        )
+
         page = super().paginate_queryset(queryset)
 
         # give views a chance to prepare objects for serialization

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1558,12 +1558,14 @@ class ResultsExport(ExportType):
         )
 
         for id_batch in itertools.batched(run_ids, 1000):
+            # Django 6.1 no longer routes custom Prefetch querysets by the parent queryset's database so the
+            # prefetches need their own explicit .using(..)
             run_batch = (
                 FlowRun.objects.filter(id__in=id_batch)
                 .order_by("modified_on", "id")
                 .prefetch_related(
-                    Prefetch("contact", Contact.objects.only("uuid", "name")),
-                    Prefetch("flow", Flow.objects.only("uuid", "name")),
+                    Prefetch("contact", Contact.objects.only("uuid", "name").using("readonly")),
+                    Prefetch("flow", Flow.objects.only("uuid", "name").using("readonly")),
                 )
                 .using("readonly")
             )

--- a/temba/flows/tests/test_export.py
+++ b/temba/flows/tests/test_export.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from temba.archives.models import Archive
 from temba.contacts.models import Contact, ContactURN
-from temba.flows.models import FlowRun, ResultsExport
+from temba.flows.models import Flow, FlowRun, ResultsExport
 from temba.orgs.models import Export
 from temba.tests import TembaTest, mock_mailroom
 from temba.tests.engine import MockSessionWriter
@@ -42,6 +42,7 @@ class ResultsExportTest(TembaTest):
 
         readonly_models = {FlowRun}
         if has_results:
+            readonly_models.add(Flow)
             readonly_models.add(Contact)
             readonly_models.add(ContactURN)
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1107,17 +1107,20 @@ class MsgIterator:
     Queryset wrapper to chunk queries and reduce in-memory footprint
     """
 
-    def __init__(self, ids, order_by=None, select_related=None, prefetch_related=None, max_obj_num=1000):
+    def __init__(
+        self, ids, order_by=None, select_related=None, prefetch_related=None, using="default", max_obj_num=1000
+    ):
         self._ids = ids
         self._order_by = order_by
         self._select_related = select_related
         self._prefetch_related = prefetch_related
+        self._using = using
         self._generator = self._setup()
         self.max_obj_num = max_obj_num
 
     def _setup(self):
         for i in range(0, len(self._ids), self.max_obj_num):
-            chunk_queryset = Msg.objects.filter(id__in=self._ids[i : i + self.max_obj_num])
+            chunk_queryset = Msg.objects.using(self._using).filter(id__in=self._ids[i : i + self.max_obj_num])
 
             if self._order_by:
                 chunk_queryset = chunk_queryset.order_by(*self._order_by)
@@ -1240,15 +1243,18 @@ class MessageExport(ExportType):
 
         all_message_ids = array(str("l"), messages.values_list("id", flat=True))
 
+        # Django 6.1 no longer routes custom Prefetch querysets by the parent queryset's database so the
+        # prefetches need their own explicit .using(..)
         for msg_batch in MsgIterator(
             all_message_ids,
             order_by=("created_on",),
             select_related=("channel", "contact_urn"),
             prefetch_related=(
-                Prefetch("contact", queryset=Contact.objects.only("uuid", "name")),
-                Prefetch("flow", queryset=Flow.objects.only("uuid", "name")),
-                Prefetch("labels", queryset=Label.objects.only("uuid", "name").order_by("name")),
+                Prefetch("contact", queryset=Contact.objects.only("uuid", "name").using("readonly")),
+                Prefetch("flow", queryset=Flow.objects.only("uuid", "name").using("readonly")),
+                Prefetch("labels", queryset=Label.objects.only("uuid", "name").order_by("name").using("readonly")),
             ),
+            using="readonly",
         ):
             # convert this batch of msgs to same format as records in our archives
             yield [msg.as_archive_json() for msg in msg_batch]


### PR DESCRIPTION
## Summary

Django 6.1 no longer routes custom `Prefetch` querysets on forward FK/O2O fields to the same database as the parent queryset (regression from django/django@821619aa87 — the custom-queryset path in `get_prefetch_querysets()` lost its `_add_hints()` call). For installs with a separate `readonly` connection, API GET endpoints that use `Prefetch(queryset=...)` were silently running those prefetch queries against the default connection, and the runs endpoint crashed: `bulk_urn_cache_initialize` assigns `urn.org = contact.org` with the URN loaded from `readonly` and the org from `default`, tripping Django's cross-database relation guard with `ValueError: Cannot assign ...: the current database router prevents this relation.`

## Changes

- **`temba/api/views.py`** — `ListAPIMixin.paginate_queryset` now re-routes any custom `Prefetch` queryset without an explicit db to the parent queryset's database before the page query runs. This is the one choke point that sees the fully-assembled queryset, since endpoints add prefetches in both `derive_queryset` and `filter_queryset`. Prefetches that already specify a db are left untouched, and this can be dropped once the upstream regression is fixed.
- **`temba/flows/models.py`** — flow results exports fetch run batches from `readonly` with custom contact/flow prefetches, which the same regression silently moved to the default connection; those prefetch querysets now specify `.using("readonly")` explicitly.
- **`temba/msgs/models.py`** — message export batches (`MsgIterator`) were never routed to `readonly` at all — only the initial id-listing query was. `MsgIterator` now takes a `using` argument, and the export passes `readonly` for the batches and their prefetches.
- **`temba/api/v2/tests/test_runs.py`** — regression test that drives the runs endpoint's real queryset/pagination path and asserts the main queryset and every custom prefetch are routed to `readonly`. Existing API tests couldn't catch this because `mockReadOnly()` patches `.using("readonly")` into a no-op.

## Behavior examples

With `GET /api/v2/runs.json` on an install with a `readonly` connection:

|  | Before | After |
|---|---|---|
| Runs / URNs queries | `readonly` | `readonly` |
| Contact/flow/start prefetch queries | `default` (silent) | `readonly` |
| Response | 500 (`ValueError` in `bulk_urn_cache_initialize`) | 200 |

Results/message exports similarly go back to (or start) running their batch and prefetch queries against `readonly`.

## Test plan

- [x] New `test_readonly_routing` fails without the fix, passes with it
- [x] `temba.api`, `temba.contacts`, `temba.msgs` and `temba.flows` suites pass
- [x] `code_check.py` clean