### PR TITLE
Make form submit button labels translatable

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-24 22:47+0000\n"
+"POT-Creation-Date: 2026-08-25 19:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -1954,6 +1954,9 @@ msgid "The API token for your integration as provided by Zenvia"
 msgstr ""
 
 msgid "Invalid token. Please check your Zenvia account settings."
+msgstr ""
+
+msgid "Submit"
 msgstr ""
 
 msgid "This channel is already connected in this workspace."
@@ -3914,9 +3917,6 @@ msgid "The unique identifier for this object"
 msgstr ""
 
 msgid "and"
-msgstr ""
-
-msgid "Submit"
 msgstr ""
 
 msgid "Confirm Access"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-24 22:47+0000\n"
+"POT-Creation-Date: 2026-08-25 19:35+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1969,6 +1969,9 @@ msgstr "El token de API para su integración proporcionado por Zenvia"
 
 msgid "Invalid token. Please check your Zenvia account settings."
 msgstr "Simbolo no valido. Verifique la configuración de su cuenta de Zenvia."
+
+msgid "Submit"
+msgstr "Enviar"
 
 msgid "This channel is already connected in this workspace."
 msgstr "Este canal ya está conectado en este workspace."
@@ -3941,9 +3944,6 @@ msgstr "El identificador único de este objeto"
 
 msgid "and"
 msgstr "y"
-
-msgid "Submit"
-msgstr "Enviar"
 
 msgid "Confirm Access"
 msgstr "Confirmar acceso"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-24 22:47+0000\n"
+"POT-Creation-Date: 2026-08-25 19:35+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -1969,6 +1969,9 @@ msgstr "Le jeton API pour votre intégration tel que fourni par Zenvia."
 
 msgid "Invalid token. Please check your Zenvia account settings."
 msgstr "Jeton invalide. Veuillez vérifier les paramètres de votre compte Zenvia."
+
+msgid "Submit"
+msgstr "Envoyer"
 
 msgid "This channel is already connected in this workspace."
 msgstr "Ce canal est déjà connecté dans cet espace de travail."
@@ -3941,9 +3944,6 @@ msgstr "L'identifiant unique pour cet objet"
 
 msgid "and"
 msgstr "et"
-
-msgid "Submit"
-msgstr "Envoyer"
 
 msgid "Confirm Access"
 msgstr "Confirmer l'accès"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-24 22:47+0000\n"
+"POT-Creation-Date: 2026-08-25 19:35+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -1973,6 +1973,9 @@ msgstr "O token de API para a sua integração, conforme fornecido pela Zenvia"
 
 msgid "Invalid token. Please check your Zenvia account settings."
 msgstr "Token inválido. Por favor verifique as configurações da sua conta da Zenvia."
+
+msgid "Submit"
+msgstr "Enviar"
 
 msgid "This channel is already connected in this workspace."
 msgstr "Este canal já está conectado nesta área de trabalho."
@@ -3945,9 +3948,6 @@ msgstr "O identificador exclusivo para este objeto"
 
 msgid "and"
 msgstr "e"
-
-msgid "Submit"
-msgstr "Enviar"
 
 msgid "Confirm Access"
 msgstr "Confirmar Acesso"

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -182,6 +182,7 @@ class CampaignCRUDL(SmartCRUDL):
         fields = ("name", "group")
         form_class = CampaignForm
         success_url = "uuid@campaigns.campaign_read"
+        submit_button_name = _("Create")
 
         def pre_save(self, obj):
             obj = super().pre_save(obj)
@@ -766,6 +767,7 @@ class CampaignEventCRUDL(SmartCRUDL):
         )
         form_class = CampaignEventForm
         template_name = "campaigns/campaignevent_update.html"
+        submit_button_name = _("Create")
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -60,6 +60,7 @@ class ChannelTypeMixin(SpaMixin):
 class ClaimViewMixin(ChannelTypeMixin, OrgPermsMixin, ComponentFormMixin):
     permission = "channels.channel_claim"
     menu_path = "/settings/channels/new-channel"
+    submit_button_name = _("Submit")
 
     class Form(forms.Form):
         def __init__(self, **kwargs):
