### PR TITLE
Hide channel logs UI for channel types that don't have logs

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -112,6 +112,9 @@ class ChannelType(metaclass=ABCMeta):
     # during activation. Channels should make sure their claim view is non-atomic if a callback will be involved
     async_activation = True
 
+    # whether channels of this type have logs of their traffic with an external provider
+    has_logs = True
+
     # used for anonymizing logs
     redact_request_keys = ()
     redact_response_keys = ()

--- a/temba/channels/templatetags/channels.py
+++ b/temba/channels/templatetags/channels.py
@@ -18,7 +18,7 @@ def channel_log_link(context, obj):
     logs_url = None
 
     if user.has_org_perm(org, "channels.channel_logs") or user.is_staff:
-        has_channel = obj.channel and obj.channel.is_active
+        has_channel = obj.channel and obj.channel.is_active and obj.channel.type.has_logs
 
         obj_age = timezone.now() - obj.created_on
 

--- a/temba/channels/templatetags/tests.py
+++ b/temba/channels/templatetags/tests.py
@@ -44,3 +44,10 @@ class ChannelsTest(TembaTest):
         self.assertEqual(
             {"logs_url": None}, channel_log_link(Context({"user_org": self.org, "user": self.admin}), old_msg)
         )
+
+        # or for messages on channels of types that don't have logs
+        webchat_channel = self.create_channel("WCH", "WebChat", "123")
+        webchat_msg = self.create_incoming_msg(joe, "Hi", channel=webchat_channel)
+        self.assertEqual(
+            {"logs_url": None}, channel_log_link(Context({"user_org": self.org, "user": self.admin}), webchat_msg)
+        )

--- a/temba/channels/tests/test_channelcrudl.py
+++ b/temba/channels/tests/test_channelcrudl.py
@@ -217,6 +217,22 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
             choose_org=self.org,
         )
 
+    def test_read_menu(self):
+        # normal channel types get a logs menu item on their read page
+        self.assertContentMenu(
+            reverse("channels.channel_read", args=[self.ex_channel.uuid]),
+            self.admin,
+            ["Configuration", "Logs", "Edit", "Delete"],
+        )
+
+        # but not types whose channels don't have logs
+        webchat_channel = self.create_channel("WCH", "WebChat", "123")
+        self.assertContentMenu(
+            reverse("channels.channel_read", args=[webchat_channel.uuid]),
+            self.admin,
+            ["Configuration", "Edit", "Delete"],
+        )
+
     def test_logs_list(self):
         channel = self.create_channel("T", "My Channel", "+250785551212")
 
@@ -251,6 +267,12 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(logs[4].uuid, response.context["logs"][0].uuid)
         self.assertEqual(logs[0].uuid, response.context["logs"][-1].uuid)
 
