### PR TITLE
Add allowed domains support to WebChat channels

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-26 19:38+0000\n"
+"POT-Creation-Date: 2026-08-27 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -1848,6 +1848,16 @@ msgid "The Authentication Token for your Movile/Wavy account"
 msgstr ""
 
 msgid "Chat with visitors on your website via an embedded chat widget."
+msgstr ""
+
+msgid "Allowed Domains"
+msgstr ""
+
+msgid "The domains of the websites that can embed this channel's chat widget, one per line or comma separated, e.g. example.com or example.com:8080. If empty, any website can embed it."
+msgstr ""
+
+#, python-format
+msgid "%(domain)s is not a valid domain. Enter domains without schemes or paths, e.g. example.com."
 msgstr ""
 
 #, python-format
@@ -5017,6 +5027,12 @@ msgid "Embed"
 msgstr ""
 
 msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
+msgstr ""
+
+msgid "Only websites on the following domains can embed this channel's chat widget. This can be changed in the channel settings."
+msgstr ""
+
+msgid "Currently any website can embed this channel's chat widget. Setting allowed domains in the channel settings stops other websites from embedding it."
 msgstr ""
 
 msgid "You can connect your WhatsApp number by clicking on it below."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-26 19:38+0000\n"
+"POT-Creation-Date: 2026-08-27 14:47+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1863,6 +1863,16 @@ msgstr "El token de autenticación para su cuenta Movile / Wavy"
 
 msgid "Chat with visitors on your website via an embedded chat widget."
 msgstr "Chatee con los visitantes de su sitio web a través de un widget de chat integrado."
+
+msgid "Allowed Domains"
+msgstr "Dominios permitidos"
+
+msgid "The domains of the websites that can embed this channel's chat widget, one per line or comma separated, e.g. example.com or example.com:8080. If empty, any website can embed it."
+msgstr "Los dominios de los sitios web que pueden integrar el widget de chat de este canal, uno por línea o separados por comas, p. ej. example.com o example.com:8080. Si está vacío, cualquier sitio web puede integrarlo."
+
+#, python-format
+msgid "%(domain)s is not a valid domain. Enter domains without schemes or paths, e.g. example.com."
+msgstr "%(domain)s no es un dominio válido. Ingrese dominios sin esquemas ni rutas, p. ej. example.com."
 
 #, python-format
 msgid "Add a %(link)s bot to send and receive messages to WeChat users for free. Your users will need an Android, Windows or iOS device and a WeChat account to send and receive messages."
@@ -5052,6 +5062,12 @@ msgstr "Integrar"
 
 msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
 msgstr "Agregue un fragmento como el siguiente a su sitio web para integrar el widget de chat (próximamente)."
+
+msgid "Only websites on the following domains can embed this channel's chat widget. This can be changed in the channel settings."
+msgstr "Solo los sitios web en los siguientes dominios pueden integrar el widget de chat de este canal. Esto se puede cambiar en la configuración del canal."
+
+msgid "Currently any website can embed this channel's chat widget. Setting allowed domains in the channel settings stops other websites from embedding it."
+msgstr "Actualmente cualquier sitio web puede integrar el widget de chat de este canal. Configurar dominios permitidos en la configuración del canal impide que otros sitios web lo integren."
 
 msgid "You can connect your WhatsApp number by clicking on it below."
 msgstr "Puede conectar su número de WhatsApp haciendo clic en él a continuación."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-26 19:38+0000\n"
+"POT-Creation-Date: 2026-08-27 14:47+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -1863,6 +1863,16 @@ msgstr "Le jeton d'authentification pour votre compte Mobile/Wavy"
 
 msgid "Chat with visitors on your website via an embedded chat widget."
 msgstr "Discutez avec les visiteurs de votre site web via un widget de chat intégré."
+
+msgid "Allowed Domains"
+msgstr "Domaines autorisés"
+
+msgid "The domains of the websites that can embed this channel's chat widget, one per line or comma separated, e.g. example.com or example.com:8080. If empty, any website can embed it."
+msgstr "Les domaines des sites web qui peuvent intégrer le widget de chat de ce canal, un par ligne ou séparés par des virgules, par ex. example.com ou example.com:8080. Si vide, n'importe quel site web peut l'intégrer."
+
+#, python-format
+msgid "%(domain)s is not a valid domain. Enter domains without schemes or paths, e.g. example.com."
+msgstr "%(domain)s n'est pas un domaine valide. Saisissez des domaines sans schéma ni chemin, par ex. example.com."
 
 #, python-format
 msgid "Add a %(link)s bot to send and receive messages to WeChat users for free. Your users will need an Android, Windows or iOS device and a WeChat account to send and receive messages."
@@ -5052,6 +5062,12 @@ msgstr "Intégrer"
 
 msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
 msgstr "Ajoutez un extrait comme celui-ci à votre site web pour intégrer le widget de chat (bientôt disponible)."
