### PR TITLE
Track usage of deprecated API features

### DIFF
--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -1,5 +1,6 @@
 import logging
 
+from django_valkey import get_valkey_connection
 from rest_framework import exceptions, status
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication, TokenAuthentication
 from rest_framework.exceptions import APIException
@@ -9,12 +10,37 @@ from rest_framework.throttling import ScopedRateThrottle
 
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseServerError
+from django.utils import timezone
 
 from temba.utils import str_to_bool
 
 from .models import APIToken
 
 logger = logging.getLogger(__name__)
+
+# deprecated feature usage is counted into monthly buckets shared with the other warnings we track against workspaces,
+# keyed as api:deprecated:<org id>/<endpoint>#<feature>
+DEPRECATED_KEY_PREFIX = "warnings"
+DEPRECATED_KEY_EXPIRY = 90 * 24 * 60 * 60
+
+
+def record_deprecated(org, feature: str):
+    """
+    Records that a workspace used a deprecated API feature, so we can see whether anything still depends on it before
+    removing it. Recording is best-effort - a failure here shouldn't fail the request.
+
+    Unlike `via_api` tracking elsewhere, this counts calls made with session auth as well as with a token, because the
+    question being answered is whether *anything* still uses the feature, not who should be credited with the change.
+    """
+
+    key = f"{DEPRECATED_KEY_PREFIX}:{timezone.now():%Y-%m}"
+
+    try:
+        r = get_valkey_connection()
+        r.hincrby(key, f"api:deprecated:{org.id}/{feature}", 1)
+        r.expire(key, DEPRECATED_KEY_EXPIRY)
+    except Exception:
+        logger.exception("error recording use of deprecated API feature")
 
 
 class RequestAttributesMixin:

--- a/temba/api/tests/test_support.py
+++ b/temba/api/tests/test_support.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from django_valkey import get_valkey_connection
+
+from django.utils import timezone
+
+from temba.api.support import record_deprecated
+from temba.tests import TembaTest
+from temba.tests.base import cleanup
+
+
+class RecordDeprecatedTest(TembaTest):
+    @cleanup(valkey=True)
+    def test_record(self):
+        r = get_valkey_connection()
+        key = f"warnings:{timezone.now():%Y-%m}"
+
+        record_deprecated(self.org, "contact_actions#archive_messages")
+        record_deprecated(self.org, "contact_actions#archive_messages")
+        record_deprecated(self.org, "contact_actions#archive")
+        record_deprecated(self.org2, "contact_actions#archive_messages")
+
+        self.assertEqual(
+            {
+                f"api:deprecated:{self.org.id}/contact_actions#archive_messages": b"2",
+                f"api:deprecated:{self.org.id}/contact_actions#archive": b"1",
+                f"api:deprecated:{self.org2.id}/contact_actions#archive_messages": b"1",
+            },
+            {f.decode(): c for f, c in r.hgetall(key).items()},
+        )
+
+        # bucket expires so that we're not accumulating this forever
+        self.assertEqual(90 * 24 * 60 * 60, r.ttl(key))
+
+    def test_record_error_is_not_fatal(self):
+        with patch("temba.api.support.get_valkey_connection") as mock_get_conn:
+            mock_get_conn.side_effect = ValueError("boom")
+
+            record_deprecated(self.org, "contact_actions#archive_messages")  # no exception

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -26,6 +26,7 @@ from temba.utils import json
 from temba.utils.fields import NameValidator
 
 from ..models import BulkActionFailure, Resthook, ResthookSubscriber, WebHookEvent
+from ..support import record_deprecated
 from ..validators import UniqueForOrgValidator
 from . import fields
 
@@ -995,6 +996,9 @@ class ContactBulkActionSerializer(WriteSerializer):
         elif action == self.INTERRUPT:
             Contact.bulk_interrupt(user, contacts)
         elif action == self.ARCHIVE_MESSAGES or action == self.ARCHIVE:
+            # tracked separately for each action name so we can see if the older alias can be dropped on its own
+            record_deprecated(self.context["org"], f"contact_actions#{action}")
+
             Msg.archive_all_for_contacts(contacts)
         elif action == self.BLOCK:
             Contact.bulk_change_status(user, contacts, modifiers.Status.BLOCKED, via_api=True)

