### PR TITLE
Don't grant session identity to cross-origin websockets connections

### DIFF
--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -17,8 +17,10 @@ SECRET = "topsecret"
 
 @override_settings(WEBSOCKETS_AUTH_SECRET=SECRET)
 class EndpointsTest(APITestMixin, TembaTest):
-    def post(self, name, data=None, *, client=None, secret=SECRET):
+    def post(self, name, data=None, *, client=None, secret=SECRET, origin=None):
         headers = {"HTTP_X_WEBSOCKETS_SECRET": secret} if secret is not None else {}
+        if origin is not None:  # the realtime server forwarding the browser's Origin header
+            headers["HTTP_ORIGIN"] = origin
         return (client or self.client).post(reverse(name), data or {}, content_type="application/json", **headers)
 
     def assertExpiry(self, expire_at):
@@ -100,6 +102,42 @@ class EndpointsTest(APITestMixin, TembaTest):
             },
         )
 
+    @override_settings(ALLOWED_HOSTS=["testserver", ".rapidpro.io"])
+    def test_connect_origin(self):
+        admin_meta = {
+            "user_id": self.admin.id,
+            "user_uuid": str(self.admin.uuid),
+            "org_id": self.org.id,
+            "org_uuid": str(self.org.uuid),
+        }
+
+        self.login(self.admin)
+
+        # a session connecting from an origin the deployment itself serves (wildcard entries included, so whitelabel
+        # domains pass) gets its full identity
+        self.assertConnect(
+            self.post("api.websockets.connect", origin="https://app.rapidpro.io"), user=self.admin, meta=admin_meta
+        )
+
+        # as does one with no Origin header at all - a non-browser client, or a proxy config that doesn't forward it
+        self.assertConnect(self.post("api.websockets.connect"), user=self.admin, meta=admin_meta)
+
+        # but a session presented from a foreign origin is refused its identity - the connection is accepted as
+        # anonymous instead, and the downgrade is warned about since it's either an attack or a misconfiguration
+        with self.assertLogs("temba.api.websockets.views", level="WARNING") as logs:
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="https://attacker.example.com"))
+        self.assertIn("foreign origin https://attacker.example.com", logs.output[0])
+
+        # an opaque or unparseable origin is foreign too
+        with self.assertLogs("temba.api.websockets.views", level="WARNING"):
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="null"))
+
+        # anonymous connections are origin-agnostic - webchat widgets connect from arbitrary sites by design - and
+        # nothing is downgraded, so nothing is warned about
+        self.client.logout()
+        with self.assertNoLogs("temba.api.websockets.views", level="WARNING"):
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="https://attacker.example.com"))
+
     def test_refresh(self):
         # a still-authenticated connection with a current workspace is extended with a new expiry
         self.login(self.admin)
@@ -118,6 +156,23 @@ class EndpointsTest(APITestMixin, TembaTest):
         # a connection whose session is gone is told it has expired, which tears the connection down
         self.client.logout()
         response = self.post("api.websockets.refresh")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+    @override_settings(ALLOWED_HOSTS=["testserver", ".rapidpro.io"])
+    def test_refresh_origin(self):
+        self.login(self.admin)
+
+        # a refresh from an origin the deployment serves, or with no Origin header, extends the connection as before
+        for origin in ("https://app.rapidpro.io", None):
+            response = self.post("api.websockets.refresh", origin=origin)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        # but a foreign origin gets no session identity, so the connection expires rather than persisting - even one
+        # that authenticated at connect (e.g. under a config that didn't yet forward the Origin header)
+        with self.assertLogs("temba.api.websockets.views", level="WARNING"):
+            response = self.post("api.websockets.refresh", origin="https://attacker.example.com")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"result": {"expired": True}}, response.json())
 
@@ -394,6 +449,47 @@ class EndpointsTest(APITestMixin, TembaTest):
         # being logged in doesn't get in the way of chat authorization - it never touches the session
         self.login(self.admin)
         assertAllowed(socket)
