### PR TITLE
Use a test mailroom client that can't make real HTTP requests

### DIFF
--- a/temba/contacts/tests/test_contact.py
+++ b/temba/contacts/tests/test_contact.py
@@ -5,7 +5,6 @@ from uuid import UUID
 
 from django.db.models import Value as DbValue
 from django.db.models.functions import Concat, Substr
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -19,7 +18,7 @@ from temba.mailroom import modifiers
 from temba.msgs.models import Msg, MsgFolder
 from temba.orgs.models import Org
 from temba.schedules.models import Schedule
-from temba.tests import MockJsonResponse, TembaTest, cleanup, mock_mailroom
+from temba.tests import TembaTest, cleanup, mock_mailroom
 from temba.tests.engine import MockSessionWriter
 from temba.tickets.models import Ticket
 from temba.utils import dynamo
@@ -86,30 +85,29 @@ class ContactTest(TembaTest):
             mr_mocks.calls["contact_modify"],
         )
 
-    @override_settings(MAILROOM_URL="http://mailroom:8090")
-    @patch("requests.post")
-    def test_open_ticket(self, mock_post):
-        mock_post.return_value = MockJsonResponse(200, {"events": {str(self.joe.uuid): []}, "skipped": []})
+    @mock_mailroom
+    def test_open_ticket(self, mr_mocks):
+        ticket = self.joe.open_ticket(self.admin, topic=self.org.default_topic, assignee=self.agent, note="Looks sus")
 
-        self.joe.open_ticket(self.admin, topic=self.org.default_topic, assignee=self.agent, note="Looks sus")
-
-        mock_post.assert_called_once_with(
-            "http://mailroom:8090/mi/contact/modify",
-            headers={"User-Agent": "Temba"},
-            json={
-                "org_id": self.org.id,
-                "user_id": self.admin.id,
-                "contact_ids": [self.joe.id],
-                "modifiers": [
-                    {
-                        "type": "ticket",
-                        "topic": {"uuid": str(self.org.default_topic.uuid), "name": "General"},
-                        "assignee": {"uuid": str(self.agent.uuid), "name": "Agnes"},
-                        "note": "Looks sus",
-                    }
-                ],
-                "via": "ui",
-            },
+        self.assertEqual(self.org.default_topic, ticket.topic)
+        self.assertEqual(self.agent, ticket.assignee)
+        self.assertEqual(
+            [
+                call(
+                    self.org,
+                    self.admin,
+                    [self.joe],
+                    [
+                        modifiers.Ticket(
+                            topic=modifiers.TopicRef(uuid=str(self.org.default_topic.uuid), name="General"),
+                            assignee=modifiers.UserRef(uuid=str(self.agent.uuid), name="Agnes"),
+                            note="Looks sus",
+                        )
+                    ],
+                    "ui",
+                )
+            ],
+            mr_mocks.calls["contact_modify"],
         )
 
     @mock_mailroom

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -2203,7 +2203,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             export.config,
         )
 
-    def test_simulate(self):
+    @mock_mailroom
+    def test_simulate(self, mr_mocks):
         flow = self.create_flow("Test")
 
         payload = {
@@ -2215,101 +2216,79 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.login(self.admin)
         simulate_url = reverse("flows.flow_simulate", args=[flow.uuid])
 
-        with override_settings(MAILROOM_AUTH_TOKEN="sesame", MAILROOM_URL="https://mailroom.temba.io"):
-            with patch("requests.post") as mock_post:
-                mock_post.return_value = MockJsonResponse(400, {"session": {}})
-                response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
-                self.assertEqual(500, response.status_code)
+        # a mailroom error becomes a 500
+        mr_mocks.exception(mailroom.RequestException("sim/start", {}, MockJsonResponse(400, {"error": "boom"})))
 
-            # start a flow
-            with patch("requests.post") as mock_post:
-                mock_post.return_value = MockJsonResponse(200, {"session": {}})
-                response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
-                self.assertEqual(200, response.status_code)
-                self.assertEqual({}, response.json()["session"])
+        response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
+        self.assertEqual(500, response.status_code)
 
-                actual_url = mock_post.call_args_list[0][0][0]
-                actual_payload = json.loads(mock_post.call_args_list[0][1]["data"])
-                actual_headers = mock_post.call_args_list[0][1]["headers"]
+        # start a flow
+        response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, response.json()["session"])
 
