### PR TITLE
Fix flow editor crash reclassifying nodes in a frozen definition

### DIFF
--- a/components/src/store/AppState.ts
+++ b/components/src/store/AppState.ts
@@ -347,6 +347,11 @@ export const zustand = createStore<AppState>()(
           throw new Error('Network response was not ok');
         }
         const data = (await response.json()) as FlowContents;
+        // reclassify while the definition is still the mutable response JSON -
+        // resolveDependencyNames below returns an immer-frozen definition that
+        // in-place reclassification would throw on
+        reclassifyTerminalNodes(data.definition);
+        reclassifyVoiceWaitNodes(data.definition);
         if (dependencyResolver && data.info?.dependencies?.length) {
           try {
             // resolving before the first paint avoids a visible flash of stale
@@ -378,8 +383,6 @@ export const zustand = createStore<AppState>()(
             console.error('failed to resolve flow dependency names', error);
           }
         }
-        reclassifyTerminalNodes(data.definition);
-        reclassifyVoiceWaitNodes(data.definition);
         const issueMaps = buildIssueMaps(data.info?.issues);
         const flowLang = data.definition.language;
         set({
@@ -475,11 +478,18 @@ export const zustand = createStore<AppState>()(
       setFlowContents: (flow: FlowContents) => {
         set((state: AppState) => {
           const flowLang = flow.definition.language;
-          // Clone to ensure mutable for sorting
-          state.flowDefinition = {
-            ...flow.definition,
-            nodes: [...(flow.definition.nodes || [])]
-          };
+          // the definition handed in may be frozen store state (e.g. restoring
+          // a pre-revision-view snapshot), so reclassify and sort on a draft
+          state.flowDefinition = produce(
+            flow.definition,
+            (draft: FlowDefinition) => {
+              reclassifyTerminalNodes(draft);
+              reclassifyVoiceWaitNodes(draft);
+              if (draft.nodes && draft._ui?.nodes) {
+                sortNodesByPosition(draft.nodes, draft._ui.nodes);
+              }
+            }
+          );
           state.flowInfo = flow.info;
           const issueMaps = buildIssueMaps(flow.info?.issues);
           state.issuesByNode = issueMaps.byNode;
@@ -488,17 +498,6 @@ export const zustand = createStore<AppState>()(
           state.languageCode = flowLang;
           state.isTranslating = false;
           state.viewingRevision = false;
-
-          reclassifyTerminalNodes(state.flowDefinition);
-          reclassifyVoiceWaitNodes(state.flowDefinition);
-
-          // Sort nodes by position when loading flow
-          if (state.flowDefinition?.nodes && state.flowDefinition?._ui?.nodes) {
-            sortNodesByPosition(
-              state.flowDefinition.nodes,
-              state.flowDefinition._ui.nodes
-            );
-          }
         });
       },
 

--- a/components/test/temba-appstate-actions.test.ts
+++ b/components/test/temba-appstate-actions.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@open-wc/testing';
+import { freeze } from 'immer';
 import { useFakeTimers } from 'sinon';
 import { setDependencyResolver, zustand } from '../src/store/AppState';
 import { resolveDependencyNames } from '../src/flow/dependencies';
@@ -479,6 +480,68 @@ describe('store/AppState actions', () => {
     });
   });
 
+  describe('setFlowContents', () => {
+    it('reclassifies voice waits in a frozen definition', () => {
+      // restoring a pre-revision-view snapshot hands back frozen store state
+      const frozen = freeze(
+        definition({
+          type: 'voice',
+          nodes: [
+            {
+              uuid: 'node-1',
+              actions: [],
+              exits: [{ uuid: 'exit-1', destination_uuid: null }],
+              router: {
+                type: 'switch',
+                wait: { type: 'msg', hint: { type: 'digits', count: 1 } },
+                categories: [],
+                cases: [],
+                default_category_uuid: null
+              }
+            }
+          ],
+          _ui: {
+            nodes: {
+              'node-1': {
+                position: { left: 0, top: 0 },
+                type: 'wait_for_response'
+              }
+            }
+          }
+        }),
+        true
+      );
+
+      state().setFlowContents({ definition: frozen, info: info() } as any);
+
+      expect((state().flowDefinition as any)._ui.nodes['node-1'].type).to.equal(
+        'wait_for_menu'
+      );
+    });
+
+    it('sorts a frozen definition by node position', () => {
+      const frozen = freeze(
+        definition({
+          nodes: [
+            nodeWithExit('node-low', 'exit-1'),
+            nodeWithExit('node-high', 'exit-2')
+          ],
+          _ui: {
+            nodes: {
+              'node-low': { position: { left: 0, top: 100 } },
+              'node-high': { position: { left: 0, top: 0 } }
+            }
+          }
+        }),
+        true
+      );
+
+      state().setFlowContents({ definition: frozen, info: info() } as any);
+
+      expect(state().flowDefinition.nodes[0].uuid).to.equal('node-high');
+    });
+  });
+
   describe('fetchRevision', () => {
     const REVISION_URL = '/flow/revisions/flow-1';
 
@@ -618,6 +681,57 @@ describe('store/AppState actions', () => {
       expect(
         (state().flowDefinition as any)._ui.nodes['node-1'].config.operand.name
       ).to.equal('Age');
+    });
+
+    it('reclassifies voice waits even when name resolution freezes the definition', async () => {
+      // resolving names returns an immer-frozen definition, so the voice wait
+      // reclassification has to happen before it or the frozen _ui throws
+      setDependencyResolver(async () => [
+        { type: 'field', key: 'age', name: 'Age' }
+      ]);
+      mockRevision({
+        definition: definition({
+          type: 'voice',
+          nodes: [
+            {
+              uuid: 'node-1',
+              actions: [
+                {
+                  type: 'set_contact_field',
+                  uuid: 'action-1',
+                  field: { key: 'age', name: 'Old Age' },
+                  value: '10'
+                }
+              ],
+              exits: [{ uuid: 'exit-1', destination_uuid: null }],
+              router: {
+                type: 'switch',
+                wait: { type: 'msg', hint: { type: 'digits', count: 1 } },
+                categories: [],
+                cases: [],
+                default_category_uuid: null
+              }
+            }
+          ],
+          _ui: {
+            nodes: {
+              'node-1': {
+                position: { left: 0, top: 0 },
+                type: 'wait_for_response'
+              }
+            }
+          }
+        }),
+        info: info({
+          dependencies: [{ type: 'field', key: 'age', name: 'Old Age' }]
+        })
+      });
+
+      await state().fetchRevision(REVISION_URL);
+
+      expect((state().flowDefinition as any)._ui.nodes['node-1'].type).to.equal(
+        'wait_for_menu'
+      );
     });
 
     it('resolves every referenced flow before exposing a revision', async () => {


### PR DESCRIPTION
## Summary

Fixes the flow editor failing to open flows — in practice voice flows with dependencies — with `TypeError: Cannot assign to read only property 'type'` thrown from `fetchRevision`, leaving the editor stuck on the loading spinner.

## Changes

- **`components/src/store/AppState.ts`**
  - `fetchRevision` now runs `reclassifyTerminalNodes` / `reclassifyVoiceWaitNodes` *before* dependency-name resolution. `resolveDependencyNames` runs the definition through immer's `produce`, which deep-freezes the result, so the in-place `_ui` node type reclassification that followed threw on any flow that both has dependencies and needs a node reclassified. Every voice wait carries a `hint` and so always needs reclassifying, which is why voice flows were reliably affected.
  - `setFlowContents` had the same latent crash when handed frozen store state (e.g. restoring the pre-revision-view snapshot after cancelling a revision browse) — it now reclassifies and sorts on an immer draft instead of mutating in place.
- **`components/test/temba-appstate-actions.test.ts`** — regression tests for both paths, verified to fail against the previous code.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Open a voice flow with ≥1 dependency | `TypeError`, editor stuck on spinner | Loads, voice waits shown as menu/digits/audio waits |
| Open a flow where name resolution times out | Loads (definition never frozen) | Loads (unchanged) |
| Cancel a revision view on a voice flow | Latent same crash | Restores the snapshot cleanly |

Before 53052385f, resolution was gated on an actual rename so the freeze rarely happened; resolving on every load with dependencies made the crash deterministic.

## Test plan

- [x] New regression tests fail against the previous `AppState.ts`, pass with the fix
- [x] Full components suite: 2970 passed, 0 failed
- [x] `bun run validate` (format, build, coverage) passes as CI runs it
