### PR TITLE
Add WebChat channel type and anonymous realtime connections

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-25 19:35+0000\n"
+"POT-Creation-Date: 2026-08-26 19:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -1845,6 +1845,9 @@ msgid "The username for your Movile/Wavy account"
 msgstr ""
 
 msgid "The Authentication Token for your Movile/Wavy account"
+msgstr ""
+
+msgid "Chat with visitors on your website via an embedded chat widget."
 msgstr ""
 
 #, python-format
@@ -4999,6 +5002,21 @@ msgstr ""
 
 #, python-format
 msgid "To connect your Vonage Account you will need to provide us your API key and secret. Both values can be found on your <a target=\"vonage\" href=\"%(settings_url)s\">Vonage settings</a> page in the API Settings section."
+msgstr ""
+
+msgid "Visitors chat with this channel through a widget embedded on your website."
+msgstr ""
+
+msgid "Channel UUID"
+msgstr ""
+
+msgid "The embedded widget uses this UUID to identify this channel when connecting."
+msgstr ""
+
+msgid "Embed"
+msgstr ""
+
+msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
 msgstr ""
 
 msgid "You can connect your WhatsApp number by clicking on it below."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-25 19:35+0000\n"
+"POT-Creation-Date: 2026-08-26 19:38+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1860,6 +1860,9 @@ msgstr "El nombre de usuario de su cuenta Movile / Wavy"
 
 msgid "The Authentication Token for your Movile/Wavy account"
 msgstr "El token de autenticación para su cuenta Movile / Wavy"
+
+msgid "Chat with visitors on your website via an embedded chat widget."
+msgstr "Chatee con los visitantes de su sitio web a través de un widget de chat integrado."
 
 #, python-format
 msgid "Add a %(link)s bot to send and receive messages to WeChat users for free. Your users will need an Android, Windows or iOS device and a WeChat account to send and receive messages."
@@ -5034,6 +5037,21 @@ msgstr "<div class=\"code mt-4\">Manage > API Usage > Callback API > Server Sett
 #, python-format
 msgid "To connect your Vonage Account you will need to provide us your API key and secret. Both values can be found on your <a target=\"vonage\" href=\"%(settings_url)s\">Vonage settings</a> page in the API Settings section."
 msgstr "Para conectar su cuenta de Vonage, deberá proporcionarnos su clave API y su secreto. Ambos valores se pueden encontrar en la página <a target=\"vonage\" href=\"%(settings_url)s\">Vonage settings</a> en la sección API Settings."
+
+msgid "Visitors chat with this channel through a widget embedded on your website."
+msgstr "Los visitantes chatean con este canal a través de un widget integrado en su sitio web."
+
+msgid "Channel UUID"
+msgstr "UUID del Canal"
+
+msgid "The embedded widget uses this UUID to identify this channel when connecting."
+msgstr "El widget integrado utiliza este UUID para identificar este canal al conectarse."
+
+msgid "Embed"
+msgstr "Integrar"
+
+msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
+msgstr "Agregue un fragmento como el siguiente a su sitio web para integrar el widget de chat (próximamente)."
 
 msgid "You can connect your WhatsApp number by clicking on it below."
 msgstr "Puede conectar su número de WhatsApp haciendo clic en él a continuación."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-25 19:35+0000\n"
+"POT-Creation-Date: 2026-08-26 19:38+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -1860,6 +1860,9 @@ msgstr "Le nom d'utilisateur de votre compte Mobile/Wavy"
 
 msgid "The Authentication Token for your Movile/Wavy account"
 msgstr "Le jeton d'authentification pour votre compte Mobile/Wavy"
+
+msgid "Chat with visitors on your website via an embedded chat widget."
+msgstr "Discutez avec les visiteurs de votre site web via un widget de chat intégré."
 
 #, python-format
 msgid "Add a %(link)s bot to send and receive messages to WeChat users for free. Your users will need an Android, Windows or iOS device and a WeChat account to send and receive messages."
