### PR TITLE
Ignore invalid attachments when deleting messages

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -477,8 +477,15 @@ class Attachment:
         raise ValueError(f"{s} is not a valid attachment")
 
     @classmethod
-    def parse_all(cls, attachments) -> list:
-        return [cls.parse(s) for s in (attachments or [])]
+    def parse_all(cls, attachments, ignore_invalid: bool = False) -> list:
+        parsed = []
+        for s in attachments or []:
+            try:
+                parsed.append(cls.parse(s))
+            except ValueError:
+                if not ignore_invalid:
+                    raise
+        return parsed
 
     @classmethod
     def bulk_delete(cls, attachments):
@@ -831,7 +838,7 @@ class Msg(models.Model):
         for msg in msgs:
             assert msg.direction == Msg.DIRECTION_IN, "only incoming messages can be soft deleted"
 
-            attachments_to_delete.extend(msg.get_attachments())
+            attachments_to_delete.extend(Attachment.parse_all(msg.attachments, ignore_invalid=True))
 
         Attachment.bulk_delete(attachments_to_delete)  # TODO move to mailroom as well
 
@@ -847,7 +854,7 @@ class Msg(models.Model):
 
         for msg in msgs:
             if msg.direction == Msg.DIRECTION_IN:
-                attachments_to_delete.extend(msg.get_attachments())
+                attachments_to_delete.extend(Attachment.parse_all(msg.attachments, ignore_invalid=True))
 
         Attachment.bulk_delete(attachments_to_delete)
 

--- a/temba/msgs/tests/test_attachment.py
+++ b/temba/msgs/tests/test_attachment.py
@@ -21,3 +21,13 @@ class AttachmentTest(TembaTest):
         )
         with self.assertRaises(ValueError):
             Attachment.parse("http://example.com/test.jpg")
+
+        # parse_all is strict by default but can be told to ignore invalid attachments
+        with self.assertRaises(ValueError):
+            Attachment.parse_all(["image:http://example.com/test.jpg", "http://example.com/test.jpg"])
+        self.assertEqual(
+            [Attachment("image", "http://example.com/test.jpg")],
+            Attachment.parse_all(
+                ["image:http://example.com/test.jpg", "http://example.com/test.jpg"], ignore_invalid=True
+            ),
+        )

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -136,6 +136,7 @@ class MsgTest(TembaTest, CRUDLTestMixin):
             attachments=[
                 r"audo/mp4:http://s3.com/attachments/1/a/b.jpg",
                 r"image/jpeg:http://s3.com/attachments/1/c/d%20e.jpg",
+                r"http://example.com/test.mp4",  # invalid attachments are ignored
             ],
         )
         msg2 = self.create_incoming_msg(self.frank, "ignore joe, he's a liar")
@@ -176,6 +177,7 @@ class MsgTest(TembaTest, CRUDLTestMixin):
             attachments=[
                 r"audo/mp4:http://s3.com/attachments/1/a/b.jpg",
                 r"image/jpeg:http://s3.com/attachments/1/c/d%20e.jpg",
+                r"http://example.com/test.mp4",  # invalid attachments are ignored
             ],
         )
         self.create_incoming_msg(self.frank, "ignore joe, he's a liar")

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -155,6 +155,7 @@ class MsgTest(TembaTest, CRUDLTestMixin):
 
         mock_storage_delete.assert_any_call("/attachments/1/a/b.jpg")
         mock_storage_delete.assert_any_call("/attachments/1/c/d e.jpg")
+        self.assertEqual(2, mock_storage_delete.call_count)  # invalid attachment not deleted from storage
 
         self.assertEqual([call(self.org, self.admin, [msg1, msg2])], mr_mocks.calls["msg_delete"])
 
@@ -189,6 +190,7 @@ class MsgTest(TembaTest, CRUDLTestMixin):
 
         mock_storage_delete.assert_any_call("/attachments/1/a/b.jpg")
         mock_storage_delete.assert_any_call("/attachments/1/c/d e.jpg")
+        self.assertEqual(2, mock_storage_delete.call_count)  # invalid attachment not deleted from storage
 
     @mock_mailroom
     def test_archive_and_release(self, mr_mocks):


### PR DESCRIPTION
## Summary

Deleting a released org can fail if any of its incoming messages has a malformed attachment value — one stored as a bare URL without a `content_type:` prefix — because `Msg.bulk_delete` parses attachments strictly to find files to delete from storage. Such values can occur when attachment fetching never completed for a received message. This makes the deletion paths tolerant: unparseable attachment values are skipped, since they don't reference stored files we need to clean up.

## Changes

- `Attachment.parse_all` gains an `ignore_invalid` flag (default `False`, so validation and serialization paths keep their strict behavior).
- `Msg.bulk_delete` and `Msg.bulk_soft_delete` now parse attachments with `ignore_invalid=True`, so a malformed value no longer aborts deletion of the whole batch.

## Behavior examples

| | Before | After |
|---|---|---|
| Deleting messages where one has attachment `https://example.com/test.mp4` (no content type prefix) | `ValueError: ... is not a valid attachment`, org deletion task fails for that org | Invalid value skipped, valid attachments still deleted from storage, messages deleted |

## Test plan

- [x] `test_attachment` covers `parse_all` strict (raises) and `ignore_invalid=True` (skips) behavior
- [x] `test_bulk_delete` and `test_bulk_soft_delete` each include a malformed attachment and verify deletion succeeds, valid attachments are still removed from storage, and the invalid value is never passed to storage (delete call count asserted)
- [x] Full `temba.msgs` suite passes; `code_check.py` clean