### PR TITLE
Remove @mock_mailroom from tests that don't use the injected mocks

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -363,8 +363,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertGet(endpoint_url + "?sort=-field:gender&page_size=0", [self.admin], results=[joe, frank])
         self.assertEqual(50, mr_mocks.calls["contact_search"][-1].kwargs["limit"])
 
-    @mock_mailroom
-    def test_contacts_update(self, mr_mocks):
+    def test_contacts_update(self):
         endpoint_url = reverse("api.internal.contacts") + ".json"
 
         joe = self.create_contact("Joe", urns=["tel:+250788111111", "facebook:123456"])

--- a/temba/api/v2/tests/test_broadcasts.py
+++ b/temba/api/v2/tests/test_broadcasts.py
@@ -6,15 +6,14 @@ from temba.api.v2.serializers import format_datetime
 from temba.msgs.models import Broadcast
 from temba.orgs.models import Org
 from temba.schedules.models import Schedule
-from temba.tests import cleanup, mock_mailroom
+from temba.tests import cleanup
 
 from . import APITest
 
 
 class BroadcastsEndpointTest(APITest):
-    @mock_mailroom
     @cleanup(s3=True)
-    def test_endpoint(self, mr_mocks):
+    def test_endpoint(self):
         endpoint_url = reverse("api.v2.broadcasts") + ".json"
 
         self.assertGetNotPermitted(endpoint_url, [None, self.agent])

--- a/temba/api/v2/tests/test_contacts.py
+++ b/temba/api/v2/tests/test_contacts.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 
 from temba.api.v2.serializers import format_datetime
 from temba.contacts.models import Contact, ContactField, ContactGroup
-from temba.tests import mock_mailroom
 
 from . import APITest
 
@@ -18,8 +17,7 @@ class ContactsEndpointTest(APITest):
         self.joe = self.create_contact("Joe Blow", phone="+250788123123")
         self.frank = self.create_contact("Frank", urns=["facebook:123456"])
 
-    @mock_mailroom
-    def test_endpoint(self, mr_mocks):
+    def test_endpoint(self):
         endpoint_url = reverse("api.v2.contacts") + ".json"
 
         self.assertGetNotPermitted(endpoint_url, [None])
@@ -600,8 +598,7 @@ class ContactsEndpointTest(APITest):
             response.json()["results"][0]["notes"][-1]["text"],
         )
 
-    @mock_mailroom
-    def test_expanded_urns_can_preserve_priority_order(self, mr_mocks):
+    def test_expanded_urns_can_preserve_priority_order(self):
         contact = self.create_contact(
             "Reordered",
             urns=["tel:+250788123456", "facebook:123456789"],
@@ -631,8 +628,7 @@ class ContactsEndpointTest(APITest):
             [f"{urn['scheme']}:{urn['path']}" for urn in response.json()["results"][0]["urns"]],
         )
 
-    @mock_mailroom
-    def test_as_agent(self, mr_mocks):
+    def test_as_agent(self):
         endpoint_url = reverse("api.v2.contacts") + ".json"
 
         self.create_field("gender", "Gender", ContactField.TYPE_TEXT, agent_access=ContactField.ACCESS_NONE)
@@ -709,8 +705,7 @@ class ContactsEndpointTest(APITest):
             errors={("fields", "string_field"): "Null characters are not allowed."},
         )
 
-    @mock_mailroom
-    def test_update_datetime_field(self, mr_mocks):
+    def test_update_datetime_field(self):
         endpoint_url = reverse("api.v2.contacts") + ".json"
 
         self.create_field("activated_at", "Tag activation", ContactField.TYPE_DATETIME)
@@ -751,8 +746,7 @@ class ContactsEndpointTest(APITest):
         )
         self.assertIsNone(response.json()["fields"]["activated_at"])
 
-    @mock_mailroom
-    def test_anonymous_org(self, mr_mocks):
+    def test_anonymous_org(self):
         endpoint_url = reverse("api.v2.contacts") + ".json"
 
         group = ContactGroup.get_or_create(self.org, self.admin, "Customers")

--- a/temba/api/v2/tests/test_definitions.py
+++ b/temba/api/v2/tests/test_definitions.py
@@ -3,15 +3,13 @@ from django.urls import reverse
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import ContactField
 from temba.flows.models import Flow
-from temba.tests import mock_mailroom
 from temba.triggers.models import Trigger
 
 from . import APITest
 
 
 class DefinitionsEndpointTest(APITest):
-    @mock_mailroom
-    def test_endpoint(self, mr_mocks):
+    def test_endpoint(self):
         endpoint_url = reverse("api.v2.definitions") + ".json"
 
         self.assertGetNotPermitted(endpoint_url, [None, self.agent])

--- a/temba/api/v2/tests/test_groups.py
+++ b/temba/api/v2/tests/test_groups.py
@@ -3,7 +3,6 @@ from django.urls import reverse
 
 from temba.campaigns.models import Campaign
 from temba.contacts.models import ContactGroup
-from temba.tests import mock_mailroom
 from temba.triggers.models import Trigger
 
 from . import APITest
@@ -11,8 +10,7 @@ from . import APITest
 
 class GroupsEndpointTest(APITest):
     @override_settings(ORG_LIMIT_DEFAULTS={"groups": 10})
-    @mock_mailroom
-    def test_endpoint(self, mr_mocks):
+    def test_endpoint(self):
         endpoint_url = reverse("api.v2.groups") + ".json"
 
         self.assertGetNotPermitted(endpoint_url, [None])

--- a/temba/api/v2/tests/test_tickets.py
+++ b/temba/api/v2/tests/test_tickets.py
@@ -3,14 +3,12 @@ from datetime import datetime, timezone as tzone
 from django.urls import reverse
 
 from temba.api.v2.serializers import format_datetime
-from temba.tests import mock_mailroom
 
 from . import APITest
 
 
 class TicketsEndpointTest(APITest):
-    @mock_mailroom
-    def test_endpoint(self, mr_mocks):
+    def test_endpoint(self):
         endpoint_url = reverse("api.v2.tickets") + ".json"
 
         self.assertGetNotPermitted(endpoint_url, [None])

--- a/temba/campaigns/tests/test_campaign.py
+++ b/temba/campaigns/tests/test_campaign.py
@@ -174,8 +174,7 @@ class CampaignTest(TembaTest):
         )
         self.assertEqual("eng", event.base_language)
 
-    @mock_mailroom
-    def test_import(self, mr_mocks):
+    def test_import(self):
         self.import_file("test_flows/the_clinic.json")
         self.assertEqual(1, Campaign.objects.count())
 
@@ -193,8 +192,7 @@ class CampaignTest(TembaTest):
         self.assertEqual({"und": {"text": "This is a second campaign message"}}, events[5].translations)
         self.assertEqual("und", events[5].base_language)
 
-    @mock_mailroom
-    def test_import_created_on_event(self, mr_mocks):
+    def test_import_created_on_event(self):
         campaign = Campaign.create(self.org, self.admin, "New contact reminders", self.farmers)
         created_on = self.org.fields.get(key="created_on")
 
@@ -212,8 +210,7 @@ class CampaignTest(TembaTest):
 
         self.org.import_app(exported, self.admin)
 
