### PR TITLE
Migrate message archiving and restoring to mailroom

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -1563,12 +1563,10 @@ class MsgBulkActionSerializer(WriteSerializer):
                 label.toggle_label(messages, add=False)
         elif action == self.DELETE:
             Msg.bulk_soft_delete(self.context["org"], self.context["user"], messages)
-        else:
-            for msg in messages:
-                if action == self.ARCHIVE and msg.visibility == Msg.VISIBILITY_VISIBLE:
-                    msg.archive()
-                elif action == self.RESTORE and msg.visibility == Msg.VISIBILITY_ARCHIVED:
-                    msg.restore()
+        elif action == self.ARCHIVE:
+            Msg.bulk_archive(self.context["org"], messages)
+        elif action == self.RESTORE:
+            Msg.bulk_restore(self.context["org"], messages)
 
         return BulkActionFailure(missing_message_ids) if missing_message_ids else None
 

--- a/temba/api/v2/tests/test_message_actions.py
+++ b/temba/api/v2/tests/test_message_actions.py
@@ -145,10 +145,7 @@ class MessageActionsEndpointTest(APITest):
         self.assertPost(endpoint_url, self.admin, {"messages": [msg2.id], "action": "delete"}, status=204)
         self.assertEqual([call(self.org, self.admin, [msg2])], mr_mocks.calls["msg_delete"])
 
-        # try to act on a valid message and a deleted message
-        msg2.visibility = Msg.VISIBILITY_DELETED_BY_USER
-        msg2.save(update_fields=("visibility",))
-
+        # try to act on a valid message and the message just deleted
         response = self.assertPost(
             endpoint_url, self.admin, {"messages": [msg2.id, msg3.id], "action": "restore"}, status=200
         )

--- a/temba/flows/tests/test_counts.py
+++ b/temba/flows/tests/test_counts.py
@@ -5,7 +5,8 @@ from django.utils import timezone
 
 from temba.flows.models import FlowActivityCount, FlowRun, FlowSession
 from temba.flows.tasks import squash_flow_counts
-from temba.tests import TembaTest
+from temba.msgs.models import Msg
+from temba.tests import TembaTest, mock_mailroom
 from temba.utils.uuid import uuid4
 
 
@@ -158,7 +159,8 @@ class FlowActivityCountTest(TembaTest):
         self.assertEqual({"status:A": 0, "status:I": 4}, flow1.counts.scope_totals())
         self.assertEqual({"status:X": 1, "status:I": 2}, flow2.counts.scope_totals())
 
-    def test_msgsin_counts(self):
+    @mock_mailroom
+    def test_msgsin_counts(self, mr_mocks):
         flow1 = self.create_flow("Test 1")
         flow2 = self.create_flow("Test 2")
 
@@ -197,8 +199,7 @@ class FlowActivityCountTest(TembaTest):
         )
 
         # other changes to msgs shouldn't create new counts
-        in1.archive()
-        in2.archive()
+        Msg.bulk_archive(self.org, [in1, in2])
 
         self.assertEqual(6, flow1.counts.count())
         self.assertEqual(3, flow2.counts.count())

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -320,6 +320,9 @@ class MailroomClient:
 
         return RecipientsPreview(query=resp["query"], total=resp["total"])
 
+    def msg_archive(self, org, msgs):
+        return self._request("msg/archive", {"org_id": org.id, "msg_uuids": [str(m.uuid) for m in msgs]})
+
     def msg_delete(self, org, user, msgs):
         return self._request(
             "msg/delete", {"org_id": org.id, "user_id": user.id, "msg_uuids": [str(m.uuid) for m in msgs]}
@@ -333,6 +336,9 @@ class MailroomClient:
             "msg/resend",
             {"org_id": org.id, "user_id": user.id, "msg_uuids": [str(m.uuid) for m in msgs]},
         )