@@ -5034,6 +5037,21 @@ msgstr "<div class=\"code mt-4\">Manage > API Usage > Callback API > Server Sett
 #, python-format
 msgid "To connect your Vonage Account you will need to provide us your API key and secret. Both values can be found on your <a target=\"vonage\" href=\"%(settings_url)s\">Vonage settings</a> page in the API Settings section."
 msgstr "Pour connecter votre compte Vonage, vous devrez nous fournir votre clé et votre secret API. Ces deux valeurs se trouvent sur votre page <a target=\"vonage\" href=\"%(settings_url)s\">Paramètres Vonage</a> , dans la section Paramètres API."
+
+msgid "Visitors chat with this channel through a widget embedded on your website."
+msgstr "Les visiteurs discutent avec ce canal via un widget intégré à votre site web."
+
+msgid "Channel UUID"
+msgstr "UUID du canal"
+
+msgid "The embedded widget uses this UUID to identify this channel when connecting."
+msgstr "Le widget intégré utilise cet UUID pour identifier ce canal lors de la connexion."
+
+msgid "Embed"
+msgstr "Intégrer"
+
+msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
+msgstr "Ajoutez un extrait comme celui-ci à votre site web pour intégrer le widget de chat (bientôt disponible)."
 
 msgid "You can connect your WhatsApp number by clicking on it below."
 msgstr "Vous pouvez connecter votre numéro WhatsApp en cliquant dessus ci-dessous."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-25 19:35+0000\n"
+"POT-Creation-Date: 2026-08-26 19:38+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -1864,6 +1864,9 @@ msgstr "O nome de usuário da sua conta Movile/Wavy"
 
 msgid "The Authentication Token for your Movile/Wavy account"
 msgstr "O token de autenticação da sua conta Movile/Wavy"
+
+msgid "Chat with visitors on your website via an embedded chat widget."
+msgstr "Converse com os visitantes do seu site através de um widget de chat incorporado."
 
 #, python-format
 msgid "Add a %(link)s bot to send and receive messages to WeChat users for free. Your users will need an Android, Windows or iOS device and a WeChat account to send and receive messages."
@@ -5038,6 +5041,21 @@ msgstr "<div class=\"code mt-4\">Manage > API Usage > Callback API > Server Sett
 #, python-format
 msgid "To connect your Vonage Account you will need to provide us your API key and secret. Both values can be found on your <a target=\"vonage\" href=\"%(settings_url)s\">Vonage settings</a> page in the API Settings section."
 msgstr "Para conectar a sua conta da Vonage, você precisará nos fornecer a sua chave e o seu segredo de API. Ambos os valores podem ser encontrados na página de <a target=\"vonage\" href=\"%(settings_url)s\">configurações da Vonage</a>, na seção API Settings."
+
+msgid "Visitors chat with this channel through a widget embedded on your website."
+msgstr "Os visitantes conversam com este canal através de um widget incorporado no seu site."
+
+msgid "Channel UUID"
+msgstr "UUID do Canal"
+
+msgid "The embedded widget uses this UUID to identify this channel when connecting."
+msgstr "O widget incorporado usa este UUID para identificar este canal ao se conectar."
+
+msgid "Embed"
+msgstr "Incorporar"
+
+msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
+msgstr "Adicione um trecho como o seguinte ao seu site para incorporar o widget de chat (em breve)."
 
 msgid "You can connect your WhatsApp number by clicking on it below."
 msgstr "Você pode conectar o seu número do WhatsApp clicando nele abaixo."

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -32,6 +32,12 @@ class EndpointsTest(APITestMixin, TembaTest):
         # connect attaches no server-side subscriptions - the browser subscribes to the sockets it wants itself
         self.assertEqual({"user": str(user.uuid), "channels": [], "meta": meta}, result)
 
+    def assertAnonymousConnect(self, response):
+        self.assertEqual(200, response.status_code)
+        # an anonymous connection has an empty user, no identity meta, and no expire_at - it never needs re-validating
+        # at the connection level, so the refresh proxy is never called for it
+        self.assertEqual({"result": {"user": "", "channels": [], "meta": {}}}, response.json())
+
     def test_connect(self):
         endpoint_url = reverse("api.websockets.connect")
 
@@ -66,20 +72,16 @@ class EndpointsTest(APITestMixin, TembaTest):
             },
         )
 