+
+msgid "Only websites on the following domains can embed this channel's chat widget. This can be changed in the channel settings."
+msgstr "Seuls les sites web des domaines suivants peuvent intégrer le widget de chat de ce canal. Cela peut être modifié dans les paramètres du canal."
+
+msgid "Currently any website can embed this channel's chat widget. Setting allowed domains in the channel settings stops other websites from embedding it."
+msgstr "Actuellement, n'importe quel site web peut intégrer le widget de chat de ce canal. Définir des domaines autorisés dans les paramètres du canal empêche les autres sites web de l'intégrer."
 
 msgid "You can connect your WhatsApp number by clicking on it below."
 msgstr "Vous pouvez connecter votre numéro WhatsApp en cliquant dessus ci-dessous."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-26 19:38+0000\n"
+"POT-Creation-Date: 2026-08-27 14:47+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -1867,6 +1867,16 @@ msgstr "O token de autenticação da sua conta Movile/Wavy"
 
 msgid "Chat with visitors on your website via an embedded chat widget."
 msgstr "Converse com os visitantes do seu site através de um widget de chat incorporado."
+
+msgid "Allowed Domains"
+msgstr "Domínios permitidos"
+
+msgid "The domains of the websites that can embed this channel's chat widget, one per line or comma separated, e.g. example.com or example.com:8080. If empty, any website can embed it."
+msgstr "Os domínios dos sites que podem incorporar o widget de chat deste canal, um por linha ou separados por vírgulas, ex. example.com ou example.com:8080. Se vazio, qualquer site pode incorporá-lo."
+
+#, python-format
+msgid "%(domain)s is not a valid domain. Enter domains without schemes or paths, e.g. example.com."
+msgstr "%(domain)s não é um domínio válido. Insira domínios sem esquemas ou caminhos, ex. example.com."
 
 #, python-format
 msgid "Add a %(link)s bot to send and receive messages to WeChat users for free. Your users will need an Android, Windows or iOS device and a WeChat account to send and receive messages."
@@ -5056,6 +5066,12 @@ msgstr "Incorporar"
 
 msgid "Add a snippet like the following to your website to embed the chat widget (coming soon)."
 msgstr "Adicione um trecho como o seguinte ao seu site para incorporar o widget de chat (em breve)."
+
+msgid "Only websites on the following domains can embed this channel's chat widget. This can be changed in the channel settings."
+msgstr "Apenas os sites nos seguintes domínios podem incorporar o widget de chat deste canal. Isso pode ser alterado nas configurações do canal."
+
+msgid "Currently any website can embed this channel's chat widget. Setting allowed domains in the channel settings stops other websites from embedding it."
+msgstr "Atualmente qualquer site pode incorporar o widget de chat deste canal. Definir domínios permitidos nas configurações do canal impede que outros sites o incorporem."
 
 msgid "You can connect your WhatsApp number by clicking on it below."
 msgstr "Você pode conectar o seu número do WhatsApp clicando nele abaixo."

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
 from temba.api.websockets.views import SUBSCRIPTION_TTL
+from temba.channels.types.webchat.views import CONFIG_ALLOWED_DOMAINS
 from temba.orgs.models import OrgRole
 from temba.tests import TembaTest
 from temba.tickets.models import Team, Topic
@@ -450,6 +451,66 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.login(self.admin)
         assertAllowed(socket)
 