-                self.assertEqual(actual_url, "https://mailroom.temba.io/mi/sim/start")
-                self.assertEqual(actual_payload["org_id"], flow.org_id)
-                self.assertEqual(
-                    {"type": "manual", "user": {"uuid": str(self.admin.uuid), "name": "Andy"}},
-                    actual_payload["trigger"],
-                )
-                self.assertEqual(len(actual_payload["assets"]["channels"]), 1)  # fake channel
-                self.assertEqual(actual_headers["Authorization"], "Token sesame")
-                self.assertEqual(actual_headers["Content-Type"], "application/json")
+        (sent,) = mr_mocks.calls["sim_start"][0].args
 
-            # try a resume
-            payload = {
-                "contact": {"uuid": "8ada55d2-2f5e-4d56-8f10-26971332cd1c", "fields": {"age": Decimal("39")}},
-                "session": {"uuid": "01979ebb-044a-7768-a0d0-0455ef356441", "status": "waiting"},
-                "resume": {},
-                "flow": {},
-            }
+        self.assertEqual(flow.org_id, sent["org_id"])
+        self.assertEqual({"uuid": "8ada55d2-2f5e-4d56-8f10-26971332cd1c"}, sent["contact"])
+        self.assertEqual({"type": "manual", "user": {"uuid": str(self.admin.uuid), "name": "Andy"}}, sent["trigger"])
+        self.assertEqual(1, len(sent["assets"]["channels"]))  # fake channel
 
-            with patch("requests.post") as mock_post:
-                mock_post.return_value = MockJsonResponse(400, {"session": {}})
-                response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
-                self.assertEqual(500, response.status_code)
+        # try a resume
+        payload = {
+            "contact": {"uuid": "8ada55d2-2f5e-4d56-8f10-26971332cd1c", "fields": {"age": Decimal("39")}},
+            "session": {"uuid": "01979ebb-044a-7768-a0d0-0455ef356441", "status": "waiting"},
+            "resume": {},
+            "flow": {},
+        }
 
-            with patch("requests.post") as mock_post:
-                mock_post.return_value = MockJsonResponse(200, {"session": {}})
-                response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
-                self.assertEqual(200, response.status_code)
-                self.assertEqual({}, response.json()["session"])
+        mr_mocks.exception(mailroom.RequestException("sim/resume", {}, MockJsonResponse(400, {"error": "boom"})))
 
-                actual_url = mock_post.call_args_list[0][0][0]
-                actual_payload = json.loads(mock_post.call_args_list[0][1]["data"])
-                actual_headers = mock_post.call_args_list[0][1]["headers"]
+        response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
+        self.assertEqual(500, response.status_code)
 
-                self.assertEqual(actual_url, "https://mailroom.temba.io/mi/sim/resume")
-                self.assertEqual(actual_payload["org_id"], flow.org_id)
-                self.assertEqual(len(actual_payload["assets"]["channels"]), 1)  # fake channel
-                self.assertEqual(actual_headers["Authorization"], "Token sesame")
-                self.assertEqual(actual_headers["Content-Type"], "application/json")
+        response = self.client.post(simulate_url, json.dumps(payload), content_type="application/json")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, response.json()["session"])
 
-    def test_simulate_voice(self):
+        (sent,) = mr_mocks.calls["sim_resume"][0].args
+
+        self.assertEqual(flow.org_id, sent["org_id"])
+        self.assertEqual({"uuid": "01979ebb-044a-7768-a0d0-0455ef356441", "status": "waiting"}, sent["session"])
+        self.assertEqual(1, len(sent["assets"]["channels"]))  # fake channel
+
+    @mock_mailroom
+    def test_simulate_voice(self, mr_mocks):
         flow = self.create_flow("Test", flow_type=Flow.TYPE_VOICE)
 
         self.login(self.admin)
         simulate_url = reverse("flows.flow_simulate", args=[flow.uuid])
 
-        with override_settings(MAILROOM_AUTH_TOKEN="sesame", MAILROOM_URL="https://mailroom.temba.io"):
-            with patch("requests.post") as mock_post:
-                mock_post.return_value = MockJsonResponse(200, {"session": {}})
-                response = self.client.post(
-                    simulate_url,
-                    {
-                        "contact": {"uuid": "8ada55d2-2f5e-4d56-8f10-26971332cd1c"},
-                        "trigger": {"type": "manual"},
-                        "flow": {},
-                    },
-                    content_type="application/json",
-                )
+        response = self.client.post(
+            simulate_url,
+            {
+                "contact": {"uuid": "8ada55d2-2f5e-4d56-8f10-26971332cd1c"},
+                "trigger": {"type": "manual"},
+                "flow": {},
+            },
+            content_type="application/json",
+        )
 
