### PR TITLE
Record usage of deprecated API endpoints and list filter params

### DIFF
--- a/temba/api/tests/mixins.py
+++ b/temba/api/tests/mixins.py
@@ -1,4 +1,7 @@
+from django_valkey import get_valkey_connection
+
 from django.db import connection
+from django.utils import timezone
 
 from temba.api.models import APIToken
 
@@ -14,6 +17,14 @@ class APITestMixin:
         super().tearDown()
 
         connection.settings_dict["ATOMIC_REQUESTS"] = True
+
+    def assertDeprecatedRecorded(self, feature: str, count: int):
+        value = get_valkey_connection().hget(
+            f"warnings:{timezone.now():%Y-%m}", f"api:deprecated:{self.org.id}/{feature}"
+        )
+        self.assertEqual(
+            count, int(value) if value is not None else 0, f"deprecated usage count mismatch for {feature}"
+        )
 
     def _getJSON(self, endpoint_url: str, user, *, by_token: bool = False, num_queries: int = None):
         self.client.logout()

--- a/temba/api/v2/tests/test_broadcasts.py
+++ b/temba/api/v2/tests/test_broadcasts.py
@@ -98,8 +98,9 @@ class BroadcastsEndpointTest(APITest):
             resp_json["results"][0],
         )
 
-        # filter by id
+        # filter by id (deprecated, so recorded)
         self.assertGet(endpoint_url + f"?id={bcast3.id}", [self.editor], results=[bcast3])
+        self.assertDeprecatedRecorded("broadcasts#filter:id", 1)
 
         # filter by uuid
         self.assertGet(endpoint_url + f"?uuid={bcast3.uuid}", [self.editor], results=[bcast3])

--- a/temba/api/v2/tests/test_channel_events.py
+++ b/temba/api/v2/tests/test_channel_events.py
@@ -24,13 +24,14 @@ class ChannelEventsEndpointTest(APITest):
             self.channel, "tel:+250788123123", ChannelEvent.TYPE_CALL_OUT, extra=dict(duration=15)
         )
 
-        # no filtering
+        # no filtering.. but as a deprecated endpoint, usage is recorded
         response = self.assertGet(
             endpoint_url,
             [self.editor, self.admin],
             results=[call4, call3, call2, call1],
             num_queries=self.BASE_SESSION_QUERIES + 3,
         )
+        self.assertDeprecatedRecorded("channel_events#list", 2)
 
         resp_json = response.json()
         self.assertEqual(

--- a/temba/api/v2/tests/test_channel_events.py
+++ b/temba/api/v2/tests/test_channel_events.py
@@ -33,6 +33,11 @@ class ChannelEventsEndpointTest(APITest):
         )
         self.assertDeprecatedRecorded("channel_events#list", 2)
 
+        # browsing the endpoint docs doesn't count as usage
+        docs_response = self.client.get(reverse("api.v2.channel_events"))
+        self.assertEqual(200, docs_response.status_code)
+        self.assertDeprecatedRecorded("channel_events#list", 2)
+
         resp_json = response.json()
         self.assertEqual(
             resp_json["results"][0],

--- a/temba/api/v2/tests/test_contact_actions.py
+++ b/temba/api/v2/tests/test_contact_actions.py
@@ -1,9 +1,6 @@
 from unittest.mock import call
 
-from django_valkey import get_valkey_connection
-
 from django.urls import reverse
-from django.utils import timezone
 
 from temba.contacts.models import Contact
 from temba.msgs.models import Msg
@@ -207,14 +204,8 @@ class ContactActionsEndpointTest(APITest):
             status=204,
         )
 
-        r = get_valkey_connection()
-        self.assertEqual(
-            {
-                f"api:deprecated:{self.org.id}/contact_actions#archive_messages": b"1",
-                f"api:deprecated:{self.org.id}/contact_actions#archive": b"1",
-            },
-            {f.decode(): c for f, c in r.hgetall(f"warnings:{timezone.now():%Y-%m}").items()},
-        )
+        self.assertDeprecatedRecorded("contact_actions#archive_messages", 1)
+        self.assertDeprecatedRecorded("contact_actions#archive", 1)
 
         # delete contacts 1 and 2
         self.assertPost(

--- a/temba/api/v2/tests/test_definitions.py
+++ b/temba/api/v2/tests/test_definitions.py
@@ -35,12 +35,13 @@ class DefinitionsEndpointTest(APITest):
             self.org, self.editor, Trigger.TYPE_KEYWORD, flow1, keywords=["test"], match_type=Trigger.MATCH_FIRST_WORD
         )
 