--- a/temba/api/v2/tests/test_contact_actions.py
+++ b/temba/api/v2/tests/test_contact_actions.py
@@ -1,16 +1,21 @@
 from unittest.mock import call
 
+from django_valkey import get_valkey_connection
+
 from django.urls import reverse
+from django.utils import timezone
 
 from temba.contacts.models import Contact
 from temba.msgs.models import Msg
 from temba.tests import mock_mailroom
+from temba.tests.base import cleanup
 from temba.tests.engine import MockSessionWriter
 
 from . import APITest
 
 
 class ContactActionsEndpointTest(APITest):
+    @cleanup(valkey=True)
     @mock_mailroom
     def test_endpoint(self, mr_mocks):
         endpoint_url = reverse("api.v2.contact_actions") + ".json"
@@ -193,6 +198,23 @@ class ContactActionsEndpointTest(APITest):
         )
         self.assertFalse(Msg.objects.filter(contact__in=[contact1, contact2], direction="I", visibility="V").exists())
         self.assertTrue(Msg.objects.filter(contact=contact3, direction="I", visibility="V").exists())
+
+        # as a deprecated action, that's recorded so we can see if anything still uses it
+        self.assertPost(
+            endpoint_url,
+            self.admin,
+            {"contacts": [contact3.uuid], "action": "archive"},  # the older alias
+            status=204,
+        )
+
+        r = get_valkey_connection()
+        self.assertEqual(
+            {
+                f"api:deprecated:{self.org.id}/contact_actions#archive_messages": b"1",
+                f"api:deprecated:{self.org.id}/contact_actions#archive": b"1",
+            },
+            {f.decode(): c for f, c in r.hgetall(f"warnings:{timezone.now():%Y-%m}").items()},
+        )
 
         # delete contacts 1 and 2
         self.assertPost(


### PR DESCRIPTION
## Summary

Adds a way to count use of deprecated API features per workspace, so an operator can tell whether
anything still depends on a feature before removing it, and applies it to the first candidate — the
`archive_messages` / `archive` actions on the contacts actions endpoint.

Those two actions are undocumented (the endpoint's own docs list only `add`, `remove`, `block`,
`unblock`, `interrupt` and `delete`), and `archive` has been a backwards-compatible alias since the
original action was renamed. They're the only remaining caller of `Msg.archive_all_for_contacts`,
which bulk-updates message visibility from Django without maintaining the denormalized `folder`
field, so retiring them removes a message state transition that would otherwise need reproducing.

## Changes

**`temba/api/support.py`** — new `record_deprecated(org, feature)`. Increments a counter for the
workspace in the current month's bucket, alongside the other warnings already tracked against
workspaces, and refreshes the bucket's 90 day expiry. Recording is best effort: a failure is logged
and swallowed rather than failing a request whose actual work succeeded.

**`temba/api/v2/serializers.py`** — `ContactBulkActionSerializer.save()` records against
`contact_actions#<action>` before performing the archive, using the action name as given so that
usage of the older `archive` alias can be assessed separately from `archive_messages`.

Counting deliberately includes calls made with session auth as well as with a token. The costs are
asymmetric: over-counting means not retiring something that could have been retired, which shows up
as a number to investigate, while under-counting means removing something a caller depends on. This
is the opposite choice from the `via_api` flag used for ticket actions, and the docstring says why —
that flag drives user-facing attribution of who changed a ticket, where counting UI actions as API
actions would be wrong.

## Behavior examples

A workspace calling the endpoint with either action is counted per action name:

```
POST /api/v2/contact_actions.json  {"contacts": [...], "action": "archive_messages"}
POST /api/v2/contact_actions.json  {"contacts": [...], "action": "archive"}
```

| Before | After |
|---|---|
| nothing recorded | `api:deprecated:<org id>/contact_actions#archive_messages` = 1 |
| nothing recorded | `api:deprecated:<org id>/contact_actions#archive` = 1 |

No change to the endpoint's request or response contract — both actions behave exactly as before.

## Test plan

- [x] New `RecordDeprecatedTest` covers counting, per-workspace separation, accumulation across
      repeated calls, the bucket expiry, and that a backend failure doesn't propagate
- [x] `ContactActionsEndpointTest` asserts both action names are counted end to end through the
      endpoint, and cleans up the keys it writes
- [x] Full Django suite passes (1146 tests), with complete coverage of the added code
- [x] `code_check.py` clean