-                self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.json(), {"session": {}})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"session": {}, "events": []}, response.json())
 
-                # since this is an IVR flow, we need to include a call
-                payload = json.loads(mock_post.call_args[1]["data"])
-                self.assertEqual(
-                    {
-                        "uuid": "01979e0b-3072-7345-ae19-879750caaaf6",
-                        "channel": {"uuid": "440099cf-200c-4d45-a8e7-4a564f4a0e8b", "name": "Test Channel"},
-                        "urn": "tel:+12065551212",
-                    },
-                    payload["call"],
-                )
-                self.assertEqual(
-                    {
-                        "type": "manual",
-                        "user": {"uuid": str(self.admin.uuid), "name": "Andy"},
-                    },
-                    payload["trigger"],
-                )
+        (sent,) = mr_mocks.calls["sim_start"][0].args
+
+        # since this is an IVR flow, we need to include a call
+        self.assertEqual(
+            {
+                "uuid": "01979e0b-3072-7345-ae19-879750caaaf6",
+                "channel": {"uuid": "440099cf-200c-4d45-a8e7-4a564f4a0e8b", "name": "Test Channel"},
+                "urn": "tel:+12065551212",
+            },
+            sent["call"],
+        )
+        self.assertEqual({"type": "manual", "user": {"uuid": str(self.admin.uuid), "name": "Andy"}}, sent["trigger"])
 
     @mock_mailroom
     def test_delete(self, mr_mocks):

--- a/temba/mailroom/__init__.py
+++ b/temba/mailroom/__init__.py
@@ -7,4 +7,10 @@ from .client.types import *  # noqa
 def get_client():
     from .client.client import MailroomClient
 
-    return MailroomClient(settings.MAILROOM_URL, settings.MAILROOM_AUTH_TOKEN)
+    # tests use a client which fakes endpoints against the test database, so that no test can reach a live mailroom
+    if settings.TESTING:
+        from temba.tests.mailroom import TestClient
+
+        return TestClient()
+
+    return MailroomClient(settings.MAILROOM_URL, settings.MAILROOM_AUTH_TOKEN)  # pragma: no cover

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -2,9 +2,6 @@ import logging
 from dataclasses import asdict
 
 import requests
-from packaging.version import Version
-
-from django.conf import settings
 
 from temba.contacts.models import Contact
 from temba.flows.models import FlowStart
@@ -184,11 +181,7 @@ class MailroomClient:
         return self._request("flow/clone", {"flow": definition, "dependency_mapping": dependency_mapping})
 
     def flow_inspect(self, org, definition: dict, is_import=False):
-        payload = {"flow": definition, "is_import": is_import}
-
-        # can't do dependency checking during tests because mailroom can't see unit test data created in a transaction
-        if not settings.TESTING:
-            payload["org_id"] = org.id
+        payload = {"org_id": org.id, "flow": definition, "is_import": is_import}
 
         return self._request("flow/inspect", payload, encode_json=True)
 
@@ -203,14 +196,6 @@ class MailroomClient:
 
         if not to_version:  # pragma: no cover
             to_version = Flow.CURRENT_SPEC_VERSION
-
-        # in tests fixtures are kept at the current spec (see the migrate_bundled_flows command), so skip the HTTP
-        # round-trip when the definition is already at or beyond the target. in production we always defer to
-        # mailroom, which may apply newer patch migrations within the same version that this client isn't aware of.
-        if settings.TESTING:
-            current = definition.get("spec_version")
-            if current and Version(current) >= Version(to_version):
-                return definition
 
         return self._request("flow/migrate", {"flow": definition, "to_version": to_version}, encode_json=True)
 

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -2,8 +2,6 @@ from datetime import datetime, timezone as tzone
 from decimal import Decimal
 from unittest.mock import patch
 
-from django.test import override_settings
-
 from temba.ai.models import LLM
 from temba.ai.types.openai.type import OpenAIType
 from temba.campaigns.models import Campaign, CampaignEvent
@@ -339,6 +337,11 @@ class MailroomClientTest(TembaTest):
                     modification="add",
                 ),
                 modifiers.URNs(urns=["+tel+1234567890"], modification="append"),