-        # nothing specified, nothing exported
+        # nothing specified, nothing exported.. but as a deprecated endpoint, usage is recorded
         self.assertGet(
             endpoint_url,
             [self.editor],
             raw=lambda j: len(j["flows"]) == 0 and len(j["campaigns"]) == 0 and len(j["triggers"]) == 0,
         )
+        self.assertDeprecatedRecorded("definitions#get", 1)
 
         # flow + all dependencies by default
         self.assertGet(

--- a/temba/api/v2/tests/test_definitions.py
+++ b/temba/api/v2/tests/test_definitions.py
@@ -43,6 +43,11 @@ class DefinitionsEndpointTest(APITest):
         )
         self.assertDeprecatedRecorded("definitions#get", 1)
 
+        # browsing the endpoint docs doesn't count as usage
+        response = self.client.get(reverse("api.v2.definitions"))
+        self.assertEqual(200, response.status_code)
+        self.assertDeprecatedRecorded("definitions#get", 1)
+
         # flow + all dependencies by default
         self.assertGet(
             endpoint_url + f"?flow={flow1.uuid}",

--- a/temba/api/v2/tests/test_messages.py
+++ b/temba/api/v2/tests/test_messages.py
@@ -159,8 +159,9 @@ class MessagesEndpointTest(APITest):
         )
         self.assertDeprecatedRecorded("messages#filter:broadcast", 1)
 
-        # can't filter with invalid id
+        # can't filter with invalid id.. and a param that fails validation isn't recorded as usage
         self.assertGet(endpoint_url + "?id=xyz", [self.editor], errors={None: "Value for id must be an integer"})
+        self.assertDeprecatedRecorded("messages#filter:id", 1)
 
         # can't filter by more than one of contact, folder, label or broadcast together
         for query in (

--- a/temba/api/v2/tests/test_messages.py
+++ b/temba/api/v2/tests/test_messages.py
@@ -115,8 +115,9 @@ class MessagesEndpointTest(APITest):
         # filter by UUID
         self.assertGet(endpoint_url + f"?uuid={joe_msg3.uuid}", [self.admin], results=[joe_msg3])
 
-        # filter by id
+        # filter by id (deprecated, so recorded)
         self.assertGet(endpoint_url + f"?id={joe_msg3.id}", [self.admin], results=[joe_msg3])
+        self.assertDeprecatedRecorded("messages#filter:id", 1)
 
         # filter by contact
         self.assertGet(
@@ -147,7 +148,7 @@ class MessagesEndpointTest(APITest):
             results=[joe_msg4, joe_msg3, joe_msg2],
         )
 
-        # filter by broadcast
+        # filter by broadcast (deprecated, so recorded)
         broadcast = self.create_broadcast(
             self.editor, {"eng": {"text": "A beautiful broadcast"}}, contacts=[joe, frank]
         )
@@ -156,6 +157,7 @@ class MessagesEndpointTest(APITest):
             [self.editor],
             results=broadcast.msgs.order_by("-id"),
         )
+        self.assertDeprecatedRecorded("messages#filter:broadcast", 1)
 
         # can't filter with invalid id
         self.assertGet(endpoint_url + "?id=xyz", [self.editor], errors={None: "Value for id must be an integer"})

--- a/temba/api/v2/tests/test_runs.py
+++ b/temba/api/v2/tests/test_runs.py
@@ -213,8 +213,9 @@ class RunsEndpointTest(APITest):
             results=[joe_run1, frank_run1, frank_run2, joe_run2, joe_run3],
         )
 
-        # filter by id
+        # filter by id (deprecated, so recorded)
         self.assertGet(endpoint_url + f"?id={frank_run2.id}", [self.admin], results=[frank_run2])
+        self.assertDeprecatedRecorded("runs#filter:id", 1)
 
         # anon orgs should not have a URN field
         with self.anonymous(self.org):
@@ -286,8 +287,9 @@ class RunsEndpointTest(APITest):
             endpoint_url + f"?flow={flow1.uuid}&responded=TrUe", [self.admin], results=[frank_run1, joe_run1]
         )
 
-        # filter by contact
+        # filter by contact (deprecated, so recorded)
         self.assertGet(endpoint_url + f"?contact={joe.uuid}", [self.admin], results=[joe_run3, joe_run2, joe_run1])