+
+    def msg_restore(self, org, msgs):
+        return self._request("msg/restore", {"org_id": org.id, "msg_uuids": [str(m.uuid) for m in msgs]})
 
     def msg_search(self, org, text: str, contact=None, in_ticket=False) -> list[tuple[Contact, dict]]:
         resp = self._request(

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -9,6 +9,7 @@ from temba.ai.types.openai.type import OpenAIType
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import ContactField, ContactImport
 from temba.flows.models import Flow, FlowStart
+from temba.msgs.models import Msg
 from temba.schedules.models import Schedule
 from temba.tests import MockJsonResponse, MockResponse, TembaTest
 from temba.tickets.models import Topic
@@ -747,6 +748,38 @@ class MailroomClientTest(TembaTest):
                     "not_seen_since_days": 30,
                 },
             },
+        )
+
+    @patch("requests.post")
+    def test_msg_archive(self, mock_post):
+        ann = self.create_contact("Ann", urns=["tel:+12340000001"])
+        msg1 = self.create_incoming_msg(ann, "Hi")
+        msg2 = self.create_incoming_msg(ann, "Hi again")
+        mock_post.return_value = MockJsonResponse(200, {})
+        response = self.client.msg_archive(self.org, [msg1, msg2])
+
+        self.assertEqual({}, response)
+
+        mock_post.assert_called_once_with(
+            "http://localhost:8090/mi/msg/archive",
+            headers={"User-Agent": "Temba", "Authorization": "Token sesame"},
+            json={"org_id": self.org.id, "msg_uuids": [str(msg1.uuid), str(msg2.uuid)]},
+        )
+
+    @patch("requests.post")
+    def test_msg_restore(self, mock_post):
+        ann = self.create_contact("Ann", urns=["tel:+12340000001"])
+        msg1 = self.create_incoming_msg(ann, "Hi", visibility=Msg.VISIBILITY_ARCHIVED)
+        msg2 = self.create_incoming_msg(ann, "Hi again", visibility=Msg.VISIBILITY_ARCHIVED)
+        mock_post.return_value = MockJsonResponse(200, {})
+        response = self.client.msg_restore(self.org, [msg1, msg2])
+
+        self.assertEqual({}, response)
+
+        mock_post.assert_called_once_with(
+            "http://localhost:8090/mi/msg/restore",
+            headers={"User-Agent": "Temba", "Authorization": "Token sesame"},
+            json={"org_id": self.org.id, "msg_uuids": [str(msg1.uuid), str(msg2.uuid)]},
         )
 
     @patch("requests.post")

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -805,7 +805,8 @@ class Msg(models.Model):
         for msg in msgs:
             assert msg.direction == Msg.DIRECTION_IN, "only incoming messages can be archived"
 
-        mailroom.get_client().msg_archive(org, msgs)
+        if msgs:
+            mailroom.get_client().msg_archive(org, msgs)
 
     @classmethod
     def bulk_restore(cls, org, msgs: list):
@@ -816,7 +817,8 @@ class Msg(models.Model):
         for msg in msgs:
             assert msg.direction == Msg.DIRECTION_IN, "only incoming messages can be restored"
 
-        mailroom.get_client().msg_restore(org, msgs)
+        if msgs:
+            mailroom.get_client().msg_restore(org, msgs)
 
     @classmethod
     def bulk_soft_delete(cls, org, user, msgs: list):

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -755,16 +755,6 @@ class Msg(models.Model):
 
         return folder.code
 