-        # a user with no current workspace can't connect for now - they're told to disconnect
+        # a user with no current workspace connects as anonymous
         self.login(self.admin)
         session = self.client.session
         del session["org_id"]
         session.save()
-        response = self.post("api.websockets.connect")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
+        self.assertAnonymousConnect(self.post("api.websockets.connect"))
 
-        # an unauthenticated request is told to disconnect
+        # as does a request with no session at all - e.g. a webchat visitor
         self.client.logout()
-        response = self.post("api.websockets.connect")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
+        self.assertAnonymousConnect(self.post("api.websockets.connect"))
 
         # because it's a server-to-server POST with no CSRF token, it still works when CSRF checks are enforced
         csrf_client = self.client_class(enforce_csrf_checks=True)
@@ -179,11 +181,10 @@ class EndpointsTest(APITestMixin, TembaTest):
         session.save()
         assertForbidden(f"history:{contact.uuid}")
 
-        # an unauthenticated request is told to disconnect
+        # an unauthenticated request - e.g. from an anonymous connection - is forbidden: anonymous connections can't
+        # subscribe to anything through this proxy
         self.client.logout()
-        response = subscribe(f"history:{contact.uuid}")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
+        assertForbidden(f"history:{contact.uuid}")
 
     def test_subscribe_notifications(self):
         def subscribe(socket, client="conn-1"):
@@ -430,11 +431,9 @@ class EndpointsTest(APITestMixin, TembaTest):
         # a missing secret is rejected
         self.assertEqual(403, self.post("api.websockets.connect", secret=None).status_code)
 
-        # a correct secret doesn't bypass session auth - a browser with no session is still told to disconnect
+        # a correct secret doesn't grant an identity - a browser with no session still only connects as anonymous
         self.client.logout()
-        response = self.post("api.websockets.connect")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4501, "reason": "unauthorized"}}, response.json())
+        self.assertAnonymousConnect(self.post("api.websockets.connect"))
 
     @override_settings(WEBSOCKETS_AUTH_SECRET=None)
     def test_secret_required(self):

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -2,9 +2,10 @@
 Endpoints called by the realtime messaging server that fronts browser WebSockets - server-to-server, never by
 browsers directly.
 
-These handle connection authentication and lifecycle: ``connect`` authenticates a new connection from the forwarded
-session cookie, and ``refresh`` periodically re-validates it. The connect result also attaches the user's identity to
-the connection's server-side ``meta``, so the proxies that authorize individual socket subscriptions (handled by
+These handle connection authentication and lifecycle: ``connect`` resolves a new connection's identity from the
+forwarded session cookie - accepting connections that don't resolve to a user as anonymous - and ``refresh``
+periodically re-validates authenticated connections. The connect result also attaches an authenticated user's identity
+to the connection's server-side ``meta``, so the proxies that authorize individual socket subscriptions (handled by
 another internal service) can act on that identity without re-reading the Django session.
 
 Unlike the rest of the internal API (``/api/internal/``), which is called by the editor running in the user's
@@ -47,13 +48,6 @@ SUBSCRIPTION_WINDOW = 60
 # minutes once the last subscriber stops refreshing (there's no unsubscribe callback, so this TTL is the only GC).
 SUBSCRIPTION_TTL = 150
 
-# instruction returned when a request has no valid session, telling the realtime server to close the connection. The
-# realtime protocol takes reconnect semantics from the *band* a custom disconnect code falls in, not from the number
-# itself: 3500-3999 and 4500-4999 tell the client not to reconnect, and every other custom code tells it to retry. Both
-# cases we send this for are terminal - the page needs a fresh session, which only a reload can produce - so the code
-# has to sit in a no-reconnect band or a logged-out tab retries the handshake for as long as it stays open.
-UNAUTHORIZED_DISCONNECT = {"disconnect": {"code": 4501, "reason": "unauthorized"}}
-
 
 class WebSocketsSessionAuthentication(APISessionAuthentication):
     """
@@ -94,13 +88,9 @@ class BaseEndpoint(APIView):
 class ConnectEndpoint(BaseEndpoint):
     """
     Connection proxy called by the realtime messaging server when a browser opens a WebSocket. The browser connects
