### PR TITLE
Fix infinite loop in schedule fire calculation on DST fall-back days

### DIFF
--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -1,6 +1,6 @@
 import calendar
 import logging
-from datetime import time, timedelta, timezone as tzone
+from datetime import datetime, time, timedelta, timezone as tzone
 
 from dateutil.relativedelta import relativedelta
 
@@ -180,21 +180,13 @@ class Schedule(models.Model):
             assert self.repeat_days_of_week != "" and self.repeat_days_of_week is not None
 
             while next_fire <= now or self._day_of_week(next_fire) not in self.repeat_days_of_week:
-                next_fire = (
-                    (next_fire.astimezone(tzone.utc) + timedelta(days=1))
-                    .astimezone(tz)
-                    .replace(hour=hour, minute=minute)
-                )
+                next_fire = self._next_day(next_fire, tz, hour, minute)
 
             return next_fire
 
         elif self.repeat_period == Schedule.REPEAT_DAILY:
             while next_fire <= now:
-                next_fire = (
-                    (next_fire.astimezone(tzone.utc) + timedelta(days=1))
-                    .astimezone(tz)
-                    .replace(hour=hour, minute=minute)
-                )
+                next_fire = self._next_day(next_fire, tz, hour, minute)
 
             return next_fire
         elif self.repeat_period == Schedule.REPEAT_YEARLY:
@@ -226,6 +218,15 @@ class Schedule(models.Model):
                 "each year on %(month)s %(day)s"
                 % {"month": self.next_fire.strftime("%B"), "day": ordinal(self.next_fire.strftime("%d"))}
             )
+
+    @staticmethod
+    def _next_day(d, tz, hour: int, minute: int):
+        """
+        The same time of day on the next calendar day in the given timezone. Advancing by adding 24 hours in UTC
+        isn't safe: on a DST fall-back day (25 local hours) that lands on the same local day, which would make the
+        loops above never advance.
+        """
+        return datetime.combine(d.date() + timedelta(days=1), time(hour, minute), tzinfo=tz)
 
     @staticmethod
     def _day_of_week(d):

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -114,6 +114,27 @@ class ScheduleTest(TembaTest):
                 display="each day at 10:00",
             ),
             dict(
+                label="daily at midnight across end of DST",  # a 25-hour day, which used to loop forever
+                trigger_date=datetime(2026, 10, 24, hour=0),
+                now=datetime(2026, 10, 23, hour=9),
+                repeat_period=Schedule.REPEAT_DAILY,
+                tz=ZoneInfo("Europe/London"),
+                first=datetime(2026, 10, 24, hour=0),
+                next=[datetime(2026, 10, 25, hour=0), datetime(2026, 10, 26, hour=0), datetime(2026, 10, 27, hour=0)],
+                display="each day at 00:00",
+            ),
+            dict(
+                label="weekly at midnight across end of DST",
+                trigger_date=datetime(2026, 10, 18, hour=0),
+                now=datetime(2026, 10, 17, hour=9),
+                repeat_period=Schedule.REPEAT_WEEKLY,
+                repeat_days_of_week="U",
+                tz=ZoneInfo("Europe/London"),
+                first=datetime(2026, 10, 18, hour=0),
+                next=[datetime(2026, 10, 25, hour=0), datetime(2026, 11, 1, hour=0)],
+                display="each week on Sunday",
+            ),
+            dict(
                 label="weekly repeating starting on non weekly day of the week",
                 trigger_date=datetime(2013, 1, 2, hour=10),
                 now=datetime(2013, 1, 2, hour=9),


### PR DESCRIPTION
## Summary

`Schedule.calculate_next_fire` could loop forever for daily and weekly schedules set at midnight in a DST-observing timezone. On a fall-back day (25 local hours), advancing by adding 24 hours in UTC and re-resolving to local time lands back on the same local day, and `.replace(hour=0)` then reproduces the exact same datetime — so `while next_fire <= now` never terminates. Any code path that projects such a schedule's fires across the transition date (e.g. the contact timeline view, which projects a year ahead) would hang until the web worker was killed by its request timeout.

## Changes

- `temba/schedules/models.py`: the daily and weekly repeat loops now advance via a new `_next_day` helper that does calendar-day arithmetic in the org's timezone (`date() + 1 day` combined with the scheduled hour/minute), which always advances regardless of DST transitions. The monthly and yearly branches step by `relativedelta` months/years and can't get stuck, so they're unchanged.
- `temba/schedules/tests.py`: regression cases for daily and weekly schedules at midnight crossing the end of DST in Europe/London (2026-10-25, a 25-hour day). Both hang indefinitely on the old code.

## Behavior example

Daily schedule at 00:00, org timezone Europe/London, current fire at 2026-10-25 00:00 BST:

| | next fire |
|---|---|
| Before | never returns (infinite loop → worker timeout) |
| After | 2026-10-26 00:00 GMT |

## Test plan

- [x] New regression tests fail (hang) against the old implementation, pass against the new one
- [x] `temba.schedules`, `temba.triggers`, `temba.contacts` CRUDL + model tests pass
- [x] `code_check.py` clean (formatting, lint, locales, migrations)