+                modifiers.Ticket(
+                    topic=modifiers.TopicRef(uuid="7c2e0c6e-1ba1-4ba0-9a7f-5b1c1e0b0b0a", name="General"),
+                    assignee=modifiers.UserRef(uuid="a2c1d0b2-3f6e-4b1a-9c2d-8f5e4d3c2b1a", name="Agnes"),
+                    note="Looks sus",
+                ),
             ],
             "ui",
         )
@@ -361,6 +364,12 @@ class MailroomClientTest(TembaTest):
                         "modification": "add",
                     },
                     {"type": "urns", "urns": ["+tel+1234567890"], "modification": "append"},
+                    {
+                        "type": "ticket",
+                        "topic": {"uuid": "7c2e0c6e-1ba1-4ba0-9a7f-5b1c1e0b0b0a", "name": "General"},
+                        "assignee": {"uuid": "a2c1d0b2-3f6e-4b1a-9c2d-8f5e4d3c2b1a", "name": "Agnes"},
+                        "note": "Looks sus",
+                    },
                 ],
                 "via": "ui",
             },
@@ -485,7 +494,21 @@ class MailroomClientTest(TembaTest):
         )
         self.assertEqual({"flow": flow_def, "language": "spa"}, json.loads(call[1]["data"]))
 
-    @override_settings(TESTING=False)
+    def test_flow_clone(self):
+        flow_def = {"nodes": [{"uuid": "3f7e5e4f-4b0e-4b0e-4b0e-4b0e4b0e4b0e"}]}
+        mapping = {"3f7e5e4f-4b0e-4b0e-4b0e-4b0e4b0e4b0e": "b6d8b8e0-0e6e-4b0e-4b0e-4b0e4b0e4b0e"}
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockJsonResponse(200, {"nodes": []})
+
+            self.assertEqual({"nodes": []}, self.client.flow_clone(flow_def, mapping))
+
+        mock_post.assert_called_once_with(
+            "http://localhost:8090/mi/flow/clone",
+            headers={"User-Agent": "Temba", "Authorization": "Token sesame"},
+            json={"flow": flow_def, "dependency_mapping": mapping},
+        )
+
     def test_flow_inspect(self):
         flow_def = {"nodes": [{"val": Decimal("1.23")}]}
 
@@ -1003,6 +1026,40 @@ class MailroomClientTest(TembaTest):
             headers={"User-Agent": "Temba", "Authorization": "Token sesame"},
             json={"org_id": self.org.id},
         )
+
+    def test_sim_start(self):
+        payload = {"org_id": self.org.id, "contact": {"uuid": "8ada55d2-2f5e-4d56-8f10-26971332cd1c"}}
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockJsonResponse(200, {"session": {}, "events": []})
+
+            self.assertEqual({"session": {}, "events": []}, self.client.sim_start(payload))
+
+        call = mock_post.call_args
+
+        self.assertEqual(("http://localhost:8090/mi/sim/start",), call[0])
+        self.assertEqual(
+            {"User-Agent": "Temba", "Authorization": "Token sesame", "Content-Type": "application/json"},
+            call[1]["headers"],
+        )
+        self.assertEqual(payload, json.loads(call[1]["data"]))
+
+    def test_sim_resume(self):
+        payload = {"org_id": self.org.id, "session": {"uuid": "01979ebb-044a-7768-a0d0-0455ef356441"}, "resume": {}}
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockJsonResponse(200, {"session": {}, "events": []})
+
+            self.assertEqual({"session": {}, "events": []}, self.client.sim_resume(payload))
+
+        call = mock_post.call_args
+
+        self.assertEqual(("http://localhost:8090/mi/sim/resume",), call[0])
+        self.assertEqual(
+            {"User-Agent": "Temba", "Authorization": "Token sesame", "Content-Type": "application/json"},
+            call[1]["headers"],
+        )
+        self.assertEqual(payload, json.loads(call[1]["data"]))
 
     @patch("requests.post")
     def test_ticket_add_note(self, mock_post):

--- a/temba/mailroom/tests/test_mocks.py
+++ b/temba/mailroom/tests/test_mocks.py
@@ -2,7 +2,16 @@ import copy
 
 from django.test import SimpleTestCase
 