+    def test_subscribe_chat_allowed_domains(self):
+        # a webchat channel and visitor, as in test_subscribe_chat
+        chat_id = "65vbbDAQCdPdEWlEhDGy4utO"
+        channel = self.create_channel("WCH", "WebChat", "wch1")
+        contact = self.create_contact("Vic", urns=[f"webchat:{chat_id}"])
+        contact.urns.update(channel=channel)
+
+        socket = f"chat:{channel.uuid}:{chat_id}"
+
+        def assertAllowed(origin=None):
+            response = self.post("api.websockets.subscribe", {"channel": socket, "client": "conn-1"}, origin=origin)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        def assertForbidden(origin=None):
+            response = self.post("api.websockets.subscribe", {"channel": socket, "client": "conn-1"}, origin=origin)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+
+        # a channel without allowed_domains is unrestricted - any forwarded origin, or none at all, is allowed
+        assertAllowed()
+        assertAllowed(origin="https://anywhere.example.com")
+
+        # pin the channel to its operator's websites
+        channel.config[CONFIG_ALLOWED_DOMAINS] = ["widgets.example.com", "example.com:8080"]
+        channel.save(update_fields=("config",))
+
+        # a forwarded origin's host[:port] must now match an entry, case-insensitively
+        assertAllowed(origin="https://widgets.example.com")
+        assertAllowed(origin="http://Widgets.Example.COM")
+        assertAllowed(origin="http://example.com:8080")
+
+        assertForbidden(origin="https://attacker.example.com")
+        assertForbidden(origin="https://example.com")  # an entry's port must be present in the origin
+        assertForbidden(origin="https://widgets.example.com:8080")  # and an origin's port in the entry
+        assertForbidden(origin="https://wwidgets.example.com")  # matching is exact, not by suffix
+        assertForbidden(origin="null")  # an opaque origin can't match
+        assertForbidden(origin="https://[")  # nor an unparseable one
+
+        # but a request without a forwarded Origin (a non-browser client, or a proxy config that doesn't forward it)
+        # is still allowed - possession of the chat-id remains the credential
+        assertAllowed()
+
+        # sub_refresh applies the same check, so adding domains tears down non-matching subscriptions
+        response = self.post(
+            "api.websockets.sub_refresh",
+            {"channel": socket, "client": "conn-1"},
+            origin="https://attacker.example.com",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+        response = self.post(
+            "api.websockets.sub_refresh",
+            {"channel": socket, "client": "conn-1"},
+            origin="https://widgets.example.com",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
+
     @override_settings(ALLOWED_HOSTS=["testserver", ".rapidpro.io"])
     def test_subscribe_origin(self):
         contact = self.create_contact("Ann", phone="+1234", org=self.org)
@@ -486,7 +547,9 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual(200, response.status_code)
         self.assertEqual({"result": {"expired": True}}, response.json())
 
-        # chat sockets are capability-based and origin-agnostic - webchat widgets subscribe from arbitrary sites
+        # chat sockets are capability-based and exempt from the session-identity origin check - webchat widgets
+        # subscribe from arbitrary sites unless the channel itself pins embedding to its operator's domains (see
+        # test_subscribe_chat_allowed_domains)
         response = subscribe(f"chat:{channel.uuid}:{chat_id}", "https://attacker.example.com")
         self.assertEqual(200, response.status_code)
         self.assertExpiry(response.json()["result"]["expire_at"])

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -17,8 +17,10 @@ SECRET = "topsecret"
 
 @override_settings(WEBSOCKETS_AUTH_SECRET=SECRET)
 class EndpointsTest(APITestMixin, TembaTest):
-    def post(self, name, data=None, *, client=None, secret=SECRET):
+    def post(self, name, data=None, *, client=None, secret=SECRET, origin=None):
         headers = {"HTTP_X_WEBSOCKETS_SECRET": secret} if secret is not None else {}
+        if origin is not None:  # the realtime server forwarding the browser's Origin header
+            headers["HTTP_ORIGIN"] = origin
         return (client or self.client).post(reverse(name), data or {}, content_type="application/json", **headers)
 
     def assertExpiry(self, expire_at):
@@ -100,6 +102,42 @@ class EndpointsTest(APITestMixin, TembaTest):
             },
         )
 
+    @override_settings(ALLOWED_HOSTS=["testserver", ".rapidpro.io"])
+    def test_connect_origin(self):
+        admin_meta = {
+            "user_id": self.admin.id,
+            "user_uuid": str(self.admin.uuid),
+            "org_id": self.org.id,
+            "org_uuid": str(self.org.uuid),
+        }
+
+        self.login(self.admin)
+
+        # a session connecting from an origin the deployment itself serves (wildcard entries included, so whitelabel
+        # domains pass) gets its full identity
+        self.assertConnect(
+            self.post("api.websockets.connect", origin="https://app.rapidpro.io"), user=self.admin, meta=admin_meta
+        )
+
+        # as does one with no Origin header at all - a non-browser client, or a proxy config that doesn't forward it
+        self.assertConnect(self.post("api.websockets.connect"), user=self.admin, meta=admin_meta)
+
+        # but a session presented from a foreign origin is refused its identity - the connection is accepted as
+        # anonymous instead, and the downgrade is warned about since it's either an attack or a misconfiguration
+        with self.assertLogs("temba.api.websockets.views", level="WARNING") as logs:
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="https://attacker.example.com"))
+        self.assertIn("foreign origin https://attacker.example.com", logs.output[0])
+
+        # an opaque or unparseable origin is foreign too
+        with self.assertLogs("temba.api.websockets.views", level="WARNING"):
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="null"))
+
+        # anonymous connections are origin-agnostic - webchat widgets connect from arbitrary sites by design - and
+        # nothing is downgraded, so nothing is warned about
+        self.client.logout()
+        with self.assertNoLogs("temba.api.websockets.views", level="WARNING"):
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="https://attacker.example.com"))
+
     def test_refresh(self):
         # a still-authenticated connection with a current workspace is extended with a new expiry
         self.login(self.admin)
@@ -118,6 +156,23 @@ class EndpointsTest(APITestMixin, TembaTest):
         # a connection whose session is gone is told it has expired, which tears the connection down
         self.client.logout()
         response = self.post("api.websockets.refresh")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+    @override_settings(ALLOWED_HOSTS=["testserver", ".rapidpro.io"])
+    def test_refresh_origin(self):
+        self.login(self.admin)
+
+        # a refresh from an origin the deployment serves, or with no Origin header, extends the connection as before
+        for origin in ("https://app.rapidpro.io", None):
+            response = self.post("api.websockets.refresh", origin=origin)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        # but a foreign origin gets no session identity, so the connection expires rather than persisting - even one
+        # that authenticated at connect (e.g. under a config that didn't yet forward the Origin header)
+        with self.assertLogs("temba.api.websockets.views", level="WARNING"):
+            response = self.post("api.websockets.refresh", origin="https://attacker.example.com")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"result": {"expired": True}}, response.json())
 
