### PR TITLE
Order message list folders by created_on so pages read straight off the folder indexes

### DIFF
--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -96,10 +96,13 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
 
     class Pagination(SearchCountMixin, CreatedOnCursorPagination):
         """
-        The sent folder is ordered by sent date; all other folders by UUID, which (since msg.uuid is uuid7) is itself
-        time-ordered and already uniquely indexed — so we get the same newest-first semantics as `-created_on, -id`
-        without the composite sort. The response always carries a `count` so the list UI can show "N of Total": a
-        search count via SearchCountMixin, otherwise the folder/label's cheap pre-calculated count (see
+        Folders are ordered by `-created_on, -id`, and the sent folder by `-sent_on, -id`. Those are the orderings
+        the partial folder indexes are built on (`msgs_inbox`, `msgs_flows`, `msgs_archived`,
+        `msgs_outbox_and_failed`, `msgs_sent` — see Msg.Meta.indexes), so a page is an index-ordered read rather
+        than a sort. Ordering by `-uuid` instead would be time-ordered too (msg.uuid is uuid7) but uuid isn't part
+        of any folder index, leaving the database to either sort the whole folder or walk the global uuid index
+        filtering by folder. The response always carries a `count` so the list UI can show "N of Total": a search
+        count via SearchCountMixin, otherwise the folder/label's cheap pre-calculated count (see
         `get_total_count`) — never a COUNT(*) on the messages table.
         """
 
@@ -109,8 +112,6 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         page_size = 50
         page_size_query_param = "page_size"
         max_page_size = 500
-
-        ordering = ("-uuid",)
 
         def get_ordering(self, request, queryset, view=None):
             if request.query_params.get("folder", "").lower() == "sent":


### PR DESCRIPTION
## Summary

The messages list endpoint paginated by `-uuid`, on the reasoning that `msg.uuid` is uuid7 and therefore time-ordered, giving newest-first without a composite sort. But `uuid` isn't part of any of the message folder indexes, so that ordering couldn't be served by them. This restores the `-created_on, -id` ordering those indexes are actually built on.

## Changes

`temba/msgs/api.py` — removed the `ordering = ("-uuid",)` override on `MessagesEndpoint.Pagination`, so it inherits `("-created_on", "-id")` from `CreatedOnCursorPagination`. The `get_ordering` hook is unchanged, so the sent folder still orders by `("-sent_on", "-id")`. The docstring now records why the ordering has to match the indexes.

Every folder index is partial and ordered by creation date (see `Msg.Meta.indexes`):

| index | fields | folders |
|---|---|---|
| `msgs_inbox` | `org, -created_on, -id` | inbox |
| `msgs_flows` | `org, -created_on, -id` | handled |
| `msgs_archived` | `org, -created_on, -id` | archived |
| `msgs_outbox_and_failed` | `org, status, -created_on, -id` | outbox, failed |
| `msgs_sent` | `org, -sent_on, -id` | sent |

`uuid` appears in none of them — it only has its own standalone unique index. Ordering a folder by `-uuid` therefore left the database with two options: read the folder's partial index and sort the whole slice, or walk the global uuid index in reverse applying the folder predicate as a filter. For a workspace holding a small share of the table, the second means walking a large number of unrelated index entries to fill one page.

## Behavior

Result ordering is unchanged — both keys are newest-first. What changes is how a page is produced. Query plans per folder, with sequential scans disabled so the index choice is visible:

| folder | index used | sort node |
|---|---|---|
| inbox | `msgs_inbox` | no |
| handled | `msgs_flows` | no |
| archived | `msgs_archived` | no |
| sent | `msgs_sent` | no |
| failed | `msgs_outbox_and_failed` | no |
| outbox | `msgs_outbox_and_failed` | yes |

Five of the six are now index-ordered reads with no sort.

Outbox still sorts, and that is pre-existing rather than introduced here. `msgs_outbox_and_failed` leads with `status`, and the outbox folder matches three status values, so rows can't be returned in creation order across the three groups. The failed folder matches a single status and so gets a clean index prefix — visible in the index conditions, where failed gets `org_id = ... AND status = 'F'` while outbox gets only `org_id = ...` with the status list demoted to a filter. In practice the outbox stays small, since it drains.

## Test plan

- [x] `temba.msgs` and `temba.api.internal` — 72 tests, passing
- [x] `code_check.py` clean (migrations, locale files, ruff format, ruff)
- [x] Query plan for each of the six folders inspected with `EXPLAIN` against the real schema, confirming the partial folder index is chosen and (outbox aside) no sort node appears
- [x] Existing endpoint tests cover folder listing, label filtering, search and cursor paging, so the unchanged newest-first ordering is verified by them

## Notes

The `label=<uuid>` path is unaffected by this and uses no folder index at all — it scans the message/label join table, looks each message up by primary key, then sorts. No index can serve `created_on` ordering there, since that column isn't on the join table. Worth a separate look.