-    with no auth token; the realtime server forwards the browser's session cookie and we resolve the user.
+    with no auth token; the realtime server forwards the browser's session cookie (if any) and we resolve the user.
 
-    We currently require an authenticated user with a current workspace; if either is missing we return
-    ``UNAUTHORIZED_DISCONNECT`` so the realtime server closes the connection, and closes it terminally - the browser
-    can't fix a missing session by connecting again, so it shouldn't retry until the page is reloaded.
-
-    On success the result carries:
+    For a connection that resolves to an authenticated user with a current workspace, the result carries:
       * ``user`` - the user identifier (uuid);
       * ``channels`` - empty: there are no server-side subscriptions. The browser subscribes to every socket it wants
         - its own ``notifications:<org-uuid>:<user-uuid>`` socket, any contact/ticket ``history`` sockets, and any
@@ -109,15 +99,21 @@ class ConnectEndpoint(BaseEndpoint):
       * ``meta`` - the user's identity (uuids and ids) attached to the connection so the subscription-authorization
         proxies can act on it without re-reading the session; ``meta`` is server-side only and never sent to the browser;
       * ``expire_at`` - when the realtime server should next call the refresh proxy to re-validate the connection.
+
+    Any other connection - no session at all, or a session without a current workspace - is accepted as *anonymous*:
+    an empty-string user, no subscriptions, no identity meta, and no ``expire_at``, so the refresh proxy never fires
+    for it - there's no session state to re-validate at the connection level. Anonymous connections exist for sockets
+    that aren't authorized here - e.g. webchat visitors, whose chat subscriptions are authorized by the messaging
+    service that owns them via separate named proxies - and can't subscribe to anything through this API's own
+    default-deny subscription proxies.
     """
 
     def post(self, request, *args, **kwargs):
         user = request.user
 
-        # for now a connection requires an authenticated user with a current workspace. This could be reworked in
-        # future to also support anonymous connections - e.g. webchat - which have no Django user or workspace.
+        # a connection that doesn't resolve to an authenticated user with a current workspace is anonymous
         if not user.is_authenticated or not request.org:
-            return Response(UNAUTHORIZED_DISCONNECT)
+            return Response({"result": {"user": "", "channels": [], "meta": {}}})
 
         org = request.org
         meta = {"user_id": user.id, "user_uuid": str(user.uuid), "org_id": org.id, "org_uuid": str(org.uuid)}
@@ -129,10 +125,12 @@ class ConnectEndpoint(BaseEndpoint):
 
 class RefreshEndpoint(BaseEndpoint):
     """
-    Refresh proxy called periodically by the realtime messaging server before a connection's ``expire_at``. We re-check
-    that the connection is still valid - the user is still logged in and still has a current workspace, matching what
-    ``connect`` requires - and either extend it with a new ``expire_at`` or let it expire. This is how a logout, session
-    expiry, or losing access to the workspace eventually tears down the WebSocket.
+    Refresh proxy called periodically by the realtime messaging server before a connection's ``expire_at``. Only
+    authenticated connections get an ``expire_at`` from connect, so this is never called for anonymous connections. We
+    re-check that the connection is still valid - the user is still logged in and still has a current workspace,
+    matching what ``connect`` requires of an authenticated connection - and either extend it with a new ``expire_at``
+    or let it expire. This is how a logout, session expiry, or losing access to the workspace eventually tears down
+    the WebSocket.
     """
 
     def post(self, request, *args, **kwargs):
@@ -267,20 +265,17 @@ class SubscribeEndpoint(SubscriptionEndpoint):
     Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a socket. The request
     body carries the requested socket name (in its ``channel`` field), which we authorize against the live session.
 
-    An unauthenticated request is told to disconnect terminally (its connection should never have got this far, and
-    like connect there's nothing a retry could fix). Otherwise, if the
-    user has a current workspace and may access the socket, we record the subscription and return an ``expire_at`` so
-    the realtime server schedules a sub_refresh; anything else is refused with a forbidden error, which Centrifugo
-    surfaces to the browser as a failed subscribe without tearing down the whole connection.
+    If the user is authenticated, has a current workspace and may access the socket, we record the subscription and
+    return an ``expire_at`` so the realtime server schedules a sub_refresh. Anything else is refused with a forbidden
+    error, which Centrifugo surfaces to the browser as a failed subscribe without tearing down the whole connection -
+    including requests from anonymous connections, which can't subscribe to anything through this proxy (their chat
+    subscriptions are authorized elsewhere via separate named proxies).
     """
 
     def post(self, request, *args, **kwargs):