+
+    @override_settings(ALLOWED_HOSTS=["testserver", ".rapidpro.io"])
+    def test_subscribe_origin(self):
+        contact = self.create_contact("Ann", phone="+1234", org=self.org)
+
+        # a webchat channel and visitor, as in test_subscribe_chat
+        chat_id = "65vbbDAQCdPdEWlEhDGy4utO"
+        channel = self.create_channel("WCH", "WebChat", "wch1")
+        chat_contact = self.create_contact("Vic", urns=[f"webchat:{chat_id}"])
+        chat_contact.urns.update(channel=channel)
+
+        def subscribe(socket, origin):
+            return self.post("api.websockets.subscribe", {"channel": socket, "client": "conn-1"}, origin=origin)
+
+        self.login(self.admin)
+
+        # a session subscribing from an origin the deployment serves, or with no Origin header, is authorized as usual
+        for origin in ("https://app.rapidpro.io", None):
+            response = subscribe(f"history:{contact.uuid}", origin)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        # but a foreign-origin request gets no session identity here either - a page the connect proxy would only
+        # accept as anonymous can't reach session-based sockets by subscribing with the same forwarded cookie
+        response = subscribe(f"history:{contact.uuid}", "https://attacker.example.com")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+
+        # and sub_refresh applies the same rule, so such a subscription expires rather than being re-armed
+        response = self.post(
+            "api.websockets.sub_refresh",
+            {"channel": f"history:{contact.uuid}", "client": "conn-1"},
+            origin="https://attacker.example.com",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+        # chat sockets are capability-based and origin-agnostic - webchat widgets subscribe from arbitrary sites
+        response = subscribe(f"chat:{channel.uuid}:{chat_id}", "https://attacker.example.com")
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
 
     def test_subscribe_ticket_topic_access(self):
         # an agent restricted to a team's topics can only watch the history of tickets they're allowed to view - the

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -131,6 +131,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         # an opaque or unparseable origin is foreign too
         with self.assertLogs("temba.api.websockets.views", level="WARNING"):
             self.assertAnonymousConnect(self.post("api.websockets.connect", origin="null"))
+        with self.assertLogs("temba.api.websockets.views", level="WARNING"):
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="https://[invalid"))
 
         # anonymous connections are origin-agnostic - webchat widgets connect from arbitrary sites by design - and
         # nothing is downgraded, so nothing is warned about

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -9,6 +9,18 @@ individual socket subscriptions: most sockets against the live Django session, b
 capability - the socket name embeds a secret chat-id, so possession of the name is the credential and anonymous
 visitors can subscribe to (only) their own chat.
 
+Because the realtime server forwards the browser's session cookie, these cookie-authenticated calls are a CSRF
+surface: a WebSocket opened by any page the browser user happens to visit would otherwise ride their session. Two
+independent layers prevent that. First, the session cookie is ``SameSite=Lax`` (the Django default), so modern
+browsers never attach it to a cross-site WebSocket handshake. Second, the realtime server forwards the browser's
+``Origin`` header, and a request that resolves to an authenticated session but originates from a host this
+deployment doesn't itself serve (judged against ``ALLOWED_HOSTS``, so whitelabel domains pass) is stripped of that
+identity: connect accepts the connection as anonymous, refresh expires it, and the subscription proxies deny its
+session-based sockets. Together these mean the realtime server's own allowed-origins whitelist can be relaxed - so
+webchat widgets can connect from arbitrary third-party sites - without those pages being able to borrow a
+visitor's session. A request with no ``Origin`` header at all (a non-browser client, or a proxy config that
+doesn't forward it) is treated as before.
+
 Unlike the rest of the internal API (``/api/internal/``), which is called by the editor running in the user's
 browser and so *must* be reachable from the public internet, every endpoint here is only ever called by the
 realtime messaging server from inside our own network. That means this API can be made truly internal: serve
@@ -19,7 +31,9 @@ isn't the realtime server even if the path is ever reachable - but the secret is
 API off the public internet.
 """
 
+import logging
 import re
+from urllib.parse import urlsplit
 
 from django_valkey import get_valkey_connection
 from rest_framework.permissions import BasePermission
@@ -28,6 +42,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from django.conf import settings
+from django.http.request import validate_host
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 
@@ -36,6 +51,8 @@ from temba.contacts.models import URN
 from temba.tickets.models import Ticket
 
 from ..support import APISessionAuthentication
+
+logger = logging.getLogger(__name__)
 
 # how long (seconds) a connection stays valid before the realtime server must re-validate it via the refresh proxy
 CONNECTION_TTL = 5 * 60
@@ -55,7 +72,9 @@ SUBSCRIPTION_TTL = 150
 class WebSocketsSessionAuthentication(APISessionAuthentication):
     """
     Session auth for the server-to-server proxy calls. The realtime server forwards the browser's session cookie but
