### PR TITLE
Refresh the contact field a split reads from workspace assets

### DIFF
--- a/components/src/flow/dependencies.ts
+++ b/components/src/flow/dependencies.ts
@@ -22,6 +22,13 @@ const dependencyIdentity = (dependency: FlowDependency): string | null => {
  * UUIDs don't appear in its dependency list. Field references use keys and
  * only occur under a `field` property; scoping keyed matching there avoids
  * confusing a field key with a result name or another keyed structure.
+ *
+ * Editor UI configs name the contact field a split reads under an `operand`
+ * property, identified by `id` rather than `key`, so those are matched
+ * separately and only when the operand is a field - the same shape carries
+ * system properties, URN schemes and run results, none of which are workspace
+ * assets. Unlike the other matches this one fills in a name that isn't there,
+ * since operands saved before names were embedded don't carry one.
  */
 export const resolveDependencyNames = (
   definition: FlowDefinition,
@@ -71,6 +78,15 @@ export const resolveDependencyNames = (
         'name' in value
       ) {
         const canonical = fieldNamesByKey.get(value.key);
+        if (canonical != null) {
+          value.name = canonical;
+        }
+      } else if (
+        propertyName === 'operand' &&
+        value.type === 'field' &&
+        typeof value.id === 'string'
+      ) {
+        const canonical = fieldNamesByKey.get(value.id);
         if (canonical != null) {
           value.name = canonical;
         }

--- a/components/src/flow/nodes/split_by_contact_field.ts
+++ b/components/src/flow/nodes/split_by_contact_field.ts
@@ -29,6 +29,17 @@ export const CONTACT_PROPERTIES = {
   channel: { id: 'channel', name: 'Channel', type: 'property' }
 };
 
+// Helper to get the display name for a saved operand. Field names are refreshed
+// from the workspace when the flow is opened, but a field that has since been
+// deleted - or a flow saved before names were embedded - leaves us without one,
+// so fall back to the key we split on rather than rendering nothing.
+const getOperandName = (operand: any): string =>
+  operand?.name ||
+  operand?.key ||
+  operand?.id ||
+  operand?.value ||
+  CONTACT_PROPERTIES.name.name;
+
 // Helper to get operand for the selected field
 const getOperandForField = (field: any): string => {
   // For URN schemes, split on the URN path (the actual ID value like Facebook ID)
@@ -107,6 +118,7 @@ export const split_by_contact_field: NodeConfig = {
     } else {
       if (!field.value) field.value = field.id;
     }
+    if (!field.name) field.name = getOperandName(field);
 
     // Extract rules from router cases using shared function
     const rules = casesToFormRules(node);
@@ -204,7 +216,8 @@ export const split_by_contact_field: NodeConfig = {
     return config;
   },
   renderTitle: (node: Node, nodeUI?: any) => {
-    return html`<div>${msg(str`Split by ${nodeUI.config.operand.name}`)}</div>`;
+    const name = getOperandName(nodeUI?.config?.operand);
+    return html`<div>${msg(str`Split by ${name}`)}</div>`;
   },
 
   // Localization support for categories

--- a/components/src/store/AppState.ts
+++ b/components/src/store/AppState.ts
@@ -356,11 +356,17 @@ export const zustand = createStore<AppState>()(
               dependencyResolver(data.info.dependencies),
               DEPENDENCY_RESOLVE_TIMEOUT
             );
-            const dependencies = canonical
-              ? replaceDependencies(data.info.dependencies, canonical)
-              : null;
-            if (dependencies) {
-              data.info = { ...data.info, dependencies };
+            if (canonical) {
+              // the info list only changes when a name actually changed, but
+              // resolving always runs: a reference can be missing a name
+              // without any name having changed
+              const dependencies = replaceDependencies(
+                data.info.dependencies,
+                canonical
+              );
+              if (dependencies) {
+                data.info = { ...data.info, dependencies };
+              }
               data.definition = resolveDependencyNames(
                 data.definition,
                 canonical
@@ -514,10 +520,9 @@ export const zustand = createStore<AppState>()(
             state.flowInfo.dependencies,
             changed
           );
-          if (!dependencies) {
-            return;
+          if (dependencies) {
+            state.flowInfo.dependencies = dependencies;
           }
-          state.flowInfo.dependencies = dependencies;
           state.flowDefinition = resolveDependencyNames(
             state.flowDefinition,
             changed

--- a/components/test/nodes/split_by_contact_field.test.ts
+++ b/components/test/nodes/split_by_contact_field.test.ts
@@ -1,6 +1,13 @@
 import { expect } from '@open-wc/testing';
+import { render } from 'lit';
 import { split_by_contact_field } from '../../src/flow/nodes/split_by_contact_field';
 import { Node } from '../../src/store/flow-definition';
+
+const renderTitleText = (node: Node, nodeUI: any): string => {
+  const host = document.createElement('div');
+  render(split_by_contact_field.renderTitle!(node, nodeUI), host);
+  return host.textContent!.trim();
+};
 
 describe('split_by_contact_field', () => {
   it('should have correct configuration', () => {
@@ -506,5 +513,62 @@ describe('split_by_contact_field', () => {
 
     // The operand must NOT be @fields.undefined
     expect(updatedNode.router!.operand).to.equal('@fields.favorite_color');
+  });
+
+  it('should render the title from the operand name', () => {
+    const node = { uuid: 'test-node-uuid', actions: [], exits: [] } as any;
+    const nodeUI = {
+      type: 'split_by_contact_field',
+      position: { left: 0, top: 0 },
+      config: { operand: { id: 'age', name: 'Age', type: 'field' } }
+    };
+
+    expect(renderTitleText(node, nodeUI)).to.equal('Split by Age');
+  });
+
+  it('should fall back to the key when the operand has no name', () => {
+    const node = { uuid: 'test-node-uuid', actions: [], exits: [] } as any;
+    // a deleted field can't be resolved, and older flows embed no name at all
+    const nodeUI = {
+      type: 'split_by_contact_field',
+      position: { left: 0, top: 0 },
+      config: { operand: { id: 'age', type: 'field' } }
+    };
+
+    expect(renderTitleText(node, nodeUI)).to.equal('Split by age');
+  });
+
+  it('should render a title when there is no ui config at all', () => {
+    const node = { uuid: 'test-node-uuid', actions: [], exits: [] } as any;
+
+    expect(renderTitleText(node, undefined)).to.equal('Split by Name');
+    expect(renderTitleText(node, {} as any)).to.equal('Split by Name');
+  });
+
+  it('should give the form a field name when the operand has none', () => {
+    const node: Node = {
+      uuid: 'test-node-uuid',
+      actions: [],
+      router: {
+        type: 'switch',
+        cases: [],
+        categories: [{ uuid: 'cat-other', name: 'Other', exit_uuid: 'exit-1' }],
+        default_category_uuid: 'cat-other',
+        operand: '@fields.age',
+        result_name: ''
+      },
+      exits: [{ uuid: 'exit-1', destination_uuid: null }]
+    } as any;
+
+    const nodeUI = {
+      type: 'split_by_contact_field',
+      position: { left: 0, top: 0 },
+      config: { operand: { id: 'age', type: 'field' } }
+    };
+
+    const formData = split_by_contact_field.toFormData!(node, nodeUI);
+
+    expect(formData.field[0].key).to.equal('age');
+    expect(formData.field[0].name).to.equal('age');
   });
 });

--- a/components/test/temba-appstate-actions.test.ts
+++ b/components/test/temba-appstate-actions.test.ts
@@ -576,6 +576,50 @@ describe('store/AppState actions', () => {
       expect(state().flowInfo.dependencies[0].name).to.equal('Alice');
     });
 
+    it('fills in a missing name when no name has changed', async () => {
+      // the field is not renamed, so nothing in the dependency list changes -
+      // the split's operand still has no name and needs one filling in
+      setDependencyResolver(async () => [
+        { type: 'field', key: 'age', name: 'Age' }
+      ]);
+      mockRevision({
+        definition: definition({
+          nodes: [
+            {
+              uuid: 'node-1',
+              exits: [],
+              actions: [
+                {
+                  type: 'set_contact_field',
+                  uuid: 'action-1',
+                  field: { key: 'age', name: 'Age' },
+                  value: '10'
+                }
+              ]
+            }
+          ],
+          _ui: {
+            nodes: {
+              'node-1': {
+                position: { left: 0, top: 0 },
+                type: 'split_by_contact_field',
+                config: { operand: { id: 'age', type: 'field' } }
+              }
+            }
+          }
+        }),
+        info: info({
+          dependencies: [{ type: 'field', key: 'age', name: 'Age' }]
+        })
+      });
+
+      await state().fetchRevision(REVISION_URL);
+
+      expect(
+        (state().flowDefinition as any)._ui.nodes['node-1'].config.operand.name
+      ).to.equal('Age');
+    });
+
     it('resolves every referenced flow before exposing a revision', async () => {
       const flow1Uuid = '11111111-1111-4111-8111-111111111111';
       const flow2Uuid = '22222222-2222-4222-8222-222222222222';

--- a/components/test/temba-appstate-actions.test.ts
+++ b/components/test/temba-appstate-actions.test.ts
@@ -827,6 +827,72 @@ describe('flow/dependencies resolveDependencyNames', () => {
     expect(resolved.nodes[0].router.result.name).to.equal('Result label');
   });
 
+  it('rewrites the field a split reads from its ui config', () => {
+    const definition = withNodes([]);
+    definition._ui.nodes = {
+      'node-1': {
+        type: 'split_by_contact_field',
+        position: { left: 0, top: 0 },
+        config: { operand: { id: 'age', name: 'Old age label', type: 'field' } }
+      }
+    };
+
+    const resolved: any = resolveDependencyNames(definition, [
+      { type: 'field', key: 'age', name: 'Age' }
+    ]);
+
+    expect(resolved._ui.nodes['node-1'].config.operand.name).to.equal('Age');
+  });
+
+  it('fills in the name of a split operand saved without one', () => {
+    const definition = withNodes([]);
+    definition._ui.nodes = {
+      'node-1': {
+        type: 'split_by_contact_field',
+        position: { left: 0, top: 0 },
+        // flows saved by older editors embed no name at all
+        config: { operand: { id: 'age', type: 'field' } }
+      }
+    };
+
+    const resolved: any = resolveDependencyNames(definition, [
+      { type: 'field', key: 'age', name: 'Age' }
+    ]);
+
+    expect(resolved._ui.nodes['node-1'].config.operand.name).to.equal('Age');
+  });
+
+  it('leaves operands which are not fields alone', () => {
+    const definition = withNodes([]);
+    definition._ui.nodes = {
+      // a system property whose id collides with a field key
+      'node-1': {
+        type: 'split_by_contact_field',
+        position: { left: 0, top: 0 },
+        config: {
+          operand: { id: 'age', name: 'Age property', type: 'property' }
+        }
+      },
+      // a run result, which isn't a workspace asset
+      'node-2': {
+        type: 'split_by_run_result',
+        position: { left: 0, top: 0 },
+        config: { operand: { id: 'age', name: 'Age result', type: 'result' } }
+      }
+    };
+
+    const resolved: any = resolveDependencyNames(definition, [
+      { type: 'field', key: 'age', name: 'Age' }
+    ]);
+
+    expect(resolved._ui.nodes['node-1'].config.operand.name).to.equal(
+      'Age property'
+    );
+    expect(resolved._ui.nodes['node-2'].config.operand.name).to.equal(
+      'Age result'
+    );
+  });
+
   it('returns the definition untouched when nothing is registered', () => {
     const definition = withNodes([]);
     expect(resolveDependencyNames(definition, [])).to.equal(definition);

--- a/components/xliff/es.xlf
+++ b/components/xliff/es.xlf
@@ -479,7 +479,7 @@
   <target>Se requiere un campo</target>
 </trans-unit>
 <trans-unit id="sa6b487784a771fb2">
-  <source>Split by <x id="0" equiv-text="${nodeUI.config.operand.name}"/></source>
+  <source>Split by <x id="0" equiv-text="${name}"/></source>
   <target>Dividir por <x id="0" equiv-text="${nodeUI.config.operand.name}"/></target>
 </trans-unit>
 <trans-unit id="sa6c2a3309400062e">

--- a/components/xliff/fr.xlf
+++ b/components/xliff/fr.xlf
@@ -479,7 +479,7 @@
   <target>Un champ est requis</target>
 </trans-unit>
 <trans-unit id="sa6b487784a771fb2">
-  <source>Split by <x id="0" equiv-text="${nodeUI.config.operand.name}"/></source>
+  <source>Split by <x id="0" equiv-text="${name}"/></source>
   <target>Diviser par <x id="0" equiv-text="${nodeUI.config.operand.name}"/></target>
 </trans-unit>
 <trans-unit id="sa6c2a3309400062e">

--- a/components/xliff/pt.xlf
+++ b/components/xliff/pt.xlf
@@ -479,7 +479,7 @@
   <target>Um campo é obrigatório</target>
 </trans-unit>
 <trans-unit id="sa6b487784a771fb2">
-  <source>Split by <x id="0" equiv-text="${nodeUI.config.operand.name}"/></source>
+  <source>Split by <x id="0" equiv-text="${name}"/></source>
   <target>Dividir por <x id="0" equiv-text="${nodeUI.config.operand.name}"/></target>
 </trans-unit>
 <trans-unit id="sa6c2a3309400062e">


### PR DESCRIPTION
## Summary

Splits on a contact field render "Split by undefined" and show a blank field in the node editor for flows saved before the field's name was embedded in their editor UI config. The same gap means a flow which does carry a name never picks up a rename. This routes those references through the dependency name resolution that already refreshes groups and subflows, and fixes a gate which stopped that resolution running when nothing had been renamed.

## Changes

**`components/src/flow/dependencies.ts`** — `resolveDependencyNames` matched two shapes: any `{uuid, name}` object, and a `{key, name}` object under a property named `field`. A contact field split identifies its field under an `operand` property, keyed by `id`, so neither matched. Adds a third branch for it.

It is scoped to `type === 'field'` so the other things sharing that shape are left alone — system properties, URN schemes, and `split_by_run_result`'s `type: 'result'` operands, none of which are workspace assets.

Unlike the existing branches it does not require `'name' in value`. The other two only ever replace a name; operands saved by older editors have no `name` key at all, so replacing would never fire on exactly the flows that are broken.

**`components/src/store/AppState.ts`** — resolution was gated on `replaceDependencies` returning a change, on the load path and again on the live path. Filling in a missing name and detecting a rename are independent conditions, so a reference lacking a name only got one when some unrelated name happened to have changed. Resolution now runs whenever canonical names come back; only the `info.dependencies` rewrite stays gated on an actual change.

**`components/src/flow/nodes/split_by_contact_field.ts`** — a deleted field can't be resolved, since the assets endpoint omits assets which no longer exist. `renderTitle` now falls back through key → id → value rather than interpolating `undefined`, and tolerates a missing UI config instead of dereferencing three levels unguarded. `toFormData` applies the same fallback so the field select shows the key rather than nothing.

**`components/xliff/*.xlf`** — regenerated. The message id is a hash of the literal parts only, so all three translations are unchanged; the diff is one `equiv-text` metadata line per locale.

## Behavior examples

For a node splitting on a contact field with key `age`, named `Age` in the workspace:

| UI config operand | Node title before | Node title after |
|---|---|---|
| `{id: "age", type: "field"}` | Split by undefined | Split by Age |
| `{id: "age", name: "Old label", type: "field"}` | Split by Old label | Split by Age |
| `{id: "age", type: "field"}`, field deleted | Split by undefined | Split by age |
| `{id: "name", name: "Name", type: "property"}` | Split by Name | Split by Name |

The refreshed name is held in the loaded definition, so a subsequent revision persists it — the same way a refreshed group or subflow name does.

## Test plan

- [x] Eight new tests: the operand being refreshed, a name being filled in where none existed, non-field operands left untouched, the render/form fallbacks, and enrichment running when no name has changed
- [x] The last of those was verified to fail without the `AppState` fix, so it guards the regression rather than passing incidentally
- [x] Full component suite green — 2964 passed, 0 failed
- [x] `bun run validate` clean, statement coverage 89.82%
- [x] Traced the live chain end to end against a running workspace: the revision endpoint returns the field in `info.dependencies`, `field` is a supported store asset type so the reference is forwarded, and the assets endpoint resolves it to its current name — which is what the new branch consumes
- [x] Reproduced the original failure first, from a flow definition carrying both operand shapes, and confirmed both now render

## Notes

Contact fields don't publish rename events — that's documented as covering flows and groups only — so a rename refreshes when the flow is opened, but not live in an already-open editor the way a group rename does. Bringing fields to parity is a separate change.