-        if not request.user.is_authenticated:
-            return Response(UNAUTHORIZED_DISCONNECT)
-
         socket = request.data.get("channel", "")
 
-        if request.org and self.is_allowed(request, socket):
+        if request.user.is_authenticated and request.org and self.is_allowed(request, socket):
             self.record_subscription(socket)
             return Response({"result": {"expire_at": self.subscription_expire_at()}})
 

--- a/temba/channels/types/webchat/__init__.py
+++ b/temba/channels/types/webchat/__init__.py
@@ -1,0 +1,1 @@
+from .type import WebChatType  # noqa

--- a/temba/channels/types/webchat/tests.py
+++ b/temba/channels/types/webchat/tests.py
@@ -1,0 +1,39 @@
+from django.urls import reverse
+
+from temba.channels.models import Channel
+from temba.tests import TembaTest
+
+
+class WebChatTypeTest(TembaTest):
+    def test_claim(self):
+        claim_url = reverse("channels.types.webchat.claim")
+
+        # not available to regular users
+        self.login(self.admin)
+
+        response = self.client.get(reverse("channels.channel_claim_all"))
+        self.assertNotContains(response, claim_url)
+
+        # and can't be claimed by them directly either
+        response = self.client.post(claim_url, {})
+        self.assertEqual(404, response.status_code)
+
+        # but is available to staff
+        self.login(self.customer_support, choose_org=self.org)
+
+        response = self.client.get(reverse("channels.channel_claim_all"))
+        self.assertContains(response, claim_url)
+
+        response = self.client.post(claim_url, {})
+        self.assertEqual(302, response.status_code)
+
+        channel = Channel.objects.get(channel_type="WCH")
+        self.assertEqual("WebChat", channel.name)
+        self.assertIsNone(channel.address)
+        self.assertEqual(["webchat"], channel.schemes)
+        self.assertEqual({}, channel.config)
+        self.assertEqual(reverse("channels.channel_configuration", args=[channel.uuid]), response.url)
+
+        # config page shows the channel UUID that the embedded widget connects with
+        response = self.client.get(reverse("channels.channel_configuration", args=[channel.uuid]))
+        self.assertContains(response, str(channel.uuid))

--- a/temba/channels/types/webchat/type.py
+++ b/temba/channels/types/webchat/type.py
@@ -1,0 +1,31 @@
+from django.utils.translation import gettext_lazy as _
+
+from temba.contacts.models import URN
+
+from ...models import ChannelType, ConfigUI
+from .views import ClaimView
+
+
+class WebChatType(ChannelType):
+    """
+    A WebChat channel which lets visitors on a website chat via an embedded widget.
+    """
+
+    code = "WCH"
+    name = "WebChat"
+    category = ChannelType.Category.SOCIAL_MEDIA
+
+    schemes = [URN.WEBCHAT_SCHEME]
+
+    claim_blurb = _("Chat with visitors on your website via an embedded chat widget.")
+    claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
+
+    def is_available_to(self, org, user):
+        available = user.is_staff
+
+        return available, available
+
+    def is_recommended_to(self, org, user):
+        return False