-    @mock_mailroom
-    def test_update_to_non_date(self, mr_mocks):
+    def test_update_to_non_date(self):
         # create our campaign and event
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
         event = CampaignEvent.create_flow_event(
@@ -230,8 +227,7 @@ class CampaignTest(TembaTest):
         # should be able to change our field type now
         ContactField.get_or_create(self.org, self.admin, "planting_date", value_type=ContactField.TYPE_TEXT)
 
-    @mock_mailroom
-    def test_unarchiving_campaigns(self, mr_mocks):
+    def test_unarchiving_campaigns(self):
         # create a campaign
         campaign = Campaign.create(self.org, self.editor, "Planting Reminders", self.farmers)
 

--- a/temba/campaigns/tests/test_campaigncrudl.py
+++ b/temba/campaigns/tests/test_campaigncrudl.py
@@ -291,8 +291,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertListFetch(list_url, [self.editor, self.admin])
         self.assertContentMenu(list_url, self.admin, ["New Campaign"])
 
-    @mock_mailroom
-    def test_list_component(self, mr_mocks):
+    def test_list_component(self):
         group = self.create_group("Reporters", contacts=[])
         campaign1 = self.create_campaign(self.org, "Welcomes", group)
         campaign2 = self.create_campaign(self.org, "Follow Ups", group)
@@ -358,8 +357,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertListFetch(archived_url, [self.editor, self.admin])
         self.assertContentMenu(archived_url, self.admin, [])
 
-    @mock_mailroom
-    def test_archive_and_activate(self, mr_mocks):
+    def test_archive_and_activate(self):
         group = self.create_group("Reporters", contacts=[])
         campaign = self.create_campaign(self.org, "Welcomes", group)
         other_org_group = self.create_group("Reporters", contacts=[], org=self.org2)

--- a/temba/campaigns/tests/test_event.py
+++ b/temba/campaigns/tests/test_event.py
@@ -6,13 +6,12 @@ from django.utils import timezone
 
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import ContactField, ContactFire
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 from temba.utils.uuid import uuid4
 
 
 class CampaignEventTest(TembaTest):
-    @mock_mailroom
-    def test_model(self, mr_mocks):
+    def test_model(self):
         contact1 = self.create_contact("Joe", phone="+1234567890")
         contact2 = self.create_contact("Jose", phone="+593979123456", language="spa")
         farmers = self.create_group("Farmers", [])

--- a/temba/campaigns/tests/test_eventcrudl.py
+++ b/temba/campaigns/tests/test_eventcrudl.py
@@ -10,7 +10,7 @@ from temba.contacts.models import ContactField
 from temba.flows.models import Flow
 from temba.msgs.models import Msg
 from temba.templates.models import TemplateTranslation
-from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
+from temba.tests import CRUDLTestMixin, TembaTest
 from temba.utils import json
 from temba.utils.compose import compose_serialize
 from temba.utils.views.mixins import TEMBA_MENU_SELECTION
@@ -53,8 +53,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         return campaign
 
-    @mock_mailroom
-    def test_update_success_url(self, mr_mocks):
+    def test_update_success_url(self):
         event = self.campaign1.events.order_by("id").first()
         registered = self.org.fields.get(key="registered")
         flow = self.org.flows.get(name="Welcomes Flow")
@@ -147,8 +146,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.requestView(read_url, self.editor)
         self.assertEqual(404, response.status_code)
 
-    @mock_mailroom
-    def test_create(self, mr_mocks):
+    def test_create(self):
         farmer1 = self.create_contact("Rob Jasper", phone="+250788111111")
         farmer2 = self.create_contact("Mike Gordon", phone="+250788222222", language="kin")
         self.create_contact("Trey Anastasio", phone="+250788333333")
@@ -455,8 +453,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual("@fields.planting_date", compose_initial["kin"]["text"])
         self.assertEqual("Required", compose_initial["eng"]["text"])
 
-    @mock_mailroom
-    def test_update(self, mr_mocks):
+    def test_update(self):
         event1, event2, event3 = self.campaign1.events.order_by("id")
         registered = self.org.fields.get(key="registered")
         accepted = self.create_field("accepted", "Accepted", value_type="D")
@@ -550,8 +547,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
             response.context["form"].fields["flow_to_start"].widget.attrs["info_text"],
         )
 
-    @mock_mailroom
-    def test_read_with_translations(self, mr_mocks):
+    def test_read_with_translations(self):
         """The read view renders message content and a translation summary."""
         self.org.set_flow_languages(self.admin, ["eng", "kin", "spa", "fra"])
 
@@ -598,8 +594,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "Translations provided in <b>Kinyarwanda</b> and <b>Spanish</b>")
         self.assertNotContains(response, "<b>French</b>")
 
-    @mock_mailroom
-    def test_create_with_template(self, mr_mocks):
+    def test_create_with_template(self):
         """Creating a message event with a WhatsApp template persists template + variables."""
         planting_date = self.create_field("planting_date", "Planting Date", ContactField.TYPE_DATETIME)
         campaign = Campaign.create(self.org, self.admin, "With Template", self.create_group("G", []))
@@ -692,8 +687,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(str(template.uuid), initial["eng"]["template"])
         self.assertEqual(["image/jpeg:http://domain/meow.jpg", "World"], initial["eng"]["variables"])
 
-    @mock_mailroom
-    def test_too_many_attachments(self, mr_mocks):
+    def test_too_many_attachments(self):
         planting_date = self.create_field("planting_date", "Planting Date", ContactField.TYPE_DATETIME)
         campaign = Campaign.create(self.org, self.admin, "Attachments", self.create_group("Ga", []))
         create_url = reverse("campaigns.campaignevent_create", args=[campaign.id])
@@ -719,8 +713,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
             form_errors={"compose": f"Maximum allowed attachments is {Msg.MAX_ATTACHMENTS} files."},
         )
 