+        # channels of types that don't have logs return a 404
+        webchat_channel = self.create_channel("WCH", "WebChat", "123")
+        self.login(self.admin)
+        response = self.client.get(reverse("channels.channel_logs_list", args=[webchat_channel.uuid]))
+        self.assertEqual(404, response.status_code)
+
     def test_logs_read(self):
         log1 = self.create_channel_log(
             self.channel,
@@ -273,6 +295,12 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertIsNone(response.context["call"])
         self.assertEqual(1, len(response.context["logs"]))
         self.assertContains(response, "GET https://foo.bar/send1")
+
+        # channels of types that don't have logs return a 404
+        webchat_channel = self.create_channel("WCH", "WebChat", "123")
+        self.login(self.admin)
+        response = self.client.get(reverse("channels.channel_logs_read", args=[webchat_channel.uuid, "log", log1.uuid]))
+        self.assertEqual(404, response.status_code)
 
     def test_logs_msg(self):
         contact = self.create_contact("Fred", phone="+12067799191")

--- a/temba/channels/types/webchat/type.py
+++ b/temba/channels/types/webchat/type.py
@@ -24,6 +24,8 @@ class WebChatType(ChannelType):
 
     config_ui = ConfigUI()  # has own template
 
+    has_logs = False  # message transport is internal to the platform
+
     def is_available_to(self, org, user):
         available = user.is_staff
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -479,7 +479,8 @@ class ChannelCRUDL(SmartCRUDL):
             if obj.type.config_ui:
                 menu.add_link(_("Configuration"), reverse("channels.channel_configuration", args=[obj.uuid]))
 
-            menu.add_link(_("Logs"), reverse("channels.channel_logs_list", args=[obj.uuid]))
+            if obj.type.has_logs:
+                menu.add_link(_("Logs"), reverse("channels.channel_logs_list", args=[obj.uuid]))
 
             if obj.type.template_type:
                 menu.add_link(_("Template Logs"), reverse("request_logs.httplog_channel", args=[obj.uuid]))
@@ -833,6 +834,12 @@ class ChannelCRUDL(SmartCRUDL):
         def derive_url_pattern(cls, path, action):
             return r"^%s/logs/(?P<uuid>[0-9a-f-]{36})/$" % path
 
+        def get_object(self, *args, **kwargs):
+            channel = super().get_object(*args, **kwargs)
+            if not channel.type.has_logs:
+                raise Http404()
+            return channel
+
         def derive_menu_path(self):
             return f"/settings/channels/{self.kwargs['uuid']}"
 
@@ -862,6 +869,12 @@ class ChannelCRUDL(SmartCRUDL):
         @classmethod
         def derive_url_pattern(cls, path, action):
             return r"^%s/logs/(?P<uuid>[0-9a-f-]{36})/(?P<reftype>log|msg|call)/(?P<refid>[0-9a-f-]{36})/$" % path
+
+        def get_object(self, *args, **kwargs):
+            channel = super().get_object(*args, **kwargs)
+            if not channel.type.has_logs:
+                raise Http404()
+            return channel
 
         def derive_menu_path(self):
             return f"/settings/channels/{self.kwargs['uuid']}"

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -695,7 +695,7 @@ class Msg(models.Model):
             return None
         if not (user.has_org_perm(org, "channels.channel_logs") or user.is_staff):
             return None
-        if not (self.channel and self.channel.is_active and self.created_on):
+        if not (self.channel and self.channel.is_active and self.channel.type.has_logs and self.created_on):
             return None
         if timezone.now() - self.created_on >= settings.RETENTION_PERIODS["channellog"]:
             return None

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -126,6 +126,17 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         msg = self.create_incoming_msg(self.joe, "hi")
         self.assertIsNone(msg._get_logs_url({"unrelated": "value"}))
 
+    def test_as_json_logs_url_channel_without_logs(self):
+        context = {"user": self.admin, "org": self.org}
+
+        msg1 = self.create_incoming_msg(self.joe, "hi")
+        self.assertIsNotNone(msg1._get_logs_url(context))
+
+        # msgs on channels of types that don't have logs don't get a logs URL
+        webchat_channel = self.create_channel("WCH", "WebChat", "123")
+        msg2 = self.create_incoming_msg(self.joe, "hi", channel=webchat_channel)
+        self.assertIsNone(msg2._get_logs_url(context))
+
     @patch("django.core.files.storage.default_storage.delete")
     @mock_mailroom
     def test_bulk_soft_delete(self, mr_mocks, mock_storage_delete):


### PR DESCRIPTION
Some channel types (e.g. WebChat) have message transport that is internal to the platform, so there are no logs of traffic with an external provider to show — their channel logs are empty or meaningless to users.

## Changes

* Adds a new `ChannelType.has_logs` attribute (defaults to `True`) and sets it to `False` for the WebChat type.
* For channels of types without logs:
  * the channel read page's context menu no longer includes a **Logs** item
  * the logs list and log read views return 404
  * per-msg / per-call log links are no longer generated — both the `channel_log_link` template tag (msg/call views) and `Msg._get_logs_url` (contact history API)

## Test plan

* `test_read_menu` — WebChat read page menu lacks **Logs**; a normal (External) channel keeps it
* `test_logs_list` / `test_logs_read` — the log views 404 for a WebChat channel, still fetch for normal channels
* `test_channel_log_link` — the template tag returns no URL for a msg on a WebChat channel
* `test_as_json_logs_url_channel_without_logs` — a normal channel's msg gets a logs URL, a WebChat msg doesn't