--- a/temba/channels/types/webchat/views.py
+++ b/temba/channels/types/webchat/views.py
@@ -1,0 +1,19 @@
+from smartmin.views import SmartFormView
+
+from temba.channels.models import Channel
+from temba.channels.views import ClaimViewMixin
+
+
+class ClaimView(ClaimViewMixin, SmartFormView):
+    class Form(ClaimViewMixin.Form):
+        pass
+
+    form_class = Form
+    readonly_servicing = False
+
+    def form_valid(self, form):
+        self.object = Channel.create(
+            self.request.org, self.request.user, None, self.channel_type, name="WebChat", config={}
+        )
+
+        return super().form_valid(form)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -826,6 +826,7 @@ CHANNEL_TYPES = [
     "temba.channels.types.vk.VKType",
     "temba.channels.types.vonage.VonageType",
     "temba.channels.types.wavy.WavyType",
+    "temba.channels.types.webchat.WebChatType",
     "temba.channels.types.wechat.WeChatType",
     "temba.channels.types.whatsapp.WhatsAppType",
     "temba.channels.types.yo.YoType",

--- a/templates/channels/types/webchat/config.html
+++ b/templates/channels/types/webchat/config.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+
+{% blocktrans trimmed %}
+  Visitors chat with this channel through a widget embedded on your website.
+{% endblocktrans %}
+<div class="card">
+  <div class="subtitle">{% trans "Channel UUID" %}</div>
+  <div class="code inline-block">{{ channel.uuid }}</div>
+  <div class="mt-2">
+    {% blocktrans trimmed %}
+      The embedded widget uses this UUID to identify this channel when connecting.
+    {% endblocktrans %}
+  </div>
+</div>
+<div class="mt-4 card">
+  <div class="subtitle">{% trans "Embed" %}</div>
+  <div class="mt-2">
+    {% blocktrans trimmed %}
+      Add a snippet like the following to your website to embed the chat widget (coming soon).
+    {% endblocktrans %}
+  </div>
+  <div class="bleed-x bleed-b text-white bg-black">
+    <div class="code p-0 break-all bg-black text-white">&lt;temba-webchat channel="{{ channel.uuid }}"&gt;&lt;/temba-webchat&gt;</div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Adds a new staff-only WebChat channel type for chatting with website visitors via an embedded widget, and reworks the realtime connect proxy to accept sessionless connections as anonymous — which such visitors need, since they never authenticate.

## Changes

### WebChat channel type (`temba/channels/types/webchat/`)

- New channel type with code `WCH`, name "WebChat", scheme `webchat`. The chat lifecycle is owned by the courier service, which handles the channel's `start` and `receive` actions in its `wch/<uuid>/<action>` URL space.
- Only available to staff for now, and never recommended.
- Claiming requires no provider credentials or configuration: the channel is created with no address and an empty config, which stays as a seam for later options (e.g. allowed domains).
- The channel configuration page shows the channel UUID and a placeholder embed snippet for the forthcoming widget component.
- New translatable strings come with authored es / fr / pt_BR translations.

### Anonymous connections (`temba/api/websockets/views.py`)

- `ConnectEndpoint` previously required every WebSocket connection to resolve to an authenticated user with a current workspace and told the realtime server to disconnect anything else. A connection that doesn't resolve to one is now accepted as anonymous instead: empty-string user, no subscriptions, no identity meta, and no connection-level `expire_at` — so the refresh proxy never fires for it. Authenticated connections keep exactly their current behavior, and `RefreshEndpoint` is unchanged.
- `SubscribeEndpoint` stays default-deny but no longer assumes connect filtered out unauthenticated requests: an unauthenticated subscribe is now refused with a forbidden error rather than a disconnect instruction, since anonymous connections are legitimate and a stray subscribe shouldn't tear one down. Anonymous connections can't subscribe to anything through these proxies — chat subscriptions are authorized by the messaging service that owns the chats, via separate named proxies.
- The now-unused unauthorized-disconnect instruction is removed, and module/class docstrings updated to describe the anonymous case.

## Behavior examples

Connect proxy result for a request with no session (previously vs now):

| Before | After |
|---|---|
| `{"disconnect": {"code": 4501, "reason": "unauthorized"}}` | `{"result": {"user": "", "channels": [], "meta": {}}}` |

An unauthenticated subscribe now gets `{"error": {"code": 403, "message": "forbidden"}}` instead of the disconnect instruction.

## Test plan

- [x] New `WebChatTypeTest` covers availability (hidden and 404 for regular users, claimable by staff), the created channel's type/name/schemes/empty config, redirect to the configuration page, and the UUID appearing there
- [x] Websockets tests updated: anonymous connect (no session, or no current workspace) is allowed with empty user and no `expire_at`; unauthenticated subscribe is denied with a forbidden error; secret checks unchanged
- [x] `temba.channels` + `temba.api` suites pass
- [x] `code_check.py` passes (formatting, migrations, regenerated locale files)