+        self.assertDeprecatedRecorded("runs#filter:contact", 1)
 
         # filter by invalid contact
         self.assertGet(endpoint_url + "?contact=invalid", [self.admin], results=[])

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -42,6 +42,7 @@ from ..support import (
     ModifiedOnCursorPagination,
     OrgUserRateThrottle,
     SentOnCursorPagination,
+    record_deprecated,
 )
 from ..views import BaseAPIView, BulkWriteAPIMixin, DeleteAPIMixin, ListAPIMixin, WriteAPIMixin
 from .serializers import (
@@ -525,6 +526,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
         # filter by id (optional, deprecated)
         broadcast_id = self.get_int_param("id")
         if broadcast_id:
+            record_deprecated(self.request.org, "broadcasts#filter:id")
             queryset = queryset.filter(id=broadcast_id)
 
         queryset = queryset.prefetch_related(
@@ -1008,6 +1010,8 @@ class ChannelEventsEndpoint(ListAPIMixin, BaseEndpoint):
         params = self.request.query_params
         org = self.request.org
 
+        record_deprecated(org, "channel_events#list")
+
         # filter by id (optional)
         call_id = self.get_int_param("id")
         if call_id:
@@ -1379,6 +1383,9 @@ class DefinitionsEndpoint(BaseEndpoint):
             return Response({})
 
         org = request.org
+
+        record_deprecated(org, "definitions#get")
+
         params = request.query_params
         flow_uuids = params.getlist("flow")
         campaign_uuids = params.getlist("campaign")
@@ -2322,10 +2329,12 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
 
         # filter by id (optional, deprecated)
         if msg_id := self.get_int_param("id"):
+            record_deprecated(org, "messages#filter:id")
             queryset = queryset.filter(id=msg_id)
 
         # filter by broadcast (optional, deprecated)
         if broadcast_id := params.get("broadcast"):
+            record_deprecated(org, "messages#filter:broadcast")
             queryset = queryset.filter(broadcast_id=broadcast_id)
 
         # filter by contact (optional)
@@ -2836,6 +2845,7 @@ class RunsEndpoint(ListAPIMixin, BaseEndpoint):
 
         # filter by id (optional, deprecated)
         if run_id := self.get_int_param("id"):
+            record_deprecated(org, "runs#filter:id")
             queryset = queryset.filter(id=run_id)
 
         # filter by flow (optional)
@@ -2847,6 +2857,7 @@ class RunsEndpoint(ListAPIMixin, BaseEndpoint):
 
         # filter by contact (optional, deprecated)
         if contact_uuid := params.get("contact"):
+            record_deprecated(org, "runs#filter:contact")
             if contact := org.contacts.filter(is_active=True, uuid=contact_uuid).first():
                 queryset = queryset.filter(contact=contact)
             else:


### PR DESCRIPTION
## Summary

Extends the recently added deprecated API feature tracking (previously only covering contact actions) to the deprecated endpoints and list filter params documented in the API, so we can see whether anything still depends on them before removing them.

## Changes

- `temba/api/v2/views.py`:
  - record `channel_events#list` on any real list request to the deprecated channel events endpoint (docs browsing isn't counted)
  - record `definitions#get` on any real request to the deprecated definitions endpoint
  - record deprecated list filter params when actually provided: `broadcasts#filter:id`, `messages#filter:id`, `messages#filter:broadcast`, `runs#filter:id`, `runs#filter:contact` — params that fail validation first aren't counted
- `temba/api/tests/mixins.py`: new `assertDeprecatedRecorded(feature, count)` helper that checks the specific hash field for the test org
- endpoint tests assert recording at each deprecated usage, and that the excluded paths really are excluded — a param that fails validation and browsing of an endpoint's docs page don't increment the counter
- the contact actions test now uses the helper too, since its previous whole-hash equality assertion breaks once other tests in the run record features into the same shared hash

## Behavior examples

Using a deprecated feature increments a field in the monthly `warnings:<YYYY-MM>` hash:

| Request | Field recorded |
|---|---|
| `GET /api/v2/channel_events.json` | `api:deprecated:<org id>/channel_events#list` |
| `GET /api/v2/definitions.json?flow=...` | `api:deprecated:<org id>/definitions#get` |
| `GET /api/v2/messages.json?broadcast=1234` | `api:deprecated:<org id>/messages#filter:broadcast` |
| `GET /api/v2/runs.json?contact=<uuid>` | `api:deprecated:<org id>/runs#filter:contact` |
| `GET /api/v2/messages.json?id=xyz` (fails validation) | nothing |
| `GET /api/v2/channel_events` (docs page) | nothing |

## Test plan

- [x] `temba.api` test suite passes
- [x] Negative paths covered: failed-validation params and docs browsing aren't counted
- [x] 100% coverage on `temba/api/v2/views.py` and `temba/api/support.py`
- [x] `code_check.py` passes