-from temba.tests.mailroom import clone_flow_definition, inspect_flow
+from temba import mailroom
+from temba.tests import TembaTest
+from temba.tests.mailroom import LiveMailroomError, clone_flow_definition, inspect_flow
+
+
+class TestClientTest(TembaTest):
+    def test_unfaked_endpoint(self):
+        # any endpoint the test client doesn't fake would be an HTTP call to a live mailroom, so fail loudly
+        with self.assertRaises(LiveMailroomError):
+            mailroom.get_client().msg_handle(self.org, [])
 
 
 class InspectFlowTest(SimpleTestCase):

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -39,12 +39,13 @@ from temba.utils.uuid import UUID, uuid4, uuid7
 
 from .dynamo import dynamo_truncate
 from .mailroom import (
+    Mocks,
     contact_urn_lookup,
     create_broadcast,
     create_contact_locally,
     create_flowstart,
-    install_mailroom_guard,
     resolve_destination,
+    set_mocks,
     update_field_locally,
 )
 
@@ -116,8 +117,11 @@ class TembaTest(SmartminTest):
     def setUp(self):
         super().setUp()
 
-        # fail loudly if a test reaches a live mailroom instead of mocking it
-        install_mailroom_guard(self)
+        # every test gets a mocked mailroom client (see temba.mailroom.get_client) using these mocks, which tests
+        # can access as mr_mocks by decorating themselves with @mock_mailroom
+        self.mr_mocks = Mocks()
+        set_mocks(self.mr_mocks)
+        self.addCleanup(set_mocks, None)
 
         # OrgRole.group and OrgRole.permissions are cached properties so get those cached before test starts to avoid
         # query count differences when a test is first to request it and when it's not.

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -5,9 +5,7 @@ from collections import defaultdict
 from dataclasses import asdict
 from decimal import Decimal
 from functools import wraps
-from unittest.mock import NonCallableMock, call, patch
-
-import requests
+from unittest.mock import call
 
 from django.conf import settings
 from django.db import connection
@@ -34,8 +32,6 @@ event_units = {
     CampaignEvent.UNIT_DAYS: "days",
     CampaignEvent.UNIT_WEEKS: "weeks",
 }
-
-_real_mailroom_request = MailroomClient._request
 
 
 def clone_flow_definition(definition: dict, dependency_mapping: dict) -> dict:
@@ -100,9 +96,8 @@ def _snakify(text: str) -> str:
 
 def inspect_flow(definition: dict) -> dict:
     """
-    Pragmatic Python stand-in for goflow's flow inspection (flows/inspect), used to fake flow/inspect for the
-    production client during tests instead of reaching a live mailroom. It reproduces the two parts of the
-    analysis that rapidpro consumes or asserts on:
+    Pragmatic Python stand-in for goflow's flow inspection (flows/inspect), used by TestClient to fake
+    flow/inspect during tests. It reproduces the two parts of the analysis that rapidpro consumes or asserts on:
 
       - dependencies: the typed asset references that goflow's actions/routers enumerate, plus the field/global
         references in expressions (used by Flow.save_revision / Flow.import_definition to wire up dependencies)
@@ -110,10 +105,9 @@ def inspect_flow(definition: dict) -> dict:
         via the API/editor)
 
     It is deliberately not a full port: goflow's issue analysis, structural validation, counts and locals aren't
-    reproduced. A test that needs those uses @mock_mailroom and stubs mr_mocks.flow_inspect (or, for validation
-    errors, mr_mocks.exception). During tests mailroom inspects without session assets (flow_inspect omits org_id
-    when settings.TESTING), so every dependency is missing=False and no asset-availability issues fire - matching
-    the empty issues we return here.
+    reproduced. A test that needs those stubs mr_mocks.flow_inspect (or, for validation errors, mr_mocks.exception)
+    instead. Every dependency comes back missing=False and no issues are reported, since we don't resolve the
+    references we find against the org's actual assets.
     """
 
     deps = []