-    @mock_mailroom
-    def test_update_form_language_edge_cases(self, mr_mocks):
+    def test_update_form_language_edge_cases(self):
         """Form init should handle events whose base language or translations don't match current org languages."""
         event = CampaignEvent.create_message_event(
             self.org,
@@ -768,8 +761,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         iso_order = [lang["iso"] for lang in langs]
         self.assertEqual(iso_order[0], "eng")
 
-    @mock_mailroom
-    def test_form_flow_queryset_default(self, mr_mocks):
+    def test_form_flow_queryset_default(self):
         # the class-level queryset for flow_to_start must not leak flows across orgs - it should be empty by
         # default and only populated when the form is instantiated with an org
         self.assertEqual(0, CampaignEventForm.base_fields["flow_to_start"].queryset.count())

--- a/temba/channels/tests/test_channel.py
+++ b/temba/channels/tests/test_channel.py
@@ -246,8 +246,7 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
 
         self.assertFalse(Channel.objects.filter(id=channel1.id).exists())
 
-    @mock_mailroom
-    def test_release_facebook(self, mr_mocks):
+    def test_release_facebook(self):
         channel = Channel.create(
             self.org,
             self.admin,
@@ -274,8 +273,7 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
             self.assertEqual(1, channel.triggers.filter(is_active=False).count())
             self.assertFalse(channel.is_active)
 
-    @mock_mailroom
-    def test_release_android(self, mr_mocks):
+    def test_release_android(self):
         android = self.claim_new_android()
         self.assertEqual("FCM111", android.config.get(Channel.CONFIG_FCM_ID))
 
@@ -526,8 +524,7 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         # should be an error response
         self.assertEqual({"error": "Can't sync unclaimed channel", "error_id": 4, "cmds": []}, response.json())
 
-    @mock_mailroom
-    def test_sync_client_reset(self, mr_mocks):
+    def test_sync_client_reset(self):
         android = self.claim_new_android()
 
         response = self.sync(android, cmds=[{"cmd": "reset"}])
@@ -588,8 +585,7 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(len(cmds[0]["to"]), 1)
         self.assertEqual(cmds[0]["to"][0]["phone"], "+250788383383")
 
-    @mock_mailroom
-    def test_sync(self, mr_mocks):
+    def test_sync(self):
         date = timezone.now()
         date = int(time.mktime(date.timetuple())) * 1000
 
@@ -815,8 +811,7 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         # bad signature, should result in 401 Unauthorized
         self.assertEqual(401, self.sync(self.tel_channel, signature="badsig", cmds=[]).status_code)
 
-    @mock_mailroom
-    def test_ignore_android_incoming_msg_invalid_phone(self, mr_mocks):
+    def test_ignore_android_incoming_msg_invalid_phone(self):
         date = timezone.now()
         date = int(time.mktime(date.timetuple())) * 1000
 

--- a/temba/channels/tests/test_channelcrudl.py
+++ b/temba/channels/tests/test_channelcrudl.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
+from temba.tests import CRUDLTestMixin, TembaTest
 from temba.utils.views.mixins import TEMBA_MENU_SELECTION
 
 from ..models import Channel, ChannelLog
@@ -411,8 +411,7 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual("https://foo.bar/call1", response.context["logs"][0]["http_logs"][0]["url"])
         self.assertEqual("https://foo.bar/call2", response.context["logs"][1]["http_logs"][0]["url"])
 
-    @mock_mailroom
-    def test_delete(self, mr_mocks):
+    def test_delete(self):
         delete_url = reverse("channels.channel_delete", args=[self.ex_channel.uuid])
 
         self.assertRequestDisallowed(delete_url, [None, self.agent, self.admin2])

--- a/temba/channels/tests/test_sync_event.py
+++ b/temba/channels/tests/test_sync_event.py
@@ -1,11 +1,10 @@
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 
 from ..models import Channel, SyncEvent
 
 
 class SyncEventTest(TembaTest):
-    @mock_mailroom
-    def test_sync_event_model(self, mr_mocks):
+    def test_sync_event_model(self):
         self.sync_event = SyncEvent.create(
             self.channel,
             dict(p_src="AC", p_sts="DIS", p_lvl=80, net="WIFI", pending=[1, 2], retry=[3, 4], cc="RW"),

--- a/temba/channels/types/android/tests.py
+++ b/temba/channels/types/android/tests.py
@@ -5,15 +5,13 @@ from django.urls import reverse
 from temba.contacts.models import URN
 from temba.orgs.models import Org
 from temba.tests import CRUDLTestMixin, TembaTest
-from temba.tests.mailroom import mock_mailroom
 from temba.users.models import User
 
 from ...models import Channel
 
 
 class AndroidTypeTest(TembaTest, CRUDLTestMixin):
-    @mock_mailroom
-    def test_claim(self, mr_mocks):
+    def test_claim(self):
         # remove our explicit country so it needs to be derived from channels
         self.org.root_location = None
         self.org.timezone = "UTC"

--- a/temba/channels/types/twilio/tests.py
+++ b/temba/channels/types/twilio/tests.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from temba.channels.models import Channel
 from temba.contacts.models import URN
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 from temba.tests.twilio import MockRequestValidator, MockTwilioClient
 
 from .type import TwilioType
@@ -16,8 +16,7 @@ class TwilioTypeTest(TembaTest):
     @patch("temba.channels.types.twilio.views.TwilioClient", MockTwilioClient)
     @patch("temba.channels.types.twilio.type.TwilioClient", MockTwilioClient)
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
-    @mock_mailroom
-    def test_claim(self, mr_mocks):
+    def test_claim(self):
         self.login(self.admin)
 
         claim_twilio = reverse("channels.types.twilio.claim")

--- a/temba/contacts/management/commands/tests.py
+++ b/temba/contacts/management/commands/tests.py
@@ -114,8 +114,7 @@ class ConvertBsuidUrnsTest(TembaTest):
         # only the collided bsuid remains
         self.assertEqual({"RW.ghi789"}, set(ContactURN.objects.filter(scheme="bsuid").values_list("path", flat=True)))
 
-    @mock_mailroom
-    def test_dropped_bsuid_moves_references(self, mr_mocks):
+    def test_dropped_bsuid_moves_references(self):
         # a dual-written contact whose bsuid URN is redundant and referenced by a message
         contact = self.create_contact("Dan", urns=["whatsapp:250788000004", "whatsapp:RW.jkl012", "bsuid:RW.jkl012"])
         bsuid = contact.urns.get(scheme="bsuid")
@@ -186,9 +185,8 @@ class ConvertBsuidUrnsTest(TembaTest):
         contact.refresh_from_db()
         self.assertGreater(contact.modified_on, start)
 
-    @mock_mailroom
     @patch("temba.contacts.management.commands.convert_bsuid_urns.BATCH_SIZE", 2)
-    def test_batches_and_skips_collisions_across_the_cursor(self, mr_mocks):
+    def test_batches_and_skips_collisions_across_the_cursor(self):
         # an existing whatsapp URN that a later bsuid will collide with when it tries to convert
         self.create_contact("Taken", urns=["whatsapp:RW.taken0"])
 

--- a/temba/contacts/tests/test_contact.py
+++ b/temba/contacts/tests/test_contact.py
@@ -110,8 +110,7 @@ class ContactTest(TembaTest):
             mr_mocks.calls["contact_modify"],
         )
 
-    @mock_mailroom
-    def test_interrupt(self, mr_mocks):
+    def test_interrupt(self):
         # noop when contact not in a flow
         self.joe.interrupt(self.admin)
 
@@ -120,8 +119,7 @@ class ContactTest(TembaTest):
         self.joe.interrupt(self.admin)
 
     @cleanup(dynamodb=True)
-    @mock_mailroom
-    def test_release(self, mr_mocks):
+    def test_release(self):
         # create a contact with a message
         old_contact = self.create_contact("Jose", phone="+12065552000")
         self.create_incoming_msg(old_contact, "hola mundo")
@@ -337,8 +335,7 @@ class ContactTest(TembaTest):
 
         self.assertEqual({"status:W": 0}, flow.counts.prefix("status:").scope_totals())
 
-    @mock_mailroom
-    def test_status_changes_and_release(self, mr_mocks):
+    def test_status_changes_and_release(self):
         flow = self.create_flow("Test")
         msg1 = self.create_incoming_msg(self.joe, "Test 1")
         msg2 = self.create_incoming_msg(self.joe, "Test 2", flow=flow)
@@ -560,8 +557,7 @@ class ContactTest(TembaTest):
             self.assertEqual(["tel:+250782222222"], [u.urn for u in self.frank.get_urns()])
             self.assertEqual([], [u.urn for u in self.billy.get_urns()])
 
-    @mock_mailroom
-    def test_bulk_inspect(self, mr_mocks):
+    def test_bulk_inspect(self):
         self.assertEqual({}, Contact.bulk_inspect([]))
         self.assertEqual(
             {
@@ -817,8 +813,7 @@ class ContactTest(TembaTest):
         results = response.json()
         self.assertEqual("Age", results["fields"][str(age.uuid)]["label"])
 
-    @mock_mailroom
-    def test_update_status(self, mr_mocks):
+    def test_update_status(self):
         self.login(self.admin)
 
         self.assertEqual(Contact.STATUS_ACTIVE, self.joe.status)
@@ -848,8 +843,7 @@ class ContactTest(TembaTest):
             self.joe.update(name="Joseph Blower", language="spa"),
         )
 
-    @mock_mailroom
-    def test_update_static_groups(self, mr_mocks):
+    def test_update_static_groups(self):
         # create some static groups
         spammers = self.create_group("Spammers", [])
         testers = self.create_group("Testers", [])
@@ -898,8 +892,7 @@ class ContactTest(TembaTest):
         # just a NOOP
         self.assertEqual([], mr_mocks.calls["contact_modify"])
 
-    @mock_mailroom
-    def test_contact_model(self, mr_mocks):
+    def test_contact_model(self):
         contact = self.create_contact(name="Boy", phone="12345")
         self.assertEqual(contact.get_display(), "Boy")
 

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -179,8 +179,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         joe.refresh_from_db()
         self.assertEqual(Contact.STATUS_ARCHIVED, joe.status)
 
-    @mock_mailroom
-    def test_list_component(self, mr_mocks):
+    def test_list_component(self):
         joe = self.create_contact("Joe", phone="123")
         frank = self.create_contact("Frank", phone="124")
         group = self.create_group("Crew", contacts=[joe, frank])
@@ -263,8 +262,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(200, response.status_code)
         self.assertToast(response, "info", "Must specify a label")
 
-    @mock_mailroom
-    def test_blocked(self, mr_mocks):
+    def test_blocked(self):
         joe = self.create_contact("Joe", urns=["twitter:joe"])
         frank = self.create_contact("Frank", urns=["twitter:frank"])
         billy = self.create_contact("Billy", urns=["twitter:billy"])
@@ -293,8 +291,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         frank.refresh_from_db()
         self.assertEqual(Contact.STATUS_ARCHIVED, frank.status)
 
-    @mock_mailroom
-    def test_stopped(self, mr_mocks):
+    def test_stopped(self):
         joe = self.create_contact("Joe", urns=["twitter:joe"])
         frank = self.create_contact("Frank", urns=["twitter:frank"])
         billy = self.create_contact("Billy", urns=["twitter:billy"])
@@ -324,8 +321,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(Contact.STATUS_ARCHIVED, frank.status)
 
     @patch("temba.contacts.models.Contact.BULK_RELEASE_IMMEDIATELY_LIMIT", 5)
-    @mock_mailroom
-    def test_archived(self, mr_mocks):
+    def test_archived(self):
         joe = self.create_contact("Joe", urns=["twitter:joe"])
         frank = self.create_contact("Frank", urns=["twitter:frank"])
         billy = self.create_contact("Billy", urns=["twitter:billy"])
@@ -433,8 +429,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.requestView(group3_url, self.admin, choose_org=self.org)
         self.assertRedirect(response, "/org/switch/")
 
-    @mock_mailroom
-    def test_read(self, mr_mocks):
+    def test_read(self):
         joe = self.create_contact("Joe", phone="123")
 
         read_url = reverse("contacts.contact_read", args=[joe.uuid])
@@ -487,8 +482,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(reverse("contacts.contact_read", args=["invalid-uuid"]))
         self.assertEqual(response.status_code, 404)
 
-    @mock_mailroom
-    def test_read_component(self, mr_mocks):
+    def test_read_component(self):
         joe = self.create_contact("Joe", phone="123")
 
         read_url = reverse("contacts.contact_read", args=[joe.uuid])
@@ -611,8 +605,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.post(chat_url, {"text": "Hello"}, content_type="application/json")
         self.assertEqual(404, response.status_code)
 
-    @mock_mailroom
-    def test_chat_reply_non_own_permission(self, mr_mocks):
+    def test_chat_reply_non_own_permission(self):
         contact = self.create_contact("Joe Blow", urns=["tel:+250781111111"])
         ticket = self.create_ticket(contact)
         chat_url = reverse("contacts.contact_chat", args=[contact.uuid])
@@ -1741,8 +1734,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(1, response.json()["future_count"])
         self.assertEqual(["Soon"], [e["message"] for e in response.json()["future"]])
 
-    @mock_mailroom
-    def test_open_ticket(self, mr_mocks):
+    def test_open_ticket(self):
         contact = self.create_contact("Joe", phone="+593979000111")
         general = self.org.default_topic
         open_url = reverse("contacts.contact_open_ticket", args=[contact.uuid])
@@ -1761,8 +1753,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # and we're redirected to that ticket
         self.assertRedirect(response, f"/ticket/all/{ticket.uuid}/")
 
-    @mock_mailroom
-    def test_interrupt(self, mr_mocks):
+    def test_interrupt(self):
         contact = self.create_contact("Joe", phone="+593979000111")
         other_org_contact = self.create_contact("Hans", phone="+593979123456", org=self.org2)
 

--- a/temba/contacts/tests/test_fieldcrudl.py
+++ b/temba/contacts/tests/test_fieldcrudl.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import ContactField
-from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
+from temba.tests import CRUDLTestMixin, TembaTest
 
 
 class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
@@ -108,8 +108,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.requestView(create_url, self.admin)
             self.assertContains(response, "You have reached the per-workspace limit")
 
-    @mock_mailroom
-    def test_update(self, mr_mocks):
+    def test_update(self):
         update_url = reverse("contacts.contactfield_update", args=[self.age.key])
 
         self.assertRequestDisallowed(update_url, [None, self.agent, self.admin2])
@@ -278,8 +277,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         with override_settings(ORG_LIMIT_DEFAULTS={"fields": 3}):
             self.assertContentMenu(list_url, self.admin, [])
 
-    @mock_mailroom
-    def test_detail(self, mr_mocks):
+    def test_detail(self):
         field = self.create_field("joined", "Joined", value_type="D")
 
         flow = self.create_flow("Flow")
@@ -401,8 +399,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.post(priority_url, "notjson", content_type="application/json")
         self.assertEqual(400, response.status_code)
 
-    @mock_mailroom
-    def test_usages(self, mr_mocks):
+    def test_usages(self):
         field = self.create_field("joined", "Joined", value_type="D")
 
         flow = self.create_flow("Flow")

--- a/temba/contacts/tests/test_group.py
+++ b/temba/contacts/tests/test_group.py
@@ -103,8 +103,7 @@ class ContactGroupTest(TembaTest):
         group.refresh_from_db()
         self.assertEqual(group.name, "first")
 
-    @mock_mailroom
-    def test_get_groups(self, mr_mocks):
+    def test_get_groups(self):
         manual = ContactGroup.create_manual(self.org, self.admin, "Static")
         deleted = ContactGroup.create_manual(self.org, self.admin, "Deleted")
         deleted.is_active = False
@@ -161,8 +160,7 @@ class ContactGroupTest(TembaTest):
 
         self.assertEqual(1, len(mr_mocks.calls["org_publish"]))
 
-    @mock_mailroom
-    def test_member_count(self, mr_mocks):
+    def test_member_count(self):
         group = self.create_group("Cool kids")
         group.contacts.add(self.joe, self.frank)
 
@@ -190,8 +188,7 @@ class ContactGroupTest(TembaTest):
         self.assertEqual(group.get_member_count(), 0)
         self.assertEqual(set(group.contacts.all()), set())
 
-    @mock_mailroom
-    def test_status_group_counts(self, mr_mocks):
+    def test_status_group_counts(self):
         # start with no contacts
         for contact in Contact.objects.all():
             contact.release(self.admin)
@@ -268,8 +265,7 @@ class ContactGroupTest(TembaTest):
             },
         )
 
-    @mock_mailroom
-    def test_release(self, mr_mocks):
+    def test_release(self):
         contact1 = self.create_contact("Bob", phone="+1234567111")
         contact2 = self.create_contact("Jim", phone="+1234567222")
         contact3 = self.create_contact("Jim", phone="+1234567333")

--- a/temba/contacts/tests/test_import.py
+++ b/temba/contacts/tests/test_import.py
@@ -270,8 +270,7 @@ class ContactImportTest(TembaTest):
             imp.get_info(),
         )
 
