### PR TITLE
Remove fail_old_android_messages task now that mailroom handles it

### DIFF
--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -1,33 +1,12 @@
 import logging
-from datetime import timedelta
 
 from celery import shared_task
 
-from django.utils import timezone
-
 from temba.utils.crons import cron_task
 
-from .models import BroadcastMsgCount, LabelCount, Media, Msg
+from .models import BroadcastMsgCount, LabelCount, Media
 
 logger = logging.getLogger(__name__)
-
-
-@cron_task()
-def fail_old_android_messages():
-    """
-    Fails old Android that haven't sent because their relayer isn't syncing. Note that we can't fail non-Android
-    messages here because they're still in Courier's queue.
-    """
-
-    too_old = Msg.objects.filter(
-        created_on__lte=timezone.now() - timedelta(days=7),
-        direction=Msg.DIRECTION_OUT,
-        is_android=True,
-        status__in=(Msg.STATUS_INITIALIZING, Msg.STATUS_QUEUED, Msg.STATUS_ERRORED),
-    )
-    num_failed = too_old.update(status=Msg.STATUS_FAILED, failed_reason=Msg.FAILED_TOO_OLD, modified_on=timezone.now())
-
-    return {"failed": num_failed}
 
 
 @cron_task(lock_timeout=7200)

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -1,11 +1,9 @@
-from datetime import timedelta
 from unittest.mock import call, patch
 
 from django.utils import timezone
 
 from temba.flows.models import Flow
 from temba.msgs.models import Msg, MsgFolder
-from temba.msgs.tasks import fail_old_android_messages
 from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
 from temba.utils.uuid import uuid7
 
@@ -258,29 +256,6 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         assertReleaseCount("I", Msg.STATUS_HANDLED, Msg.VISIBILITY_VISIBLE, None, MsgFolder.INBOX)
         assertReleaseCount("I", Msg.STATUS_HANDLED, Msg.VISIBILITY_ARCHIVED, None, MsgFolder.ARCHIVED)
         assertReleaseCount("I", Msg.STATUS_HANDLED, Msg.VISIBILITY_VISIBLE, flow, MsgFolder.HANDLED)
-
-    def test_fail_old_android_messages(self):
-        msg1 = self.create_outgoing_msg(self.joe, "Hello", status=Msg.STATUS_QUEUED)
-        msg2 = self.create_outgoing_msg(
-            self.joe, "Hello", status=Msg.STATUS_QUEUED, created_on=timezone.now() - timedelta(days=8)
-        )
-        msg3 = self.create_outgoing_msg(
-            self.joe, "Hello", status=Msg.STATUS_ERRORED, created_on=timezone.now() - timedelta(days=8)
-        )
-        msg4 = self.create_outgoing_msg(
-            self.joe, "Hello", status=Msg.STATUS_SENT, created_on=timezone.now() - timedelta(days=8)
-        )
-
-        fail_old_android_messages()
-
-        def assert_status(msg, status):
-            msg.refresh_from_db()
-            self.assertEqual(status, msg.status)
-
-        assert_status(msg1, Msg.STATUS_QUEUED)
-        assert_status(msg2, Msg.STATUS_FAILED)
-        assert_status(msg3, Msg.STATUS_FAILED)
-        assert_status(msg4, Msg.STATUS_SENT)
 
     def test_big_ids(self):
         # create an incoming message with big id

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -710,7 +710,6 @@ CELERY_BEAT_SCHEDULE = {
     "check-android-channels": {"task": "check_android_channels", "schedule": timedelta(seconds=300)},
     "delete-released-orgs": {"task": "delete_released_orgs", "schedule": crontab(hour=4, minute=0)},
     "expire-invitations": {"task": "expire_invitations", "schedule": crontab(hour=0, minute=10)},
-    "fail-old-android-messages": {"task": "fail_old_android_messages", "schedule": crontab(hour=0, minute=0)},
     "refresh-turn-whatsapp-tokens": {"task": "refresh_turn_whatsapp_tokens", "schedule": crontab(hour=6, minute=0)},
     "refresh-templates": {"task": "refresh_templates", "schedule": timedelta(hours=6)},
     "send-notification-emails": {"task": "send_notification_emails", "schedule": timedelta(seconds=60)},


### PR DESCRIPTION
## Summary

Failing stale outgoing Android messages is now done by mailroom, so the Django Celery task is removed. This is part of making mailroom and courier the only writers of message state — the Django task updated `status` without ever touching the denormalized `msgs_msg.folder` column, leaving it stale.

## Changes

- `temba/msgs/tasks.py` — removed the `fail_old_android_messages` cron task, along with the `timedelta`, `timezone` and `Msg` imports it was the only user of
- `temba/settings_common.py` — removed the `fail-old-android-messages` beat schedule entry
- `temba/msgs/tests/test_msg.py` — removed `test_fail_old_android_messages` and its now-unused imports

`Msg.FAILED_TOO_OLD` stays: it remains a valid `failed_reason` value, and is what mailroom writes.

## Behavior

Behaviour is deliberately not a like-for-like port — mailroom's version is stricter on both axes:

| | Django task (removed) | Mailroom |
|---|---|---|
| Age threshold | 7 days | 72 hours, shared with the channel-sync give-up threshold |
| Frequency | daily at midnight | hourly |
| Updates `folder` | no | yes |

Because 72h is well short of 7 days, mailroom fails these messages long before the Django task would have seen them, so running both during a rolling deploy is harmless.

## Test plan

- `temba.msgs` suite passes (57 tests)
- Full suite passes (1149 tests) under coverage with `--fail-under=100` — the removal orphans no now-uncovered code
- `code_check.py` clean; no migration or locale drift (nothing removed was translatable)
- Repo-wide grep for `fail_old_android_messages` / `fail-old-android-messages` returns nothing