@@ -699,6 +700,7 @@ class ChannelCRUDL(SmartCRUDL):
             return response
 
     class Update(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
+        submit_button_name = _("Save")
         field_config = {
             "is_enabled": {
                 "help": _("Makes channel available for sending. Incoming messages will be archived if not enabled.")

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -363,6 +363,7 @@ class FlowCRUDL(SmartCRUDL):
 
         form_class = Form
         success_url = "uuid@flows.flow_editor"
+        submit_button_name = _("Create")
         field_config = {"name": {"help": _("Choose a unique name to describe this flow, e.g. Registration")}}
 
         def derive_exclude(self):
@@ -1559,6 +1560,7 @@ class FlowLabelCRUDL(SmartCRUDL):
     class Update(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = FlowLabelForm
         success_url = "uuid@flows.flow_filter"
+        submit_button_name = _("Save")
 
         def get_form_kwargs(self):
             kwargs = super().get_form_kwargs()

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -842,6 +842,7 @@ class LabelCRUDL(SmartCRUDL):
         form_class = LabelForm
         success_url = "uuid@msgs.msg_filter"
         title = _("Update Label")
+        submit_button_name = _("Save")
 
         def get_form_kwargs(self):
             kwargs = super().get_form_kwargs()

--- a/temba/orgs/views/base.py
+++ b/temba/orgs/views/base.py
@@ -67,6 +67,8 @@ class BaseCreateModal(ComponentFormMixin, ModalFormMixin, LimitAwareMixin, OrgPe
     Base create modal view
     """
 
+    submit_button_name = _("Create")
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["org"] = self.request.org
@@ -85,6 +87,7 @@ class BaseUpdateView(OrgObjPermsMixin, SmartUpdateView):
 
     slug_url_kwarg = "uuid"
     model_org_lookup = "org"
+    submit_button_name = _("Save")
 
     def derive_queryset(self, **kwargs):
         qs = super().derive_queryset(**kwargs).filter(**{self.model_org_lookup: self.request.org})
@@ -102,6 +105,8 @@ class BaseUpdateModal(ComponentFormMixin, ModalFormMixin, BaseUpdateView):
     """
     Base update modal view
     """
+
+    submit_button_name = _("Save")
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/temba/orgs/views/views.py
+++ b/temba/orgs/views/views.py
@@ -238,6 +238,7 @@ class UserCRUDL(SmartCRUDL):
 
         form_class = Form
         require_feature = Org.FEATURE_USERS
+        submit_button_name = _("Save")
 
         def get_object_org(self):
             return self.request.org
@@ -347,6 +348,7 @@ class UserCRUDL(SmartCRUDL):
         form_class = Form
         success_url = "@orgs.user_edit"
         success_message = _("Your profile has been updated successfully.")
+        submit_button_name = _("Save")
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
@@ -921,6 +923,7 @@ class OrgCRUDL(SmartCRUDL):
 
         form_class = Form
         success_url = "@orgs.org_list"
+        submit_button_name = _("Save")
 
         def get_object_org(self):
             return self.request.org
@@ -997,6 +1000,7 @@ class OrgCRUDL(SmartCRUDL):
 
         form_class = Form
         require_feature = (Org.FEATURE_NEW_ORGS, Org.FEATURE_CHILD_ORGS)
+        submit_button_name = _("Create")
 
         def get_form_kwargs(self):
             kwargs = super().get_form_kwargs()
@@ -1128,6 +1132,7 @@ class OrgCRUDL(SmartCRUDL):
         form_class = Form
         fields = ("organization",)
         title = _("Select your Workspace")
+        submit_button_name = _("Submit")
 
         def pre_process(self, request, *args, **kwargs):
             user = self.request.user
@@ -1503,6 +1508,7 @@ class OrgCRUDL(SmartCRUDL):
 
         success_url = "@orgs.org_languages"
         form_class = LanguageForm
+        submit_button_name = _("Save")
 
         def get_form_kwargs(self):
             kwargs = super().get_form_kwargs()

--- a/temba/public/views.py
+++ b/temba/public/views.py
@@ -53,6 +53,7 @@ class Forgetme(NoNavMixin, ComponentFormMixin, SmartFormView):
             return code
 
     form_class = Form
+    submit_button_name = _("Submit")
 
     template_name = "public/public_forgetme.html"
 

--- a/temba/staff/views.py
+++ b/temba/staff/views.py
@@ -193,6 +193,7 @@ class OrgCRUDL(SmartCRUDL):
 
         form_class = Form
         success_url = "id@staff.org_read"
+        submit_button_name = _("Save")
 
         def derive_title(self):
             return None
@@ -318,6 +319,7 @@ class UserCRUDL(SmartCRUDL):
         form_class = Form
         success_message = _("User updated successfully.")
         title = _("Update User")
+        submit_button_name = _("Save")
 
         def post(self, request, *args, **kwargs):
             obj = self.get_object()

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -690,6 +690,7 @@ class TicketCRUDL(SmartCRUDL):
         fields = ("topic",)
         slug_url_kwarg = "uuid"
         success_url = "hide"
+        submit_button_name = _("Save")
 
     class Note(ModalFormMixin, ComponentFormMixin, OrgObjPermsMixin, SmartUpdateView):
         """
@@ -712,6 +713,7 @@ class TicketCRUDL(SmartCRUDL):
         fields = ("note",)
         success_url = "hide"
         slug_url_kwarg = "uuid"
+        submit_button_name = _("Save")
 
         def form_valid(self, form):
             self.get_object().add_note(self.request.user, note=form.cleaned_data["note"])

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -272,6 +272,7 @@ class TriggerCRUDL(SmartCRUDL):
         trigger_type = None
         permission = "triggers.trigger_create"
         success_url = "@triggers.trigger_list"
+        submit_button_name = _("Create")
 
         @property
         def type(self):
@@ -360,6 +361,7 @@ class TriggerCRUDL(SmartCRUDL):
 
     class Update(ModalFormMixin, ComponentFormMixin, OrgObjPermsMixin, SmartUpdateView):
         slug_url_kwarg = "uuid"
+        submit_button_name = _("Save")
 
         def get_form_class(self):
             return self.object.type.form

--- a/temba/utils/views/mixins.py
+++ b/temba/utils/views/mixins.py
@@ -12,6 +12,7 @@ from django.db import IntegrityError, transaction
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.utils import timezone
 from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
 
 from temba import __version__ as temba_version
 from temba.utils.fields import CheckboxWidget, DateWidget, InputWidget, SelectMultipleWidget, SelectWidget
@@ -224,6 +225,8 @@ class ModalFormMixin(SmartFormView):
     """
     TODO rework this to be an actual mixin
     """
+
+    submit_button_name = _("Submit")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary

Form submit buttons always rendered their label in English, whatever the user's language. The labels come from `submit_button_name` on smartmin's form view classes, and smartmin ships no translation catalogs — so `makemessages` never sees those strings and there is nothing to translate against. This moves the defaults onto our own shared view base classes and mixins, where they get extracted into `locale/*/LC_MESSAGES/django.po` like every other string.

No button changes wording. `Submit`, `Save` and `Create` were already present in the catalogs with es/fr/pt_BR translations, so these buttons start rendering translated immediately with no translator work needed.

## Changes

**Shared bases** — the labels now live where extraction can find them:

- `temba/orgs/views/base.py` — `BaseCreateModal` → `Create`, `BaseUpdateView` and `BaseUpdateModal` → `Save`
- `temba/utils/views/mixins.py` — `ModalFormMixin` → `Submit`, as the generic fallback
- `temba/channels/views.py` — `ClaimViewMixin` → `Submit`, covering every channel type's claim view
- `temba/triggers/views.py` — `TriggerCRUDL.BaseCreate` → `Create`, covering all the per-type create views

**Explicit labels where a mixin would otherwise shadow the base.** `ModalFormMixin` subclasses `SmartFormView`, so in `class Foo(ModalFormMixin, ..., SmartUpdateView)` the MRO puts `ModalFormMixin` ahead of `SmartUpdateView`. That was harmless while `ModalFormMixin` defined no label, but defining one there flattens every such view to `Submit`. Each affected view now states its own label, preserving current wording: `ChannelCRUDL.Update`, `CampaignCRUDL.Create`, `CampaignEventCRUDL.Create`, `FlowCRUDL.Create`, `FlowLabelCRUDL.Update`, `LabelCRUDL.Update`, `TicketCRUDL.Update`/`Note`, `TriggerCRUDL.Update`, `OrgCRUDL.Create`/`Update`, `UserCRUDL.Update`, and both staff `Update` views.

**Individual views** whose templates render `{{ submit_button_name }}` but which sit under no shared base: `OrgCRUDL.Choose`, `OrgCRUDL.Languages`, `UserCRUDL.Edit`, `public.Forgetme`.

Views that never render the label are left alone — JSON and POST-only endpoints, formax sections (which render `section.button`), and templates that hardcode their own `{% trans %}` label.

## Behavior examples

Spanish UI, before and after:

| View | Before | After |
|---|---|---|
| Create contact group | `Create` | `Crear` |
| Update channel | `Save` | `Guardar` |
| Claim a channel | `Submit` | `Enviar` |
| Create trigger | `Create` | `Crear` |

English is unchanged everywhere.

## Test plan

- Resolved `submit_button_name` through the MRO for all 171 `SmartFormMixin` subclasses before and after the change — **zero wording changes**, which is what keeps this safe given the shadowing described above.
- Same sweep confirms the views still resolving to smartmin's untranslated strings are only ones that never render a button.
- Full Django suite passes (1141 tests).
- `code_check.py` clean, including the locale check — the only catalog change is the `Submit` entry moving position, since all three msgids already existed.