-    @mock_mailroom
-    def test_batches_with_fields(self, mr_mocks):
+    def test_batches_with_fields(self):
         self.create_field("goats", "Goats", ContactField.TYPE_NUMBER)
 
         imp = self.create_contact_import("media/test_imports/extra_fields_and_group.xlsx")
@@ -401,8 +400,7 @@ class ContactImportTest(TembaTest):
             batch.specs,
         )
 
-    @mock_mailroom
-    def test_batches_with_invalid_urn(self, mr_mocks):
+    def test_batches_with_invalid_urn(self):
         imp = self.create_contact_import("media/test_imports/invalid_urn.xlsx")
         imp.start()
         batch = imp.batches.get()
@@ -421,8 +419,7 @@ class ContactImportTest(TembaTest):
             batch.specs,
         )
 
-    @mock_mailroom
-    def test_batches_with_multiple_tels(self, mr_mocks):
+    def test_batches_with_multiple_tels(self):
         imp = self.create_contact_import("media/test_imports/multiple_tel_urns.xlsx")
         imp.start()
         batch = imp.batches.get()
@@ -445,8 +442,7 @@ class ContactImportTest(TembaTest):
             batch.specs,
         )
 
-    @mock_mailroom
-    def test_batches_from_xlsx(self, mr_mocks):
+    def test_batches_from_xlsx(self):
         imp = self.create_contact_import("media/test_imports/simple.xlsx")
         imp.start()
         batch = imp.batches.get()
@@ -475,8 +471,7 @@ class ContactImportTest(TembaTest):
             batch.specs,
         )
 
-    @mock_mailroom
-    def test_batches_from_xlsx_with_formulas(self, mr_mocks):
+    def test_batches_from_xlsx_with_formulas(self):
         imp = self.create_contact_import("media/test_imports/formula_data.xlsx")
         imp.start()
         batch = imp.batches.get()
@@ -501,8 +496,7 @@ class ContactImportTest(TembaTest):
             batch.specs,
         )
 
-    @mock_mailroom
-    def test_detect_spamminess(self, mr_mocks):
+    def test_detect_spamminess(self):
         imp = self.create_contact_import("media/test_imports/sequential_tels.xlsx")
         imp.start()
 
@@ -533,8 +527,7 @@ class ContactImportTest(TembaTest):
                 )
             )
 
-    @mock_mailroom
-    def test_detect_spamminess_verified_org(self, mr_mocks):
+    def test_detect_spamminess_verified_org(self):
         # if an org is verified, no flagging occurs
         self.org.verify()
 