@@ -196,40 +190,18 @@ class LiveMailroomError(BaseException):
     """
 
 
-def _guarded_mailroom_request(self, endpoint, payload=None, post=True, encode_json=False):
-    # a patched transport (e.g. patch("requests.post")) means no real network call happens - that's how the
-    # MailroomClient's own request-construction tests work, so let those through to the real _request. this only
-    # detects Mock-based patches; patch("requests.post", new=<plain callable>) would slip past, but that form
-    # isn't used against requests here.
-    transport = requests.post if post else requests.get
-    if isinstance(transport, NonCallableMock):
-        return _real_mailroom_request(self, endpoint, payload=payload, post=post, encode_json=encode_json)
-
-    # flow/clone and flow/inspect are reached by undecorated import/save tests via the production client; both are
-    # faked from the request payload (see clone_flow_definition / inspect_flow) rather than reaching a live
-    # mailroom. @mock_mailroom tests don't get here - TestClient overrides the high-level client methods.
-    if endpoint == "flow/clone":
-        return clone_flow_definition(payload["flow"], payload["dependency_mapping"])
-    if endpoint == "flow/inspect":
-        return inspect_flow(payload["flow"])
-
-    # any other endpoint reaching here is an un-mocked live mailroom call - fail loudly
-    raise LiveMailroomError(
-        f"test reached live mailroom endpoint /mi/{endpoint}; decorate the test with @mock_mailroom "
-        f"(adding a TestClient fake if needed) or mock the call"
-    )
+_current_mocks = None
 
 
-def install_mailroom_guard(test):
+def set_mocks(mocks):
     """
-    Makes any un-mocked call to a live mailroom fail loudly. Patches MailroomClient._request, which covers both
-    the production client and the TestClient used by @mock_mailroom (TestClient fakes most endpoints above this
-    layer, so only un-faked ones reach here).
+    Sets the mocks that the test client returned by mailroom.get_client() will use. Called by TembaTest.setUp so
+    that every test gets its own.
     """
 
-    patcher = patch.object(MailroomClient, "_request", _guarded_mailroom_request)
-    patcher.start()
-    test.addCleanup(patcher.stop)
+    global _current_mocks
+
+    _current_mocks = mocks
 
 
 def mock_inspect_query(org, query: str, fields=None) -> mailroom.QueryMetadata:
@@ -365,10 +337,22 @@ def _client_method(func):
 
 
 class TestClient(MailroomClient):
-    def __init__(self, mocks: Mocks):
-        self.mocks = mocks
+    """
+    The client that mailroom.get_client() returns during tests. It fakes mailroom endpoints against the test
+    database, and any endpoint it doesn't fake fails loudly rather than reaching a live mailroom.
+    """
+
+    def __init__(self):
+        # tests get their mocks from TembaTest.setUp - anything else (e.g. a SimpleTestCase) gets an empty set
+        self.mocks = _current_mocks or Mocks()
 
         super().__init__(settings.MAILROOM_URL, settings.MAILROOM_AUTH_TOKEN)
+
+    def _request(self, endpoint, payload=None, post=True, encode_json=False):
+        # reaching here means a client method we haven't faked above, which in production would be an HTTP call
+        raise LiveMailroomError(
+            f"test reached un-faked mailroom endpoint /mi/{endpoint}; add a fake for it to TestClient"
+        )
 
     @_client_method
     def android_event(self, org, channel, phone: str, event_type: str, extra: dict, occurred_on):
@@ -562,14 +546,7 @@ class TestClient(MailroomClient):
         if self.mocks._flow_inspect:
             return self.mocks._flow_inspect.pop(0)
 
-        return {
-            "dependencies": [],
-            "issues": [],
-            "results": [],
-            "parent_refs": [],
-            "counts": {},
-            "locals": [],
-        }
+        return inspect_flow(definition)
 
     @_client_method
     def flow_interrupt(self, org, flow):
@@ -717,6 +694,14 @@ class TestClient(MailroomClient):
         return {}
 
     @_client_method
+    def sim_start(self, payload: dict):
+        return {"session": {}, "events": []}
+
+    @_client_method
+    def sim_resume(self, payload: dict):
+        return {"session": {}, "events": []}
+
+    @_client_method
     def ticket_add_note(self, org, user, tickets, note: str, via: str):
         now = timezone.now()
         tickets = list(Ticket.objects.filter(org=org, id__in=[t.id for t in tickets]))
@@ -779,32 +764,18 @@ class TestClient(MailroomClient):
 
 def mock_mailroom(method=None):
     """