@@ -394,6 +449,47 @@ class EndpointsTest(APITestMixin, TembaTest):
         # being logged in doesn't get in the way of chat authorization - it never touches the session
         self.login(self.admin)
         assertAllowed(socket)
+
+    @override_settings(ALLOWED_HOSTS=["testserver", ".rapidpro.io"])
+    def test_subscribe_origin(self):
+        contact = self.create_contact("Ann", phone="+1234", org=self.org)
+
+        # a webchat channel and visitor, as in test_subscribe_chat
+        chat_id = "65vbbDAQCdPdEWlEhDGy4utO"
+        channel = self.create_channel("WCH", "WebChat", "wch1")
+        chat_contact = self.create_contact("Vic", urns=[f"webchat:{chat_id}"])
+        chat_contact.urns.update(channel=channel)
+
+        def subscribe(socket, origin):
+            return self.post("api.websockets.subscribe", {"channel": socket, "client": "conn-1"}, origin=origin)
+
+        self.login(self.admin)
+
+        # a session subscribing from an origin the deployment serves, or with no Origin header, is authorized as usual
+        for origin in ("https://app.rapidpro.io", None):
+            response = subscribe(f"history:{contact.uuid}", origin)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        # but a foreign-origin request gets no session identity here either - a page the connect proxy would only
+        # accept as anonymous can't reach session-based sockets by subscribing with the same forwarded cookie
+        response = subscribe(f"history:{contact.uuid}", "https://attacker.example.com")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+
+        # and sub_refresh applies the same rule, so such a subscription expires rather than being re-armed
+        response = self.post(
+            "api.websockets.sub_refresh",
+            {"channel": f"history:{contact.uuid}", "client": "conn-1"},
+            origin="https://attacker.example.com",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+        # chat sockets are capability-based and origin-agnostic - webchat widgets subscribe from arbitrary sites
+        response = subscribe(f"chat:{channel.uuid}:{chat_id}", "https://attacker.example.com")
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
 
     def test_subscribe_ticket_topic_access(self):
         # an agent restricted to a team's topics can only watch the history of tickets they're allowed to view - the

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -131,6 +131,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         # an opaque or unparseable origin is foreign too
         with self.assertLogs("temba.api.websockets.views", level="WARNING"):
             self.assertAnonymousConnect(self.post("api.websockets.connect", origin="null"))
+        with self.assertLogs("temba.api.websockets.views", level="WARNING"):
+            self.assertAnonymousConnect(self.post("api.websockets.connect", origin="https://[invalid"))
 
         # anonymous connections are origin-agnostic - webchat widgets connect from arbitrary sites by design - and
         # nothing is downgraded, so nothing is warned about

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -7,7 +7,9 @@ forwarded session cookie - accepting connections that don't resolve to a user as
 periodically re-validates authenticated connections. The ``subscribe`` and ``sub_refresh`` proxies then authorize
 individual socket subscriptions: most sockets against the live Django session, but webchat ``chat`` sockets by
 capability - the socket name embeds a secret chat-id, so possession of the name is the credential and anonymous
-visitors can subscribe to (only) their own chat.
+visitors can subscribe to (only) their own chat. A webchat channel configured with ``allowed_domains`` additionally
+pins browser embedding to its operator's own sites: the forwarded ``Origin`` of a chat subscription must then match
+one of those domains.
 
 Because the realtime server forwards the browser's session cookie, these cookie-authenticated calls are a CSRF
 surface: a WebSocket opened by any page the browser user happens to visit would otherwise ride their session. Two
@@ -47,6 +49,7 @@ from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 
 from temba.channels.models import Channel
+from temba.channels.types.webchat.views import CONFIG_ALLOWED_DOMAINS
 from temba.contacts.models import URN
 from temba.tickets.models import Ticket
 
@@ -269,7 +272,8 @@ class SubscriptionEndpoint(BaseEndpoint):
         foreign origin - a request the connect proxy would refuse session identity must be refused session-based
         sockets here too, or a third-party page could bypass the connect-time downgrade by subscribing with the same
         forwarded cookie (see module docs) - so their handlers are never reached by an anonymous or foreign-origin
-        request. The capability-based chat route never touches the session and so has no origin restrictions.
+        request. The capability-based chat route never touches the session and so is exempt from the session-identity
+        origin check - though the chat handler applies its own per-channel origin restriction (``allowed_domains``).
         """
         if not isinstance(socket, str):  # malformed payload (e.g. a non-string socket) is just a denial, not a 500
             return False
@@ -345,10 +349,27 @@ class SubscriptionEndpoint(BaseEndpoint):
         with that chat-id exists on that channel for an active contact - and a URN always shares its channel's org, so
         this also scopes the chat to the channel's own workspace. Requiring an active contact means releasing a
         contact closes their chat immediately, rather than only once their URNs are actually purged.
+
+        On top of that credential, a channel configured with ``allowed_domains`` is pinned to its operator's own
+        websites: if the request carries a browser ``Origin`` header (forwarded from the WebSocket handshake by the
+        realtime server), its host[:port] must match one of the configured entries or the subscription is denied -
+        the same restriction courier applies on its webchat HTTP endpoints. An absent header (a non-browser client,
+        or a proxy config that doesn't forward it) or an empty config allows as before.
         """
         channel = Channel.objects.filter(uuid=channel_uuid, channel_type="WCH", is_active=True).first()
         if not channel:
             return False
+
+        allowed_domains = channel.config.get(CONFIG_ALLOWED_DOMAINS) or []
+        origin = request.headers.get("Origin", "")
+        if allowed_domains and origin:
+            try:
+                host = urlsplit(origin).netloc.lower()  # an origin's netloc is exactly its host[:port]
+            except ValueError:
+                return False
+
+            if host not in [d.lower() for d in allowed_domains]:
+                return False
 
         return channel.urns.filter(scheme=URN.WEBCHAT_SCHEME, path=chat_id, contact__is_active=True).exists()
 

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -9,6 +9,18 @@ individual socket subscriptions: most sockets against the live Django session, b
 capability - the socket name embeds a secret chat-id, so possession of the name is the credential and anonymous
 visitors can subscribe to (only) their own chat.
 
+Because the realtime server forwards the browser's session cookie, these cookie-authenticated calls are a CSRF
+surface: a WebSocket opened by any page the browser user happens to visit would otherwise ride their session. Two
+independent layers prevent that. First, the session cookie is ``SameSite=Lax`` (the Django default), so modern
+browsers never attach it to a cross-site WebSocket handshake. Second, the realtime server forwards the browser's
+``Origin`` header, and a request that resolves to an authenticated session but originates from a host this
+deployment doesn't itself serve (judged against ``ALLOWED_HOSTS``, so whitelabel domains pass) is stripped of that
+identity: connect accepts the connection as anonymous, refresh expires it, and the subscription proxies deny its
+session-based sockets. Together these mean the realtime server's own allowed-origins whitelist can be relaxed - so
+webchat widgets can connect from arbitrary third-party sites - without those pages being able to borrow a
+visitor's session. A request with no ``Origin`` header at all (a non-browser client, or a proxy config that
+doesn't forward it) is treated as before.
+
 Unlike the rest of the internal API (``/api/internal/``), which is called by the editor running in the user's
 browser and so *must* be reachable from the public internet, every endpoint here is only ever called by the
 realtime messaging server from inside our own network. That means this API can be made truly internal: serve
@@ -19,7 +31,9 @@ isn't the realtime server even if the path is ever reachable - but the secret is
 API off the public internet.
 """
 
+import logging
 import re
+from urllib.parse import urlsplit
 
 from django_valkey import get_valkey_connection
 from rest_framework.permissions import BasePermission
@@ -28,6 +42,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from django.conf import settings
+from django.http.request import validate_host
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 
@@ -36,6 +51,8 @@ from temba.contacts.models import URN
 from temba.tickets.models import Ticket
 
 from ..support import APISessionAuthentication
+
+logger = logging.getLogger(__name__)
 
 # how long (seconds) a connection stays valid before the realtime server must re-validate it via the refresh proxy
 CONNECTION_TTL = 5 * 60
@@ -55,7 +72,9 @@ SUBSCRIPTION_TTL = 150
 class WebSocketsSessionAuthentication(APISessionAuthentication):
     """
     Session auth for the server-to-server proxy calls. The realtime server forwards the browser's session cookie but
-    can't present a CSRF token, so we no-op the CSRF check. Identity still comes from the real, signed session cookie.
+    can't present a CSRF token, so we no-op the CSRF check. Identity still comes from the real, signed session cookie,
+    and cross-origin protection comes from the cookie's ``SameSite`` policy plus the forwarded-Origin check the
+    endpoints apply (see module docs).
     """
 
     def enforce_csrf(self, request):
@@ -87,6 +106,30 @@ class BaseEndpoint(APIView):
         """Unix time at which the connection should next be re-validated by the refresh proxy."""
         return int(timezone.now().timestamp()) + CONNECTION_TTL
 
+    def is_foreign_origin(self, request) -> bool:
+        """
+        Whether the request carries a forwarded browser ``Origin`` header whose host isn't one this deployment itself
+        serves. A foreign-origin request must never be granted session identity (see module docs). Origins are judged
+        against ``ALLOWED_HOSTS`` - the same configuration that already defines which hosts the deployment answers
+        for, wildcard entries included - so whitelabel domains pass without a separate list. An absent header (a
+        non-browser client, or a proxy config that doesn't forward it) is not foreign; an unparseable or opaque one
+        (e.g. ``null``) is.
+        """
+        origin = request.headers.get("Origin", "")
+        if not origin:
+            return False
+
+        try:
+            host = urlsplit(origin).hostname
+        except ValueError:
+            host = None
+
+        allowed_hosts = settings.ALLOWED_HOSTS
+        if settings.DEBUG and not allowed_hosts:  # mirror the dev fallback Django's own host validation uses
+            allowed_hosts = [".localhost", "127.0.0.1", "[::1]"]
+
+        return not (host and validate_host(host, allowed_hosts))
+
 
 class ConnectEndpoint(BaseEndpoint):
     """
@@ -108,6 +151,11 @@ class ConnectEndpoint(BaseEndpoint):
     for it - there's no session state to re-validate at the connection level. Anonymous connections exist for webchat
     visitors: the subscribe proxy authorizes their ``chat`` sockets by capability - the socket name embeds a secret
     chat-id - and denies them every session-based socket.
+
+    A connection that *does* resolve to a session but arrives from a foreign origin - a forwarded browser ``Origin``
+    header for a host this deployment doesn't serve - is also accepted as anonymous rather than being granted the
+    session's identity: a third-party page must never be able to ride a visitor's session (see module docs).
+    Anonymous connections are origin-agnostic - webchat widgets connect from arbitrary sites by design.
     """
 
     def post(self, request, *args, **kwargs):
@@ -115,6 +163,15 @@ class ConnectEndpoint(BaseEndpoint):
 
         # a connection that doesn't resolve to an authenticated user with a current workspace is anonymous
         if not user.is_authenticated or not request.org:
+            return Response({"result": {"user": "", "channels": [], "meta": {}}})
+
+        # so is one that resolves to a session but comes from an origin we don't serve - it gets no session identity.
+        # That's either a third-party page trying to ride the session or a misconfigured origin, so warn.
+        if self.is_foreign_origin(request):
+            logger.warning(
+                "websockets connect downgraded to anonymous: session presented from foreign origin %s",
+                request.headers.get("Origin"),
+            )
             return Response({"result": {"user": "", "channels": [], "meta": {}}})
 
         org = request.org
@@ -129,15 +186,26 @@ class RefreshEndpoint(BaseEndpoint):
     """
     Refresh proxy called periodically by the realtime messaging server before a connection's ``expire_at``. Only
     authenticated connections get an ``expire_at`` from connect, so this is never called for anonymous connections. We
-    re-check that the connection is still valid - the user is still logged in and still has a current workspace,
-    matching what ``connect`` requires of an authenticated connection - and either extend it with a new ``expire_at``
-    or let it expire. This is how a logout, session expiry, or losing access to the workspace eventually tears down
-    the WebSocket.
+    re-check that the connection is still valid - the user is still logged in, still has a current workspace, and the
+    connection's forwarded ``Origin`` (if any) is still one we serve, matching what ``connect`` requires of an
+    authenticated connection - and either extend it with a new ``expire_at`` or let it expire. This is how a logout,
+    session expiry, or losing access to the workspace eventually tears down the WebSocket - and a foreign-origin
+    refresh expires the connection too, so an authenticated connection can't outlive a tightening of the origin rules
+    that would refuse it identity today.
     """
 
     def post(self, request, *args, **kwargs):
         # mirror connect: a connection is only kept alive while it has an authenticated user with a current workspace
         if not request.user.is_authenticated or not request.org:
+            return Response({"result": {"expired": True}})
+
+        # and, as at connect, a foreign origin gets no session identity - without it the connection can't stay
+        # authenticated, so it expires
+        if self.is_foreign_origin(request):
+            logger.warning(
+                "websockets connection expired: session presented from foreign origin %s",
+                request.headers.get("Origin"),
+            )
             return Response({"result": {"expired": True}})
 
         return Response({"result": {"expire_at": self.expire_at()}})
@@ -197,8 +265,11 @@ class SubscriptionEndpoint(BaseEndpoint):
         """
         Default-deny authorization of a client-requested socket, routed by matching the socket name against
         ``SOCKET_ROUTES`` - so adding a new socket type later is one route and one handler. Session-based routes are
-        denied outright unless the request has an authenticated user with a current workspace, so their handlers are
-        never reached by an anonymous request.
+        denied outright unless the request has an authenticated user with a current workspace *and* isn't from a
+        foreign origin - a request the connect proxy would refuse session identity must be refused session-based
+        sockets here too, or a third-party page could bypass the connect-time downgrade by subscribing with the same
+        forwarded cookie (see module docs) - so their handlers are never reached by an anonymous or foreign-origin
+        request. The capability-based chat route never touches the session and so has no origin restrictions.
         """
         if not isinstance(socket, str):  # malformed payload (e.g. a non-string socket) is just a denial, not a 500
             return False
@@ -206,7 +277,9 @@ class SubscriptionEndpoint(BaseEndpoint):
         for pattern, handler, session_based in self.SOCKET_ROUTES:
             match = pattern.fullmatch(socket)  # unlike $ anchoring, fullmatch won't tolerate a trailing newline
             if match:
-                if session_based and (not request.user.is_authenticated or not request.org):
+                if session_based and (
+                    not request.user.is_authenticated or not request.org or self.is_foreign_origin(request)
+                ):
                     return False
 
                 return getattr(self, handler)(request, **match.groupdict())

--- a/temba/channels/types/webchat/tests.py
+++ b/temba/channels/types/webchat/tests.py
@@ -82,8 +82,16 @@ class WebChatTypeTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(config_url)
         self.assertContains(response, "example.com, www.example.com:8080")
 
-        # entries with schemes, paths or other invalid characters are rejected
-        for invalid in ("https://example.com", "example.com/chat", "example com", "example.com:port", "-example.com"):
+        # entries with schemes, paths, other invalid characters or out-of-range ports are rejected
+        for invalid in (
+            "https://example.com",
+            "example.com/chat",
+            "example com",
+            "example.com:port",
+            "-example.com",
+            "example.com:0",
+            "example.com:99999",
+        ):
             self.assertUpdateSubmit(
                 update_url,
                 self.admin,

--- a/temba/channels/types/webchat/tests.py
+++ b/temba/channels/types/webchat/tests.py
@@ -1,10 +1,12 @@
 from django.urls import reverse
 
 from temba.channels.models import Channel
-from temba.tests import TembaTest
+from temba.tests import CRUDLTestMixin, TembaTest
+
+from .views import CONFIG_ALLOWED_DOMAINS
 
 
-class WebChatTypeTest(TembaTest):
+class WebChatTypeTest(CRUDLTestMixin, TembaTest):
     def test_claim(self):
         claim_url = reverse("channels.types.webchat.claim")
 
@@ -37,3 +39,64 @@ class WebChatTypeTest(TembaTest):
         # config page shows the channel UUID that the embedded widget connects with
         response = self.client.get(reverse("channels.channel_configuration", args=[channel.uuid]))
         self.assertContains(response, str(channel.uuid))
+
+        # and explains that without allowed domains, any website can embed the widget
+        self.assertContains(response, "any website can embed")
+
+    def test_update(self):
+        channel = self.create_channel("WCH", "WebChat", "123")
+        update_url = reverse("channels.channel_update", args=[channel.id])
+        config_url = reverse("channels.channel_configuration", args=[channel.uuid])
+
+        self.assertRequestDisallowed(update_url, [None, self.agent, self.admin2])
+        self.assertUpdateFetch(
+            update_url,
+            [self.editor, self.admin],
+            form_fields={"name": "WebChat", "is_enabled": True, "allowed_domains": ""},
+        )
+
+        # domains can be one per line or comma separated, and are normalized to lowercase host[:port] entries with
+        # blanks and duplicates dropped
+        self.assertUpdateSubmit(
+            update_url,
+            self.admin,
+            {
+                "name": "WebChat",
+                "is_enabled": True,
+                "allowed_domains": "Example.com\n www.example.com:8080, example.com,\n",
+            },
+        )
+
+        channel.refresh_from_db()
+        self.assertEqual(["example.com", "www.example.com:8080"], channel.config.get(CONFIG_ALLOWED_DOMAINS))
+
+        # saved domains are shown back one per line
+        self.assertUpdateFetch(
+            update_url,
+            [self.admin],
+            form_fields={"name": "WebChat", "is_enabled": True, "allowed_domains": "example.com\nwww.example.com:8080"},
+        )
+
+        # and on the configuration page
+        self.login(self.admin)
+        response = self.client.get(config_url)
+        self.assertContains(response, "example.com, www.example.com:8080")
+
+        # entries with schemes, paths or other invalid characters are rejected
+        for invalid in ("https://example.com", "example.com/chat", "example com", "example.com:port", "-example.com"):
+            self.assertUpdateSubmit(
+                update_url,
+                self.admin,
+                {"name": "WebChat", "is_enabled": True, "allowed_domains": f"example.com\n{invalid}"},
+                form_errors={
+                    "allowed_domains": f"{invalid.lower()} is not a valid domain. "
+                    "Enter domains without schemes or paths, e.g. example.com."
+                },
+                object_unchanged=channel,
+            )
+
+        # clearing the field removes the restriction
+        self.assertUpdateSubmit(update_url, self.admin, {"name": "WebChat", "is_enabled": True, "allowed_domains": ""})
+
+        channel.refresh_from_db()
+        self.assertEqual([], channel.config.get(CONFIG_ALLOWED_DOMAINS))

--- a/temba/channels/types/webchat/type.py
+++ b/temba/channels/types/webchat/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.contacts.models import URN
 
 from ...models import ChannelType, ConfigUI
-from .views import ClaimView
+from .views import ClaimView, UpdateForm
 
 
 class WebChatType(ChannelType):
@@ -19,6 +19,8 @@ class WebChatType(ChannelType):
 
     claim_blurb = _("Chat with visitors on your website via an embedded chat widget.")
     claim_view = ClaimView
+
+    update_form = UpdateForm
 
     config_ui = ConfigUI()  # has own template
 

--- a/temba/channels/types/webchat/views.py
+++ b/temba/channels/types/webchat/views.py
@@ -1,7 +1,19 @@
+import re
+
 from smartmin.views import SmartFormView
 
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
 from temba.channels.models import Channel
-from temba.channels.views import ClaimViewMixin
+from temba.channels.views import ClaimViewMixin, UpdateChannelForm
+
+CONFIG_ALLOWED_DOMAINS = "allowed_domains"
+
+# a domain entry is a host - dot-separated alphanumeric labels which may contain hyphens - optionally followed by a
+# port, e.g. "example.com" or "localhost:3000" - never a scheme or path
+DOMAIN_REGEX = re.compile(r"[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*(:\d{1,5})?")
 
 
 class ClaimView(ClaimViewMixin, SmartFormView):
@@ -17,3 +29,35 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         )
 
         return super().form_valid(form)
+
+
+class UpdateForm(UpdateChannelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        field = forms.CharField(
+            label=_("Allowed Domains"),
+            required=False,
+            widget=forms.Textarea(attrs={"rows": 3}),
+            help_text=_(
+                "The domains of the websites that can embed this channel's chat widget, one per line or comma "
+                "separated, e.g. example.com or example.com:8080. If empty, any website can embed it."
+            ),
+        )
+        self.add_config_field(CONFIG_ALLOWED_DOMAINS, field, default=[])
+        field.initial = "\n".join(field.initial or [])
+
+    def clean_allowed_domains(self) -> list:
+        domains = []
+        for entry in re.split(r"[,\n]", self.cleaned_data[CONFIG_ALLOWED_DOMAINS]):
+            entry = entry.strip().lower()
+            if not entry:
+                continue
+            if not DOMAIN_REGEX.fullmatch(entry):
+                raise ValidationError(
+                    _("%(domain)s is not a valid domain. Enter domains without schemes or paths, e.g. example.com."),
+                    params={"domain": entry},
+                )
+            if entry not in domains:
+                domains.append(entry)
+        return domains

--- a/temba/channels/types/webchat/views.py
+++ b/temba/channels/types/webchat/views.py
@@ -12,8 +12,8 @@ from temba.channels.views import ClaimViewMixin, UpdateChannelForm
 CONFIG_ALLOWED_DOMAINS = "allowed_domains"
 
 # a domain entry is a host - dot-separated alphanumeric labels which may contain hyphens - optionally followed by a
-# port, e.g. "example.com" or "localhost:3000" - never a scheme or path
-DOMAIN_REGEX = re.compile(r"[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*(:\d{1,5})?")
+# port (whose 1-65535 range is checked separately), e.g. "example.com" or "localhost:3000" - never a scheme or path
+DOMAIN_REGEX = re.compile(r"[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*(:(?P<port>\d{1,5}))?")
 
 
 class ClaimView(ClaimViewMixin, SmartFormView):
@@ -53,7 +53,8 @@ class UpdateForm(UpdateChannelForm):
             entry = entry.strip().lower()
             if not entry:
                 continue
-            if not DOMAIN_REGEX.fullmatch(entry):
+            match = DOMAIN_REGEX.fullmatch(entry)
+            if not match or (match["port"] and not 1 <= int(match["port"]) <= 65535):
                 raise ValidationError(
                     _("%(domain)s is not a valid domain. Enter domains without schemes or paths, e.g. example.com."),
                     params={"domain": entry},

--- a/templates/channels/types/webchat/config.html
+++ b/templates/channels/types/webchat/config.html
@@ -23,3 +23,20 @@
     <div class="code p-0 break-all bg-black text-white">&lt;temba-webchat channel="{{ channel.uuid }}"&gt;&lt;/temba-webchat&gt;</div>
   </div>
 </div>
+<div class="mt-4 card">
+  <div class="subtitle">{% trans "Allowed Domains" %}</div>
+  <div class="mt-2">
+    {% if channel.config.allowed_domains %}
+      {% blocktrans trimmed %}
+        Only websites on the following domains can embed this channel's chat widget. This can be changed in the
+        channel settings.
+      {% endblocktrans %}
+      <div class="code inline-block mt-2">{{ channel.config.allowed_domains|join:", " }}</div>
+    {% else %}
+      {% blocktrans trimmed %}
+        Currently any website can embed this channel's chat widget. Setting allowed domains in the channel settings
+        stops other websites from embedding it.
+      {% endblocktrans %}
+    {% endif %}
+  </div>
+</div>


### PR DESCRIPTION
A WebChat channel can now be pinned to its operator's own websites via an `allowed_domains` list of `host[:port]` entries in its config. Possession of the secret chat-id remains the credential for a chat; `allowed_domains` additionally restricts which websites' pages can embed the channel's chat widget. Empty config stays the default and means unrestricted. Courier applies the same restriction on its webchat HTTP endpoints (separate PR).

### Changes

* **Channel settings UI**: the channel update form gains an *Allowed Domains* field (one domain per line or comma separated), normalized to deduplicated lowercase `host[:port]` entries. Entries with schemes, paths, invalid characters or out-of-range ports (outside 1-65535) are rejected. The channel's configuration page explains the setting - that it's what stops other websites embedding the channel's chat - and shows the current value.
* **Subscribe enforcement**: the websockets subscribe/sub_refresh proxies' chat handler now also checks the browser `Origin` header forwarded by the realtime server: if the channel has `allowed_domains` and an `Origin` is present, its `host[:port]` must match an entry (case-insensitively) or the subscription is denied. An absent header (a non-browser client, or a proxy config that doesn't yet forward it) or an empty config allows as before, and the handler stays session-free - docstrings describe the layering.
* New strings are translated for es/fr/pt_BR.

### Test plan

* `temba.channels.types.webchat` covers form validation, normalization, round-trip display and the configuration page blurb.
* `temba.api.websockets` covers the subscribe/sub_refresh matrix: unconfigured, matching (case-insensitive, with and without ports), non-matching, opaque (`null`) and unparseable origins, and absent header.