@@ -544,8 +537,7 @@ class ContactImportTest(TembaTest):
         self.org.refresh_from_db()
         self.assertFalse(self.org.is_flagged)
 
-    @mock_mailroom
-    def test_data_types(self, mr_mocks):
+    def test_data_types(self):
         imp = self.create_contact_import("media/test_imports/data_formats.xlsx")
         imp.start()
         batch = imp.batches.get()
@@ -596,8 +588,7 @@ class ContactImportTest(TembaTest):
         for test in tests:
             self.assertEqual(test[1], ContactImport(org=self.org, original_filename=test[0]).get_default_group_name())
 
-    @mock_mailroom
-    def test_delete(self, mr_mocks):
+    def test_delete(self):
         imp = self.create_contact_import("media/test_imports/simple.xlsx")
         imp.start()
         imp.delete()

--- a/temba/contacts/tests/test_importcrudl.py
+++ b/temba/contacts/tests/test_importcrudl.py
@@ -4,12 +4,11 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from temba.contacts.models import ContactField, ContactGroup, ContactImport
-from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
+from temba.tests import CRUDLTestMixin, TembaTest
 
 
 class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
-    @mock_mailroom
-    def test_create_and_preview(self, mr_mocks):
+    def test_create_and_preview(self):
         create_url = reverse("contacts.contactimport_create")
 
         self.assertRequestDisallowed(create_url, [None, self.agent])
@@ -57,8 +56,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(302, response.status_code)
         self.assertEqual(read_url, response.url)
 
-    @mock_mailroom
-    def test_creating_new_group(self, mr_mocks):
+    def test_creating_new_group(self):
         self.login(self.admin)
         imp = self.create_contact_import("media/test_imports/simple.xlsx")
         preview_url = reverse("contacts.contactimport_preview", args=[imp.id])
@@ -105,8 +103,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
             imp.refresh_from_db()
             self.assertEqual(doctors, imp.group)
 
-    @mock_mailroom
-    def test_using_existing_group(self, mr_mocks):
+    def test_using_existing_group(self):
         self.login(self.admin)
         imp = self.create_contact_import("media/test_imports/simple.xlsx")
         preview_url = reverse("contacts.contactimport_preview", args=[imp.id])
@@ -135,8 +132,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
         imp.refresh_from_db()
         self.assertEqual(doctors, imp.group)
 
-    @mock_mailroom
-    def test_preview_with_mappings(self, mr_mocks):
+    def test_preview_with_mappings(self):
         self.create_field("age", "Age", ContactField.TYPE_NUMBER)
 
         imp = self.create_contact_import("media/test_imports/extra_fields_and_group.xlsx")
@@ -263,8 +259,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
     @patch("temba.contacts.models.ContactImport.BATCH_SIZE", 2)
-    @mock_mailroom
-    def test_read(self, mr_mocks):
+    def test_read(self):
         imp = self.create_contact_import("media/test_imports/simple.xlsx")
         imp.start()
 
@@ -273,8 +268,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRequestDisallowed(read_url, [None, self.agent, self.admin2])
         self.assertReadFetch(read_url, [self.editor, self.admin], context_object=imp)
 
-    @mock_mailroom
-    def test_preview_with_field_limit_reached(self, mr_mocks):
+    def test_preview_with_field_limit_reached(self):
         """Test that new fields are automatically ignored when field limit is reached"""
         # Create import with a file that has new fields
         imp = self.create_contact_import("media/test_imports/extra_fields_and_group.xlsx")
@@ -294,8 +288,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
                 self.assertFalse(include_field.initial)  # Should be initially unchecked
                 self.assertTrue(include_field.widget.attrs.get("disabled", False))  # Should be disabled
 
-    @mock_mailroom
-    def test_preview_with_field_limit_not_reached(self, mr_mocks):
+    def test_preview_with_field_limit_not_reached(self):
         """Test that new fields are normally available when field limit is not reached"""
         # Create import with a file that has new fields
         imp = self.create_contact_import("media/test_imports/extra_fields_and_group.xlsx")
@@ -315,8 +308,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
                 self.assertTrue(include_field.initial)  # Should be initially checked
                 self.assertFalse(include_field.widget.attrs.get("disabled", False))  # Should not be disabled
 
-    @mock_mailroom
-    def test_preview_with_group_limit_reached(self, mr_mocks):
+    def test_preview_with_group_limit_reached(self):
         """Test that new group option is hidden when group limit is reached"""
 
         imp = self.create_contact_import("media/test_imports/simple.xlsx")
@@ -336,8 +328,7 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
             # Initial value should be existing group mode
             self.assertEqual(form.fields["group_mode"].initial, form.GROUP_MODE_EXISTING)
 
-    @mock_mailroom
-    def test_field_limit_validation_prevents_circumvention(self, mr_mocks):
+    def test_field_limit_validation_prevents_circumvention(self):
         """Test that backend validation prevents field limit circumvention"""
         imp = self.create_contact_import("media/test_imports/extra_fields_and_group.xlsx")
 

--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -141,8 +141,7 @@ class FlowMigrationTest(TembaTest):
         self.assertEqual(Flow.FINAL_LEGACY_VERSION, handed_off["version"])
         self.assertEqual(Flow.CURRENT_SPEC_VERSION, to_version)
 
-    @mock_mailroom
-    def test_migrate_to_11_12(self, mr_mocks):
+    def test_migrate_to_11_12(self):
         flow = self.create_flow("Favorites")
         definition = {
             "entry": "79b4776b-a995-475d-ae06-1cab9af8a28e",
@@ -243,16 +242,14 @@ class FlowMigrationTest(TembaTest):
         self.assertEqual(migrated["action_sets"][0]["actions"][0]["msg"]["base"], "Hey there, Yes or No?")
         self.assertEqual(len(migrated["action_sets"]), 3)
 
-    @mock_mailroom
-    def test_migrate_to_11_12_with_one_node(self, mr_mocks):
+    def test_migrate_to_11_12_with_one_node(self):
         flow = self.create_flow("Migrate 11.12 One Node")
         flow_json = self.load_flow_def("migrate_to_11_12_one_node")
         migrated = migrate_to_version_11_12(flow_json, flow)
 
         self.assertEqual(len(migrated["action_sets"]), 0)
 
-    @mock_mailroom
-    def test_migrate_to_11_12_other_org_existing_flow(self, mr_mocks):
+    def test_migrate_to_11_12_other_org_existing_flow(self):
         flow = self.create_flow("Migrate 11.12 Other Org")
         flow_json = self.load_flow_def("migrate_to_11_12_other_org", {"CHANNEL-UUID": str(self.channel.uuid)})
 
@@ -265,8 +262,7 @@ class FlowMigrationTest(TembaTest):
         # check action set was removed
         self.assertEqual(len(migrated["rule_sets"]), 0)
 
-    @mock_mailroom
-    def test_migrate_to_11_11(self, mr_mocks):
+    def test_migrate_to_11_11(self):
         flow = self.create_flow("Migrate 11.11")
         flow_json = self.load_flow_def("migrate_to_11_11")
 
@@ -326,8 +322,7 @@ class FlowMigrationTest(TembaTest):
             },
         )
 
-    @mock_mailroom
-    def test_migrate_to_11_9(self, mr_mocks):
+    def test_migrate_to_11_9(self):
         flow = self.create_flow("Master")
 
         # the migration drops references to flows that are missing or invalid - create the referenced flows with
@@ -448,8 +443,7 @@ class FlowMigrationTest(TembaTest):
         # check value field on save action was updsated
         self.assertEqual(flow_json["action_sets"][1]["actions"][1]["value"], "@extra.response_3")
 
-    @mock_mailroom
-    def test_migrate_to_11_4(self, mr_mocks):
+    def test_migrate_to_11_4(self):
         flow_json = self.load_flow_def("migrate_to_11_4")
         migrated = migrate_to_version_11_4(flow_json.copy())
 
@@ -652,8 +646,7 @@ class FlowMigrationTest(TembaTest):
         # we cannot migrate flows to version 11 without flow object (languages depend on flow.org)
         self.assertRaises(ValueError, migrate_to_version_11_1, definition)
 