-    can't present a CSRF token, so we no-op the CSRF check. Identity still comes from the real, signed session cookie.
+    can't present a CSRF token, so we no-op the CSRF check. Identity still comes from the real, signed session cookie,
+    and cross-origin protection comes from the cookie's ``SameSite`` policy plus the forwarded-Origin check the
+    endpoints apply (see module docs).
     """
 
     def enforce_csrf(self, request):
@@ -87,6 +106,30 @@ class BaseEndpoint(APIView):
         """Unix time at which the connection should next be re-validated by the refresh proxy."""
         return int(timezone.now().timestamp()) + CONNECTION_TTL
 
+    def is_foreign_origin(self, request) -> bool:
+        """
+        Whether the request carries a forwarded browser ``Origin`` header whose host isn't one this deployment itself
+        serves. A foreign-origin request must never be granted session identity (see module docs). Origins are judged
+        against ``ALLOWED_HOSTS`` - the same configuration that already defines which hosts the deployment answers
+        for, wildcard entries included - so whitelabel domains pass without a separate list. An absent header (a
+        non-browser client, or a proxy config that doesn't forward it) is not foreign; an unparseable or opaque one
+        (e.g. ``null``) is.
+        """
+        origin = request.headers.get("Origin", "")
+        if not origin:
+            return False
+
+        try:
+            host = urlsplit(origin).hostname
+        except ValueError:
+            host = None
+
+        allowed_hosts = settings.ALLOWED_HOSTS
+        if settings.DEBUG and not allowed_hosts:  # mirror the dev fallback Django's own host validation uses
+            allowed_hosts = [".localhost", "127.0.0.1", "[::1]"]
+
+        return not (host and validate_host(host, allowed_hosts))
+
 
 class ConnectEndpoint(BaseEndpoint):
     """
@@ -108,6 +151,11 @@ class ConnectEndpoint(BaseEndpoint):
     for it - there's no session state to re-validate at the connection level. Anonymous connections exist for webchat
     visitors: the subscribe proxy authorizes their ``chat`` sockets by capability - the socket name embeds a secret
     chat-id - and denies them every session-based socket.
+
+    A connection that *does* resolve to a session but arrives from a foreign origin - a forwarded browser ``Origin``
+    header for a host this deployment doesn't serve - is also accepted as anonymous rather than being granted the
+    session's identity: a third-party page must never be able to ride a visitor's session (see module docs).
+    Anonymous connections are origin-agnostic - webchat widgets connect from arbitrary sites by design.
     """
 
     def post(self, request, *args, **kwargs):
@@ -115,6 +163,15 @@ class ConnectEndpoint(BaseEndpoint):
 
         # a connection that doesn't resolve to an authenticated user with a current workspace is anonymous
         if not user.is_authenticated or not request.org:
+            return Response({"result": {"user": "", "channels": [], "meta": {}}})
+
+        # so is one that resolves to a session but comes from an origin we don't serve - it gets no session identity.
+        # That's either a third-party page trying to ride the session or a misconfigured origin, so warn.
+        if self.is_foreign_origin(request):
+            logger.warning(
+                "websockets connect downgraded to anonymous: session presented from foreign origin %s",
+                request.headers.get("Origin"),
+            )
             return Response({"result": {"user": "", "channels": [], "meta": {}}})
 
         org = request.org
@@ -129,15 +186,26 @@ class RefreshEndpoint(BaseEndpoint):
     """
     Refresh proxy called periodically by the realtime messaging server before a connection's ``expire_at``. Only
     authenticated connections get an ``expire_at`` from connect, so this is never called for anonymous connections. We
-    re-check that the connection is still valid - the user is still logged in and still has a current workspace,
-    matching what ``connect`` requires of an authenticated connection - and either extend it with a new ``expire_at``
-    or let it expire. This is how a logout, session expiry, or losing access to the workspace eventually tears down
-    the WebSocket.
+    re-check that the connection is still valid - the user is still logged in, still has a current workspace, and the
+    connection's forwarded ``Origin`` (if any) is still one we serve, matching what ``connect`` requires of an
+    authenticated connection - and either extend it with a new ``expire_at`` or let it expire. This is how a logout,
+    session expiry, or losing access to the workspace eventually tears down the WebSocket - and a foreign-origin
+    refresh expires the connection too, so an authenticated connection can't outlive a tightening of the origin rules
+    that would refuse it identity today.
     """
 
     def post(self, request, *args, **kwargs):
         # mirror connect: a connection is only kept alive while it has an authenticated user with a current workspace
         if not request.user.is_authenticated or not request.org:
+            return Response({"result": {"expired": True}})
+
+        # and, as at connect, a foreign origin gets no session identity - without it the connection can't stay
+        # authenticated, so it expires
+        if self.is_foreign_origin(request):
+            logger.warning(
+                "websockets connection expired: session presented from foreign origin %s",
+                request.headers.get("Origin"),
+            )
             return Response({"result": {"expired": True}})
 
         return Response({"result": {"expire_at": self.expire_at()}})
@@ -197,8 +265,11 @@ class SubscriptionEndpoint(BaseEndpoint):
         """
         Default-deny authorization of a client-requested socket, routed by matching the socket name against
         ``SOCKET_ROUTES`` - so adding a new socket type later is one route and one handler. Session-based routes are
-        denied outright unless the request has an authenticated user with a current workspace, so their handlers are
-        never reached by an anonymous request.
+        denied outright unless the request has an authenticated user with a current workspace *and* isn't from a
+        foreign origin - a request the connect proxy would refuse session identity must be refused session-based
+        sockets here too, or a third-party page could bypass the connect-time downgrade by subscribing with the same
+        forwarded cookie (see module docs) - so their handlers are never reached by an anonymous or foreign-origin
+        request. The capability-based chat route never touches the session and so has no origin restrictions.
         """
         if not isinstance(socket, str):  # malformed payload (e.g. a non-string socket) is just a denial, not a 500
             return False
@@ -206,7 +277,9 @@ class SubscriptionEndpoint(BaseEndpoint):
         for pattern, handler, session_based in self.SOCKET_ROUTES:
             match = pattern.fullmatch(socket)  # unlike $ anchoring, fullmatch won't tolerate a trailing newline
             if match:
-                if session_based and (not request.user.is_authenticated or not request.org):
+                if session_based and (
+                    not request.user.is_authenticated or not request.org or self.is_foreign_origin(request)
+                ):
                     return False
 
                 return getattr(self, handler)(request, **match.groupdict())

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -111,9 +111,11 @@ class BaseEndpoint(APIView):
         Whether the request carries a forwarded browser ``Origin`` header whose host isn't one this deployment itself
         serves. A foreign-origin request must never be granted session identity (see module docs). Origins are judged
         against ``ALLOWED_HOSTS`` - the same configuration that already defines which hosts the deployment answers
-        for, wildcard entries included - so whitelabel domains pass without a separate list. An absent header (a
-        non-browser client, or a proxy config that doesn't forward it) is not foreign; an unparseable or opaque one
-        (e.g. ``null``) is.
+        for, wildcard entries included - so whitelabel domains pass without a separate list. That also means a
+        deployment running with ``ALLOWED_HOSTS = ["*"]`` disables this check entirely - every origin validates -
+        leaving the cookie's ``SameSite`` policy as its only cross-origin defense. An absent header (a non-browser
+        client, or a proxy config that doesn't forward it) is not foreign; an unparseable or opaque one (e.g.
+        ``null``) is.
         """
         origin = request.headers.get("Origin", "")
         if not origin:


### PR DESCRIPTION
## Summary

The realtime messaging server authenticates browser WebSocket connections by proxying to `/api/websockets/`, forwarding the browser's session cookie. Those cookie-authenticated calls are a CSRF surface: if the realtime server's allowed-origins whitelist is relaxed - which webchat widgets embedded on third-party sites will require - any page a logged-in user visits could open a socket that rides their session.

The first line of defense is that the session cookie is `SameSite=Lax` (the Django default; nothing overrides it), so modern browsers never attach it to a cross-site WebSocket handshake in the first place.

This adds a second, server-side layer for when the realtime server forwards the browser's `Origin` header to the proxies: a request that resolves to an authenticated session but originates from a host the deployment doesn't itself serve is refused session identity.

## Changes

* `BaseEndpoint.is_foreign_origin()` judges a forwarded `Origin` header's host against `ALLOWED_HOSTS` - the same configuration that already defines which hosts the deployment answers for, wildcard entries included - so whitelabel domains pass without a separate list. An absent header (a non-browser client, or a proxy config that doesn't forward it) keeps current behavior; an unparseable or opaque (`null`) origin counts as foreign. As documented in the helper, `ALLOWED_HOSTS = ["*"]` disables this layer entirely - `SameSite` remains the only cross-origin defense there.
* **connect** accepts a foreign-origin session as anonymous instead of granting its identity, and logs a warning since a downgrade is either an attack or a misconfigured origin.
* **refresh** expires a foreign-origin connection (also logged), so an authenticated connection can't persist once its origin would be refused identity - e.g. one authenticated under a config that didn't yet forward the header.
* **subscribe / sub_refresh** deny session-based sockets to foreign-origin requests, so the connect-time downgrade can't be bypassed by subscribing with the same forwarded cookie. The capability-based webchat `chat` route is untouched and origin-agnostic - anonymous connections have no origin restrictions, and webchat's own per-channel origin controls come later at the channel level.
* Module and endpoint docstrings describe the defense layering.

## Test plan

* New tests: session connect from an own origin (wildcard match included) → full identity; from a foreign, opaque, or unparseable origin → anonymous plus warning; no `Origin` header → full identity, unchanged; refresh from a foreign origin → expired; subscribe/sub_refresh from a foreign origin → session sockets denied/expired while chat sockets still work; anonymous connect from any origin → anonymous, no warning.
* All websockets API tests pass and coverage of the touched module is 100%.