### PR TITLE
Reject import files whose top-level JSON is not an object

### DIFF
--- a/temba/orgs/tests/test_definitionexport.py
+++ b/temba/orgs/tests/test_definitionexport.py
@@ -131,6 +131,11 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         response = self.client.post(create_url, post_data)
         self.assertFormError(response.context["form"], "file", "This file is not a valid flow definition file.")
 
+        # test import using JSON that isn't an object
+        non_dict_data = io.BytesIO(b'[{"version": 7, "action_sets": []}]')
+        response = self.client.post(create_url, {"file": non_dict_data})
+        self.assertFormError(response.context["form"], "file", "This file is not a valid flow definition file.")
+
     def test_import_errors(self):
         self.login(self.admin)
         OrgImport.objects.all().delete()

--- a/temba/orgs/views/views.py
+++ b/temba/orgs/views/views.py
@@ -1689,6 +1689,9 @@ class OrgImportCRUDL(SmartCRUDL):
                 except DjangoUnicodeDecodeError, ValueError:
                     raise ValidationError(_("This file is not a valid flow definition file."))
 
+                if not isinstance(json_data, dict):
+                    raise ValidationError(_("This file is not a valid flow definition file."))
+
                 if Version(str(json_data.get("version", 0))) < Version(Org.EARLIEST_IMPORT_VERSION):
                     raise ValidationError(_("This file is no longer valid. Please export a new version and try again."))
 


### PR DESCRIPTION
## Summary

Uploading a flow definition file whose top-level JSON is a list (e.g. a very old single-flow export) crashed `OrgImportCRUDL.Create` with an unhandled `AttributeError: 'list' object has no attribute 'get'`. The user now sees the standard invalid-file form error instead.

## Changes

- `temba/orgs/views/views.py` — `clean_file` now raises `ValidationError` ("This file is not a valid flow definition file.") when the parsed JSON isn't an object, before any `.get()` access.
- `temba/orgs/tests/test_definitionexport.py` — new test case posting a list-shaped file and asserting the form error.

## Behavior examples

| Upload | Before | After |
|---|---|---|
| `[{"version": 7, "action_sets": []}]` | 500 error | form error: "This file is not a valid flow definition file." |
| `{"version": "2", "flows": []}` | form error (too old) | unchanged |

## Test plan

- [x] `temba.orgs.tests.test_definitionexport` — 18 tests pass, including the new non-object case
- [x] `code_check.py` — no formatting, migration, or locale changes needed (reuses an existing translated string)