-    @mock_mailroom
-    def test_migrate_to_11_0(self, mr_mocks):
+    def test_migrate_to_11_0(self):
         self.create_field("nickname", "Nickname", ContactField.TYPE_TEXT)
         self.create_field("district", "District", ContactField.TYPE_DISTRICT)
         self.create_field("joined_on", "Joined On", ContactField.TYPE_DATETIME)
@@ -686,8 +679,7 @@ class FlowMigrationTest(TembaTest):
             ],
         )
 
-    @mock_mailroom
-    def test_migrate_to_11_0_with_null_ruleset_label(self, mr_mocks):
+    def test_migrate_to_11_0_with_null_ruleset_label(self):
         flow = self.create_flow("Migrate 11.0")
         definition = {
             "rule_sets": [
@@ -708,8 +700,7 @@ class FlowMigrationTest(TembaTest):
 
         self.assertEqual(migrated, definition)
 
-    @mock_mailroom
-    def test_migrate_to_11_0_with_null_msg_text(self, mr_mocks):
+    def test_migrate_to_11_0_with_null_msg_text(self):
         flow = self.create_flow("Migrate 11.0")
         definition = {
             "action_sets": [
@@ -726,8 +717,7 @@ class FlowMigrationTest(TembaTest):
         migrated = migrate_to_version_11_0(definition, flow)
         self.assertEqual(migrated, definition)
 
-    @mock_mailroom
-    def test_migrate_to_11_0_with_broken_localization(self, mr_mocks):
+    def test_migrate_to_11_0_with_broken_localization(self):
         flow = self.create_flow("Migrate 11.0")
         flow_def = self.load_flow_def("migrate_to_11_0")
         migrated = migrate_to_version_11_0(flow_def, flow)
@@ -781,8 +771,7 @@ class FlowMigrationTest(TembaTest):
             for action in actionset["actions"]:
                 self.assertIsNotNone(action.get("uuid"))
 
-    @mock_mailroom
-    def test_migrate_to_10(self, mr_mocks):
+    def test_migrate_to_10(self):
         # this is really just testing our rewriting of webhook rulesets
         flow = self.create_flow("Dual Webhook")
         flow_def = self.load_flow_def("dual_webhook")
@@ -795,8 +784,7 @@ class FlowMigrationTest(TembaTest):
             self.assertNotIn("webhook", ruleset)
             self.assertNotIn("webhook_action", ruleset)
 
-    @mock_mailroom
-    def test_migrate_to_9(self, mr_mocks):
+    def test_migrate_to_9(self):
         contact = self.create_contact("Ben Haggerty", phone="+12065552020")
 
         # our group and flow to move to uuids
@@ -1035,8 +1023,7 @@ class FlowMigrationTest(TembaTest):
         self.assertEqual("@step.value|lower_case", beer_expression["operand"])
         self.assertEqual(5, len(beer_expression["rules"]))
 
-    @mock_mailroom
-    def test_migrate_sample_flows(self, mr_mocks):
+    def test_migrate_sample_flows(self):
         self.org.create_sample_flows("https://app.rapidpro.io")
         self.assertEqual(3, self.org.flows.filter(name__icontains="Sample Flow").count())
 

--- a/temba/flows/tests/test_counts.py
+++ b/temba/flows/tests/test_counts.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from temba.flows.models import FlowActivityCount, FlowRun, FlowSession
 from temba.flows.tasks import squash_flow_counts
 from temba.msgs.models import Msg
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 from temba.utils.uuid import uuid4
 
 
@@ -159,8 +159,7 @@ class FlowActivityCountTest(TembaTest):
         self.assertEqual({"status:A": 0, "status:I": 4}, flow1.counts.scope_totals())
         self.assertEqual({"status:X": 1, "status:I": 2}, flow2.counts.scope_totals())
 
-    @mock_mailroom
-    def test_msgsin_counts(self, mr_mocks):
+    def test_msgsin_counts(self):
         flow1 = self.create_flow("Test 1")
         flow2 = self.create_flow("Test 2")
 

--- a/temba/flows/tests/test_export.py
+++ b/temba/flows/tests/test_export.py
@@ -10,7 +10,7 @@ from temba.archives.models import Archive
 from temba.contacts.models import Contact, ContactURN
 from temba.flows.models import Flow, FlowRun, ResultsExport
 from temba.orgs.models import Export
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 from temba.tests.engine import MockSessionWriter
 from temba.utils import json
 from temba.utils.s3 import s3
@@ -63,8 +63,7 @@ class ResultsExportTest(TembaTest):
 
         return load_workbook(filename=default_storage.open(f"orgs/{self.org.id}/results_exports/{export.uuid}.xlsx"))
 
-    @mock_mailroom
-    def test_export(self, mr_mocks):
+    def test_export(self):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         flow = self.get_flow("color")
@@ -1099,8 +1098,7 @@ class ResultsExportTest(TembaTest):
             tz,
         )
 
-    @mock_mailroom
-    def test_no_responses(self, mr_mocks):
+    def test_no_responses(self):
         today = timezone.now().astimezone(self.org.timezone).date()
         flow = self.create_flow("Test")
 

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -144,8 +144,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(flow.is_active)
         self.assertEqual(0, flow.global_dependencies.count())
 
-    @mock_mailroom
-    def test_get_definition(self, mr_mocks):
+    def test_get_definition(self):
         favorites = self.get_flow("favorites_v13")
 
         # fill the definition with junk metadata
@@ -175,8 +174,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         favorites.revisions.all().delete()
         self.assertRaises(AssertionError, favorites.get_definition)
 
-    @mock_mailroom
-    def test_ensure_current_version(self, mr_mocks):
+    def test_ensure_current_version(self):
         # importing migrates to latest spec version
         flow = self.get_flow("favorites_v13")
         self.assertEqual(Flow.CURRENT_SPEC_VERSION, flow.version_number)
@@ -207,8 +205,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(old_saved_on, flow.saved_on)
         self.assertGreater(flow.modified_on, old_modified_on)
 
-    @mock_mailroom
-    def test_flow_archive_with_campaign(self, mr_mocks):
+    def test_flow_archive_with_campaign(self):
         self.login(self.admin)
         self.get_flow("the_clinic")
 
@@ -248,8 +245,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         flow.refresh_from_db()
         self.assertTrue(flow.is_archived)
 
-    @mock_mailroom
-    def test_flow_archive_with_ongoing_runs(self, mr_mocks):
+    def test_flow_archive_with_ongoing_runs(self):
         self.login(self.admin)
         flow = self.create_flow("Test Flow")
 
@@ -599,8 +595,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
             )
             self.assertEqual(len(flow.info["parent_refs"]), 0)
 
-    @mock_mailroom
-    def test_group_send(self, mr_mocks):
+    def test_group_send(self):
         # create an inactive group with the same name, to test that this doesn't blow up our import
         group = ContactGroup.get_or_create(self.org, self.admin, "Survey Audience")
         group.release(self.admin)
@@ -611,8 +606,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         # fetching a flow with a group send shouldn't throw
         self.get_flow("group_send_flow")
 
-    @mock_mailroom
-    def test_delete(self, mr_mocks):
+    def test_delete(self):
         flow = self.get_flow("favorites_v13")
         flow_nodes = flow.get_definition()["nodes"]
         color_prompt = flow_nodes[0]

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -552,8 +552,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         flow.refresh_from_db()
         self.assertEqual("New Name", flow.name)
 
-    @mock_mailroom
-    def test_list_views(self, mr_mocks):
+    def test_list_views(self):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
 
@@ -663,8 +662,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(reverse("flows.flow_filter", args=[label2.uuid]))
         self.assertEqual(f"/flow/labels/{label2.uuid}", response.headers.get(TEMBA_MENU_SELECTION))
 
-    @mock_mailroom
-    def test_list_component(self, mr_mocks):
+    def test_list_component(self):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
         label = FlowLabel.create(self.org, self.admin, "Important")
@@ -741,8 +739,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(f"{export_url}?ids=foo")
         self.assertEqual([], list(response.context["form"].initial["flows"]))
 
-    @mock_mailroom
-    def test_get_definition(self, mr_mocks):
+    def test_get_definition(self):
         flow = self.get_flow("color")
 
         # if definition is outdated, metadata values are updated from db object
@@ -778,8 +775,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertEqual("Amazing Flow 2", flow.get_definition()["metadata"]["name"])
 
-    @mock_mailroom
-    def test_revisions(self, mr_mocks):
+    def test_revisions(self):
         flow = self.create_flow("Color")
 
         revisions_url = reverse("flows.flow_revisions", args=[flow.uuid])
@@ -1619,8 +1615,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             ),
         )
 