-    Convenience decorator to make a test method use a mocked version of the mailroom client
+    Convenience decorator which passes the test's mailroom mocks to the test method. The mocked client itself is
+    installed for every test (see TembaTest.setUp) - this is just how a test gets at its mocks.
     """
 
     def actual_decorator(f):
         @wraps(f)
         def wrapper(instance, *args, **kwargs):
-            _wrap_test_method(f, instance, *args, **kwargs)
+            return f(instance, instance.mr_mocks, *args, **kwargs)
 
         return wrapper
 
     return actual_decorator(method) if method else actual_decorator
-
-
-def _wrap_test_method(f, instance, *args, **kwargs):
-    mocks = Mocks()
-
-    patch_get_client = None
-
-    try:
-        patch_get_client = patch("temba.mailroom.get_client")
-        mock_get_client = patch_get_client.start()
-        mock_get_client.return_value = TestClient(mocks)
-
-        return f(instance, mocks, *args, **kwargs)
-    finally:
-        patch_get_client.stop()
 
 
 def apply_modifiers(org, user, contacts, modifiers: list):
@@ -842,7 +813,7 @@ def apply_modifiers(org, user, contacts, modifiers: list):
 
         elif mod.type == "ticket":
             topic = org.topics.get(uuid=mod.topic.uuid, is_active=True)
-            assignee = org.users.get(email=mod.assignee.email, is_active=True) if mod.assignee else None
+            assignee = org.users.get(uuid=mod.assignee.uuid, is_active=True) if mod.assignee else None
             for contact in contacts:
                 contact.tickets.create(
                     uuid=uuid7(),


### PR DESCRIPTION
## Summary

Tests used the production mailroom client unless decorated with `@mock_mailroom`, and were kept off a live mailroom by a guard patched over `MailroomClient._request` in `setUp`. Instead, `get_client()` now returns the test client for every test, so the production client is never constructed during a test run and the guard, its transport sniffing, and the test-only branches it forced into production code all go away.

Without this, an un-mocked call in a dev environment reaches whatever is listening on the configured mailroom URL — succeeding quietly against the wrong database rather than failing.

## Changes

**`temba/mailroom/__init__.py`** — `get_client()` returns `TestClient` when `settings.TESTING`.

**`temba/tests/mailroom.py`**
- `TestClient` is the testing client: it takes its `Mocks` from a module-level holder set by `TembaTest.setUp`, and its `_request` override raises `LiveMailroomError` for any endpoint it doesn't fake, since reaching that layer is what an HTTP call looks like.
- Removed `install_mailroom_guard`, `_guarded_mailroom_request` and the `NonCallableMock` check that let a mocked transport through to the real `_request` (and which a non-Mock patch could slip past).
- `flow_inspect` now defaults to computing dependencies via `inspect_flow` instead of returning none. Previously only the guard's fallback computed them, so decorated and undecorated tests got different answers for the same call.
- Added `sim_start` / `sim_resume` fakes.
- Fixed the `ticket` modifier in `apply_modifiers`, which looked up the assignee by `mod.assignee.email` although `UserRef` carries `uuid` and `name`. It had never run, because the only test that opened a ticket went out through a mocked transport.

**`temba/tests/base.py`** — `setUp` creates `self.mr_mocks` and installs it. `@mock_mailroom` becomes a pass-through to it, so no decorated test body changes.

**`temba/mailroom/client/client.py`** — dropped both `settings.TESTING` branches, which existed only to make live calls survivable from tests: `flow_inspect` omitting `org_id`, and `flow_migrate` short circuiting a definition already at the target spec. The client no longer imports `settings`.

**Tests moved to where they belong** — `test_open_ticket`, `test_simulate` and `test_simulate_voice` went through `get_client()` with `patch("requests.post")` to assert URLs, headers and payloads. Those assertions move to `MailroomClientTest`, which constructs the client directly, and the originals assert behavior via `mr_mocks.calls`. Also adds `test_flow_clone`, which was missing, and `TestClientTest.test_unfaked_endpoint` to cover the guard.

## Behavior examples

| | Before | After |
|---|---|---|
| Un-mocked call in an undecorated test | Real HTTP to the configured mailroom URL, unless the guard was installed by `setUp` | `LiveMailroomError`, wherever the call is made from |
| Client used by an undecorated test | Production `MailroomClient` | `TestClient` |
| `flow_inspect` with no stub | Computed dependencies undecorated, none under `@mock_mailroom` | Computed dependencies either way |
| Guard coverage | Only code running inside a test method | Any code that calls `get_client()` |

## Test plan

- Full suite passes: `manage.py test temba --keepdb --noinput --parallel 4` (1152 tests)
- `code_check.py` clean — formatting, lint, migrations, locale files
- `coverage report --fail-under=100` reports full coverage on every file touched here
- New `test_unfaked_endpoint` asserts an un-faked endpoint raises rather than reaching the network