-    def archive(self):
-        """
-        Archives this message
-        """
-        assert self.direction == self.DIRECTION_IN
-
-        if self.visibility == self.VISIBILITY_VISIBLE:
-            self.visibility = self.VISIBILITY_ARCHIVED
-            self.save(update_fields=("visibility", "modified_on"))
-
     @classmethod
     def archive_all_for_contacts(cls, contacts):
         """
@@ -778,16 +768,6 @@ class Msg(models.Model):
         for batch in itertools.batched(msg_ids, 100):
             Msg.objects.filter(pk__in=batch).update(visibility=cls.VISIBILITY_ARCHIVED, modified_on=timezone.now())
 
-    def restore(self):
-        """
-        Restores (i.e. un-archives) this message
-        """
-        assert self.direction == self.DIRECTION_IN
-
-        if self.visibility == self.VISIBILITY_ARCHIVED:
-            self.visibility = self.VISIBILITY_VISIBLE
-            self.save(update_fields=("visibility", "modified_on"))
-
     @classmethod
     def apply_action_label(cls, user, msgs, label):
         label.toggle_label(msgs, add=True)
@@ -798,13 +778,13 @@ class Msg(models.Model):
 
     @classmethod
     def apply_action_archive(cls, user, msgs):
-        for msg in msgs:
-            msg.archive()
+        if msgs := list(msgs):
+            cls.bulk_archive(msgs[0].org, msgs)
 
     @classmethod
     def apply_action_restore(cls, user, msgs):
-        for msg in msgs:
-            msg.restore()
+        if msgs := list(msgs):
+            cls.bulk_restore(msgs[0].org, msgs)
 
     @classmethod
     def apply_action_delete(cls, user, msgs):
@@ -815,6 +795,28 @@ class Msg(models.Model):
     def apply_action_resend(cls, user, msgs):
         if msgs := list(msgs):
             mailroom.get_client().msg_resend(msgs[0].org, user, msgs)
+
+    @classmethod
+    def bulk_archive(cls, org, msgs: list):
+        """
+        Bulk archives the given incoming messages. Messages which aren't currently visible are ignored.
+        """
+
+        for msg in msgs:
+            assert msg.direction == Msg.DIRECTION_IN, "only incoming messages can be archived"
+
+        mailroom.get_client().msg_archive(org, msgs)
+
+    @classmethod
+    def bulk_restore(cls, org, msgs: list):
+        """
+        Bulk restores (i.e. un-archives) the given incoming messages. Messages which aren't archived are ignored.
+        """
+
+        for msg in msgs:
+            assert msg.direction == Msg.DIRECTION_IN, "only incoming messages can be restored"
+
+        mailroom.get_client().msg_restore(org, msgs)
 
     @classmethod
     def bulk_soft_delete(cls, org, user, msgs: list):

--- a/temba/msgs/tests/test_label.py
+++ b/temba/msgs/tests/test_label.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from temba.msgs.models import Label, LabelCount, MessageExport, Msg
 from temba.msgs.tasks import squash_msg_counts
-from temba.tests import TembaTest
+from temba.tests import TembaTest, mock_mailroom
 
 
 class LabelTest(TembaTest):
@@ -22,7 +22,8 @@ class LabelTest(TembaTest):
         # don't allow duplicate name
         self.assertRaises(AssertionError, Label.create, self.org, self.editor, "Spam")
 
-    def test_toggle_label(self):
+    @mock_mailroom
+    def test_toggle_label(self, mr_mocks):
         label = self.create_label("Spam")
         msg1 = self.create_incoming_msg(self.joe, "Message 1")
         msg2 = self.create_incoming_msg(self.joe, "Message 2")
@@ -46,13 +47,13 @@ class LabelTest(TembaTest):
         squash_msg_counts()
         self.assertEqual(label.get_visible_count(), 2)
 
-        msg2.archive()  # won't remove label from msg, but msg no longer counts toward visible count
+        Msg.bulk_archive(self.org, [msg2])  # won't remove label from msg, but msg no longer counts toward visible count
 
         label.refresh_from_db()
         self.assertEqual(label.get_visible_count(), 1)
         self.assertEqual(set(label.get_messages()), {msg1, msg2})
 
-        msg2.restore()  # msg back in visible count
+        Msg.bulk_restore(self.org, [msg2])  # msg back in visible count
 
         label.refresh_from_db()
         self.assertEqual(label.get_visible_count(), 2)
@@ -64,14 +65,14 @@ class LabelTest(TembaTest):
         self.assertEqual(label.get_visible_count(), 1)
         self.assertEqual(set(label.get_messages()), {msg1})
 
-        msg3.archive()
+        Msg.bulk_archive(self.org, [msg3])
         label.toggle_label([msg3], add=True)  # labelling an already archived message doesn't increment the count
 
         label.refresh_from_db()
         self.assertEqual(label.get_visible_count(), 1)
         self.assertEqual(set(label.get_messages()), {msg1, msg3})
 
-        msg3.restore()  # but then restoring that message will
+        Msg.bulk_restore(self.org, [msg3])  # but then restoring that message will
 
         label.refresh_from_db()
         self.assertEqual(label.get_visible_count(), 2)

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -143,6 +143,11 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         msg2 = self.create_incoming_msg(self.frank, "ignore joe, he's a liar")
         out1 = self.create_outgoing_msg(self.frank, "hi")
 
+        label = self.create_label("Spam")
+        label.toggle_label([msg1, msg2], add=True)
+
+        self.assertEqual(2, label.get_visible_count())
+
         # can't soft delete outgoing messages
         with self.assertRaises(AssertionError):
             Msg.bulk_soft_delete(self.org, self.admin, [out1])
@@ -153,6 +158,16 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         mock_storage_delete.assert_any_call("/attachments/1/c/d e.jpg")
 
         self.assertEqual([call(self.org, self.admin, [msg1, msg2])], mr_mocks.calls["msg_delete"])
+
+        # mailroom clears content and labels as well as updating visibility
+        msg1.refresh_from_db()
+        self.assertEqual(Msg.VISIBILITY_DELETED_BY_USER, msg1.visibility)
+        self.assertEqual(Msg.FOLDER_DELETED, msg1.folder)
+        self.assertEqual("", msg1.text)
+        self.assertEqual([], msg1.attachments)
+        self.assertEqual(set(), set(msg1.labels.all()))
+
+        self.assertEqual(0, label.get_visible_count())
 
     @patch("django.core.files.storage.default_storage.delete")
     def test_bulk_delete(self, mock_storage_delete):

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -175,18 +175,19 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         mock_storage_delete.assert_any_call("/attachments/1/a/b.jpg")
         mock_storage_delete.assert_any_call("/attachments/1/c/d e.jpg")
 
-    def test_archive_and_release(self):
+    @mock_mailroom
+    def test_archive_and_release(self, mr_mocks):
         msg1 = self.create_incoming_msg(self.joe, "Incoming")
         label = self.create_label("Spam")
         label.toggle_label([msg1], add=True)
 
-        msg1.archive()
+        Msg.bulk_archive(self.org, [msg1])
 
         msg1 = Msg.objects.get(pk=msg1.pk)
         self.assertEqual(msg1.visibility, Msg.VISIBILITY_ARCHIVED)
         self.assertEqual(set(msg1.labels.all()), {label})  # don't remove labels
 
-        msg1.restore()
+        Msg.bulk_restore(self.org, [msg1])
 
         msg1 = Msg.objects.get(pk=msg1.id)
         self.assertEqual(msg1.visibility, Msg.VISIBILITY_VISIBLE)
@@ -200,7 +201,12 @@ class MsgTest(TembaTest, CRUDLTestMixin):
 
         # can't archive outgoing messages
         msg2 = self.create_outgoing_msg(self.joe, "Outgoing")
-        self.assertRaises(AssertionError, msg2.archive)
+
+        with self.assertRaises(AssertionError):
+            Msg.bulk_archive(self.org, [msg2])
+
+        with self.assertRaises(AssertionError):
+            Msg.bulk_restore(self.org, [msg2])
 
     def test_release_counts(self):
         flow = self.create_flow("Test")

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -214,6 +214,13 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(0, label.get_messages().count())  # do remove labels
         self.assertIsNotNone(label)
 
+        # an empty selection doesn't reach mailroom at all
+        Msg.bulk_archive(self.org, [])
+        Msg.bulk_restore(self.org, [])
+
+        self.assertEqual(1, len(mr_mocks.calls["msg_archive"]))
+        self.assertEqual(1, len(mr_mocks.calls["msg_restore"]))
+
         # can't archive outgoing messages
         msg2 = self.create_outgoing_msg(self.joe, "Outgoing")
 

--- a/temba/msgs/tests/test_msg_folder.py
+++ b/temba/msgs/tests/test_msg_folder.py
@@ -4,7 +4,7 @@ from temba.flows.models import Flow, FlowRun, FlowSession
 from temba.msgs.models import Msg, MsgFolder
 from temba.orgs.tasks import squash_item_counts
 from temba.schedules.models import Schedule
-from temba.tests import TembaTest
+from temba.tests import TembaTest, mock_mailroom
 from temba.utils import s3
 
 
@@ -65,7 +65,8 @@ class MsgFolderTest(TembaTest):
             select = s3.compile_select(where=folder.get_archive_query())
             self.assertEqual(expected_select, select, f"select s3 mismatch for {folder}")
 
-    def test_get_counts(self):
+    @mock_mailroom
+    def test_get_counts(self, mr_mocks):
         def assert_counts(org, expected: dict):
             self.assertEqual(MsgFolder.get_counts(org), expected)
 
@@ -114,7 +115,7 @@ class MsgFolderTest(TembaTest):
             },
         )
 
-        msg3.archive()
+        Msg.bulk_archive(self.org, [msg3])
 
         bcast1 = self.create_broadcast(
             self.editor,
@@ -145,7 +146,7 @@ class MsgFolderTest(TembaTest):
             },
         )
 
-        msg1.archive()
+        Msg.bulk_archive(self.org, [msg1])
         msg3.delete()  # deleting an archived msg
         msg4.delete()  # deleting a visible msg
         msg5.status = "F"
@@ -170,7 +171,7 @@ class MsgFolderTest(TembaTest):
             },
         )
 
-        msg1.restore()
+        Msg.bulk_restore(self.org, [msg1])
         msg5.status = "F"  # already failed
         msg5.save(update_fields=("status",))
         msg6.status = "D"

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -38,7 +38,8 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
             ],
         )
 
-    def test_inbox(self):
+    @mock_mailroom
+    def test_inbox(self, mr_mocks):
         contact1 = self.create_contact("Joe Blow", phone="+250788000001")
         contact2 = self.create_contact("Frank", phone="+250788000002")
         msg1 = self.create_incoming_msg(contact1, "message number 1")

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -652,6 +652,8 @@ class TestClient(MailroomClient):
 
     @_client_method
     def msg_delete(self, org, user, msgs):
+        delete_msgs(msgs)
+
         return {}
 
     @_client_method
@@ -918,6 +920,28 @@ def create_contact_locally(
     update_fields_locally(user, contact, fields)
     update_groups_locally(contact, group_uuids, add=True)
     return contact
+
+
+def delete_msgs(msgs):
+    """
+    Simulates mailroom soft deleting the given incoming messages - clearing their content and labels as well as
+    updating their visibility. Messages which aren't visible or archived are ignored. Note that unlike the visibility
+    changes below, mailroom doesn't bump modified_on here.
+    """
+
+    for msg in msgs:
+        if msg.direction != Msg.DIRECTION_IN or msg.visibility not in (
+            Msg.VISIBILITY_VISIBLE,
+            Msg.VISIBILITY_ARCHIVED,
+        ):
+            continue
+
+        msg.visibility = Msg.VISIBILITY_DELETED_BY_USER
+        msg.folder = msg.derive_folder()
+        msg.text = ""
+        msg.attachments = []
+        msg.save(update_fields=("visibility", "folder", "text", "attachments"))
+        msg.labels.clear()
 
 
 def update_msgs_visibility(msgs, from_visibility: str, to_visibility: str):

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -645,7 +645,19 @@ class TestClient(MailroomClient):
         return mock(org)
 
     @_client_method
+    def msg_archive(self, org, msgs):
+        update_msgs_visibility(msgs, Msg.VISIBILITY_VISIBLE, Msg.VISIBILITY_ARCHIVED)
+
+        return {}
+
+    @_client_method
     def msg_delete(self, org, user, msgs):
+        return {}
+
+    @_client_method
+    def msg_restore(self, org, msgs):
+        update_msgs_visibility(msgs, Msg.VISIBILITY_ARCHIVED, Msg.VISIBILITY_VISIBLE)
+
         return {}
 
     @_client_method
@@ -906,6 +918,22 @@ def create_contact_locally(
     update_fields_locally(user, contact, fields)
     update_groups_locally(contact, group_uuids, add=True)
     return contact
+
+
+def update_msgs_visibility(msgs, from_visibility: str, to_visibility: str):
+    """
+    Simulates mailroom changing the visibility of the given messages, and the folder that follows from it. Messages
+    which aren't in the visibility we're transitioning from are ignored.
+    """
+
+    for msg in msgs:
+        if msg.visibility != from_visibility:
+            continue
+
+        msg.visibility = to_visibility
+        msg.folder = msg.derive_folder()
+        msg.modified_on = timezone.now()
+        msg.save(update_fields=("visibility", "folder", "modified_on"))
 
 
 def update_fields_locally(user, contact, fields):


### PR DESCRIPTION
## Summary

Replaces `Msg.archive()` / `Msg.restore()` with `bulk_archive` / `bulk_restore` classmethods that call mailroom's `msg/archive` and `msg/restore` endpoints, so message state transitions — and the denormalized `folder` that follows from them — are maintained in one place instead of being reimplemented here.

Requires mailroom v26.3.51 or later, which added those endpoints.

## Changes

**`temba/mailroom/client/client.py`** — `msg_archive` and `msg_restore`, both taking `{"org_id", "msg_uuids"}`. No `user_id`: unlike deletion, archiving isn't attributed to a user anywhere, so a required-but-unused field would be misleading.

**`temba/msgs/models.py`** — the two instance methods become `bulk_archive` / `bulk_restore` classmethods alongside `bulk_soft_delete`, keeping the incoming-only assertion the instance methods had. `apply_action_archive` / `apply_action_restore` now make one call for the whole selection rather than one per message. Both bulk methods skip the call entirely for an empty selection, since mailroom marks `msg_uuids` as required and would return a 400 — previously only the CRUDL wrappers guarded against that, so the two call paths disagreed.

**`temba/api/v2/serializers.py`** — the bulk action's per-message visibility checks are gone; mailroom ignores messages that aren't in the visibility being transitioned from, which is the same rule expressed once instead of per call site.

**`temba/tests/mailroom.py`** — the fakes now apply the changes they describe rather than returning an empty dict:

- `msg_archive` / `msg_restore` update visibility and the derived folder, ignoring messages not in the visibility being transitioned from
- `msg_delete` mirrors mailroom's own delete — clears text and attachments and removes labels as well as updating visibility, and deliberately doesn't bump `modified_on`, matching mailroom

That keeps the label-count and folder-count tests exercising the database triggers that maintain those counts, and lets the label count decrement on deletion be covered for the first time. One test that worked around the old no-op fake by setting `visibility` itself no longer needs to.

## Behavior examples

Unchanged from the caller's perspective; the ignore rule now lives in one place:

| Action | Message state | Result |
|---|---|---|
| archive | visible | archived |
| archive | already archived | ignored |
| archive | deleted | ignored |
| restore | archived | visible |
| restore | already visible | ignored |
| archive/restore | empty selection | no call to mailroom |
| archive/restore | outgoing | `AssertionError` before any call |

The API bulk-action endpoint's partial-success response is unaffected — a request naming a deleted message and a valid one still reports the former as a failure and applies the latter.

## Test plan

- Full suite green, run as CI does: `coverage run manage.py test --noinput --parallel 4`, 1146 tests, `coverage report --fail-under=100` at 100%
- `code_check.py` clean — no migrations, locale or lint changes
- New client tests assert both request payloads
- `test_archive_and_release` covers the incoming-only assertion for both directions and the empty-selection short-circuit
- `test_bulk_soft_delete` now asserts the cleared content, removed labels and decremented label count
- Existing label-count, folder-count and CRUDL tests unchanged in intent, now running through the mailroom fakes