-    @mock_mailroom
-    def test_copy_view(self, mr_mocks):
+    def test_copy_view(self):
         flow = self.get_flow("color")
 
         self.login(self.admin)
@@ -1720,8 +1715,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.assertReadFetch(chart_url_invalid, [self.editor, self.admin])
         self.assertEqual({"data": {"labels": [], "datasets": []}}, response.json())
 
-    @mock_mailroom
-    def test_results(self, mr_mocks):
+    def test_results(self):
         flow = self.create_flow("Test 1")
 
         results_url = reverse("flows.flow_results", args=[flow.uuid])
@@ -1939,8 +1933,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             response.json(),
         )
 
-    @mock_mailroom
-    def test_activity_inactive_flow(self, mr_mocks):
+    def test_activity_inactive_flow(self):
         flow = self.create_flow("Deleted")
         flow.release(self.admin)
 
@@ -2290,8 +2283,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         self.assertEqual({"type": "manual", "user": {"uuid": str(self.admin.uuid), "name": "Andy"}}, sent["trigger"])
 
-    @mock_mailroom
-    def test_delete(self, mr_mocks):
+    def test_delete(self):
         child = self.create_flow("Child")
         parent = self.create_flow("Parent")
         parent.field_dependencies.add(self.create_field("age", "Age"))
@@ -2318,8 +2310,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(0, parent.field_dependencies.all().count())
         self.assertEqual(0, parent.flow_dependencies.all().count())
 
-    @mock_mailroom
-    def test_delete_of_inactive_flow(self, mr_mocks):
+    def test_delete_of_inactive_flow(self):
         flow = self.create_flow("Test")
         flow.release(self.admin)
 

--- a/temba/flows/tests/test_run.py
+++ b/temba/flows/tests/test_run.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from django.utils import timezone
 
 from temba.flows.models import FlowRun, FlowSession
-from temba.tests import TembaTest, matchers, mock_mailroom
+from temba.tests import TembaTest, matchers
 from temba.tests.engine import MockSessionWriter
 from temba.utils.uuid import uuid4
 
@@ -47,8 +47,7 @@ class FlowRunTest(TembaTest):
             run.get_path(),
         )
 
-    @mock_mailroom
-    def test_as_archive_json(self, mr_mocks):
+    def test_as_archive_json(self):
         flow = self.get_flow("color")
         flow_nodes = flow.get_definition()["nodes"]
         color_prompt = flow_nodes[0]

--- a/temba/flows/tests/test_startcrudl.py
+++ b/temba/flows/tests/test_startcrudl.py
@@ -2,12 +2,11 @@ from django.urls import reverse
 
 from temba.flows.models import FlowStart, FlowStartCount
 from temba.mailroom.client.types import Exclusions
-from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
+from temba.tests import CRUDLTestMixin, TembaTest
 
 
 class FlowStartCRUDLTest(TembaTest, CRUDLTestMixin):
-    @mock_mailroom
-    def test_list(self, mr_mocks):
+    def test_list(self):
         list_url = reverse("flows.flowstart_list")
 
         flow1 = self.create_flow("Test Flow 1")
@@ -62,8 +61,7 @@ class FlowStartCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertTrue(response.context["filtered"])
         self.assertEqual(response.context["url_params"], "?type=manual&")
 
-    @mock_mailroom
-    def test_read(self, mr_mocks):
+    def test_read(self):
         flow1 = self.create_flow("Test Flow 1")
         flow2 = self.create_flow("Test 2")
 

--- a/temba/msgs/tests/test_broadcast.py
+++ b/temba/msgs/tests/test_broadcast.py
@@ -89,8 +89,7 @@ class BroadcastTest(TembaTest):
         self.assertEqual({(today, "text:in"): 3, (today, "text:out"): 6}, self.channel.counts.day_totals(scoped=True))
         self.assertEqual({(today, "text:out"): 1}, self.facebook_channel.counts.day_totals(scoped=True))
 
-    @mock_mailroom
-    def test_model(self, mr_mocks):
+    def test_model(self):
         schedule = Schedule.create(self.org, timezone.now(), Schedule.REPEAT_MONTHLY)
 
         bcast2 = Broadcast.create(

--- a/temba/msgs/tests/test_broadcastcrudl.py
+++ b/temba/msgs/tests/test_broadcastcrudl.py
@@ -542,8 +542,7 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             "Using a message template may incur additional fees from your channel provider.",
         )
 
-    @mock_mailroom
-    def test_to_node(self, mr_mocks):
+    def test_to_node(self):
         to_node_url = reverse("msgs.broadcast_to_node")
 
         # give Joe a flow run that has stopped on a node

--- a/temba/msgs/tests/test_label.py
+++ b/temba/msgs/tests/test_label.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from temba.msgs.models import Label, LabelCount, MessageExport, Msg
 from temba.msgs.tasks import squash_msg_counts
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 
 
 class LabelTest(TembaTest):
@@ -22,8 +22,7 @@ class LabelTest(TembaTest):
         # don't allow duplicate name
         self.assertRaises(AssertionError, Label.create, self.org, self.editor, "Spam")
 
-    @mock_mailroom
-    def test_toggle_label(self, mr_mocks):
+    def test_toggle_label(self):
         label = self.create_label("Spam")
         msg1 = self.create_incoming_msg(self.joe, "Message 1")
         msg2 = self.create_incoming_msg(self.joe, "Message 2")

--- a/temba/msgs/tests/test_msg_folder.py
+++ b/temba/msgs/tests/test_msg_folder.py
@@ -4,7 +4,7 @@ from temba.flows.models import Flow, FlowRun, FlowSession
 from temba.msgs.models import Msg, MsgFolder
 from temba.orgs.tasks import squash_item_counts
 from temba.schedules.models import Schedule
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 from temba.utils import s3
 
 
@@ -65,8 +65,7 @@ class MsgFolderTest(TembaTest):
             select = s3.compile_select(where=folder.get_archive_query())
             self.assertEqual(expected_select, select, f"select s3 mismatch for {folder}")
 
-    @mock_mailroom
-    def test_get_counts(self, mr_mocks):
+    def test_get_counts(self):
         def assert_counts(org, expected: dict):
             self.assertEqual(MsgFolder.get_counts(org), expected)
 

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -38,8 +38,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
             ],
         )
 
-    @mock_mailroom
-    def test_inbox(self, mr_mocks):
+    def test_inbox(self):
         contact1 = self.create_contact("Joe Blow", phone="+250788000001")
         contact2 = self.create_contact("Frank", phone="+250788000002")
         msg1 = self.create_incoming_msg(contact1, "message number 1")

--- a/temba/orgs/tests/test_definitionexport.py
+++ b/temba/orgs/tests/test_definitionexport.py
@@ -66,8 +66,7 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(1, len(response.context["buckets"]))
         self.assertEqual([child, parent], response.context["buckets"][0])
 
-    @mock_mailroom
-    def test_import_voice_flows_expiration_time(self, mr_mocks):
+    def test_import_voice_flows_expiration_time(self):
         # import file has invalid expires for an IVR flow so it should get clamped to the maximum (15)
         self.get_flow("ivr")
 
@@ -153,8 +152,7 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
             self.assertIsNone(Flow.objects.filter(org=self.org, name="New Mother").first())
 
     @patch("temba.mailroom.client.client.MailroomClient.campaign_schedule")
-    @mock_mailroom
-    def test_import_campaign_with_translations(self, mr_mocks, mock_schedule):
+    def test_import_campaign_with_translations(self, mock_schedule):
         self.import_file("test_flows/campaign_import_with_translations.json")
 
         campaign = Campaign.objects.all().first()
@@ -167,8 +165,7 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(event.base_language, "swa")
 
     @patch("temba.mailroom.client.client.MailroomClient.campaign_schedule")
-    @mock_mailroom
-    def test_reimport(self, mr_mocks, mock_schedule):
+    def test_reimport(self, mock_schedule):
         self.import_file("test_flows/survey_campaign.json")
 
         campaign = Campaign.objects.filter(is_active=True).last()
@@ -659,8 +656,7 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         response = self.client.get("%s?archived=1" % reverse("orgs.org_export"))
         self.assertNotContains(response, "Register Patient")
 
-    @mock_mailroom
-    def test_prevent_flow_type_changes(self, mr_mocks):
+    def test_prevent_flow_type_changes(self):
         flow1 = self.create_flow("Background")
 
         flow2 = self.get_flow("background")  # contains a flow called Background

--- a/temba/staff/tests.py
+++ b/temba/staff/tests.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from temba.contacts.models import Contact
 from temba.orgs.models import Org, OrgMembership, OrgRole
-from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
+from temba.tests import CRUDLTestMixin, TembaTest
 from temba.utils.views.mixins import TEMBA_MENU_SELECTION
 
 
@@ -144,8 +144,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.org.refresh_from_db()
         self.assertTrue(self.org.is_verified)
 
-    @mock_mailroom
-    def test_service(self, mr_mocks):
+    def test_service(self):
         service_url = reverse("staff.org_service")
         inbox_url = reverse("msgs.msg_inbox")
 
@@ -334,8 +333,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         self.editor.refresh_from_db()
         self.assertFalse(self.editor.is_mfa_enabled)
 
-    @mock_mailroom
-    def test_delete(self, mr_mocks):
+    def test_delete(self):
         delete_url = reverse("staff.user_delete", args=[self.editor.id])
 
         # this is a customer support only view

--- a/temba/tickets/tests/test_ticket.py
+++ b/temba/tickets/tests/test_ticket.py
@@ -88,8 +88,7 @@ class TicketTest(TembaTest):
         # a non-staff user with no membership in the org sees nothing (fails closed)
         self.assertEqual(set(), set(Ticket.get_accessible(self.org, self.admin2)))
 
-    @mock_mailroom
-    def test_counts(self, mr_mocks):
+    def test_counts(self):
         general = self.org.default_topic
         cats = Topic.create(self.org, self.admin, "Cats")
 

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -272,8 +272,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
             menu_url, self.agent3, ["My Tickets (0)", "Unassigned (0)", "All (0)", ("Topics", ["Support (0)"])]
         )
 
-    @mock_mailroom
-    def test_folder(self, mr_mocks):
+    def test_folder(self):
         self.login(self.admin)
 
         contact1 = self.create_contact("Joe", phone="123", last_seen_on=timezone.now())
@@ -580,8 +579,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertEqual([], response.json()["results"])
             self.assertNotIn("next", response.json())
 
-    @mock_mailroom
-    def test_folder_refresh_bounding(self, mr_mocks):
+    def test_folder_refresh_bounding(self):
         contact = self.create_contact("Joe", phone="123")
         base = timezone.now().replace(microsecond=0)
 
@@ -611,8 +609,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.requestView(f"/ticket/folder/all/?after={after}", self.admin)
             self.assertEqual([str(t.uuid) for t in tied], [t["ticket"]["uuid"] for t in response.json()["results"]])
 
-    @mock_mailroom
-    def test_folder_merged_page_ties(self, mr_mocks):
+    def test_folder_merged_page_ties(self):
         contact = self.create_contact("Joe", phone="123")
         open1 = self.create_ticket(contact)
         closed1 = self.create_ticket(contact, closed_on=timezone.now())
@@ -641,8 +638,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertEqual([], response.json()["results"])
             self.assertNotIn("next", response.json())
 
-    @mock_mailroom
-    def test_folder_cursor_without_status(self, mr_mocks):
+    def test_folder_cursor_without_status(self):
         contact = self.create_contact("Joe", phone="123")
         open1 = self.create_ticket(contact)
         open2 = self.create_ticket(contact)
@@ -664,8 +660,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
                 [str(open1.uuid), str(closed1.uuid)], [t["ticket"]["uuid"] for t in response.json()["results"]]
             )
 
-    @mock_mailroom
-    def test_folder_invalid_params(self, mr_mocks):
+    def test_folder_invalid_params(self):
         contact = self.create_contact("Joe", phone="123")
         ticket1 = self.create_ticket(contact)
         ticket2 = self.create_ticket(contact, assignee=self.admin)
@@ -804,8 +799,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(200, response.status_code)
         self.assertEqual({"results": []}, response.json())
 
-    @mock_mailroom
-    def test_note(self, mr_mocks):
+    def test_note(self):
         ticket = self.create_ticket(self.contact)
 
         update_url = reverse("tickets.ticket_note", args=[ticket.uuid])
@@ -1010,8 +1004,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
             response["Content-Disposition"],
         )
 
-    @mock_mailroom
-    def test_export(self, mr_mocks):
+    def test_export(self):
         export_url = reverse("tickets.ticket_export")
 
         self.assertRequestDisallowed(export_url, [None, self.agent])

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -9,7 +9,6 @@ from temba.contacts.omnibox import omnibox_serialize
 from temba.flows.models import Flow
 from temba.schedules.models import Schedule
 from temba.tests import CRUDLTestMixin, TembaTest
-from temba.tests.mailroom import mock_mailroom
 from temba.triggers.models import Trigger
 from temba.utils.views.mixins import TEMBA_MENU_SELECTION
 
@@ -58,8 +57,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         with override_settings(ORG_LIMIT_DEFAULTS={"triggers": 1}):
             self.assertPageMenu(menu_url, self.editor, ["Active (1)", "Archived (1)", "Messages (1)"])
 
-    @mock_mailroom
-    def test_create(self, mr_mocks):
+    def test_create(self):
         create_url = reverse("triggers.trigger_create")
         create_new_convo_url = reverse("triggers.trigger_create_new_conversation")
         create_inbound_call_url = reverse("triggers.trigger_create_inbound_call")

--- a/temba/users/tests/test_user.py
+++ b/temba/users/tests/test_user.py
@@ -3,7 +3,7 @@ from allauth.mfa.models import Authenticator
 from temba.api.models import APIToken
 from temba.orgs.models import OrgRole
 from temba.orgs.tasks import update_members_seen
-from temba.tests import TembaTest, mock_mailroom
+from temba.tests import TembaTest
 from temba.users.models import User
 
 
@@ -128,8 +128,7 @@ class UserTest(TembaTest):
                     f"expected {user} to{'' if has_perm else ' not'} have perm {perm} in org {org.name}",
                 )
 
-    @mock_mailroom
-    def test_release(self, mr_mocks):
+    def test_release(self):
         token = APIToken.create(self.org, self.admin)
 
         # admin doesn't "own" any orgs


### PR DESCRIPTION
## Summary

`@mock_mailroom` exists only to pass a test's `self.mr_mocks` in as a method argument — the mocked mailroom client itself is installed for *every* test in `TembaTest.setUp`. 132 test methods carried the decorator (and its `mr_mocks` parameter) without ever referencing it, which reads as though those tests need special mailroom setup when they don't.

This removes the decorator wherever the injected parameter was unused, leaving it on the 74 tests that genuinely configure mocks.

## Changes

- Dropped `@mock_mailroom` and the unused `mr_mocks` parameter from 132 test methods across 40 files in `api`, `campaigns`, `channels`, `contacts`, `flows`, `msgs`, `orgs`, `staff`, `tickets`, `triggers` and `users`.
- Removed the now-unused `mock_mailroom` import from the 22 files where it was the last usage.

No changes to `temba/tests/mailroom.py` or to any test's behavior — the mocked client is still installed everywhere, so tests that reach mailroom indirectly are unaffected.

## Before / after

```python
# before
@mock_mailroom
def test_toggle_label(self, mr_mocks):
    label = self.create_label("Spam")
    ...

# after
def test_toggle_label(self):
    label = self.create_label("Spam")
    ...
```

## Test plan

- [x] Identified candidates by AST — decorated methods whose injected parameter is never referenced in the body
- [x] Full test suite passes: 1158 tests, no failures
- [x] `code_check.py` clean (migrations, locale files, ruff format, ruff)