### PR TITLE
Add migration to backfill Msg.folder

### DIFF
--- a/temba/msgs/migrations/0310_backfill_msg_folder.py
+++ b/temba/msgs/migrations/0310_backfill_msg_folder.py
@@ -1,0 +1,75 @@
+from django.db import connection as default_connection, migrations
+from django.db.models import Max, Min
+
+# Msg.folder is denormalized from direction/visibility/status/flow and is written by mailroom and courier for new
+# messages - this fills it in for the messages that predate that. The CASE mirrors Msg.derive_folder, including its
+# precedence: being deleted, and then being unhandled, both come before the user facing folders, so that a message
+# which is archived or deleted whilst still pending doesn't land in Archived.
+#
+# The branches are exhaustive over the states the database allows, because the temba_msg_on_change trigger rejects
+# the only two combinations that would otherwise fall through - an incoming message that isn't pending or handled,
+# and an outgoing message that is archived. Should one somehow exist, it keeps its null folder.
+#
+# The table is far too large to scan for null folders, so we walk the primary key range in batches instead, newest
+# first so that the messages users are most likely to be looking at are filled in first. Each batch is its own
+# transaction, so an interrupted run can be resumed from the last id it reported.
+
+BATCH_SIZE = 1_000_000  # ids per batch, not rows - ids are sparse wherever messages have been deleted
+
+SQL_BACKFILL_FOLDER = """
+UPDATE msgs_msg SET folder = CASE
+    WHEN visibility IN ('D', 'X') THEN 'D'                                                   -- deleted
+    WHEN direction = 'I' AND status = 'P' THEN 'P'                                           -- pending
+    WHEN direction = 'I' AND visibility = 'V' AND status = 'H' AND flow_id IS NULL THEN 'I'  -- inbox
+    WHEN direction = 'I' AND visibility = 'V' AND status = 'H' THEN 'W'                      -- handled
+    WHEN direction = 'I' AND visibility = 'A' AND status = 'H' THEN 'A'                      -- archived
+    WHEN direction = 'O' AND visibility = 'V' AND status IN ('I', 'Q', 'E') THEN 'O'         -- outbox
+    WHEN direction = 'O' AND visibility = 'V' AND status IN ('W', 'S', 'D', 'R') THEN 'S'    -- sent
+    WHEN direction = 'O' AND visibility = 'V' AND status = 'F' THEN 'X'                      -- failed
+END
+WHERE id >= %(low)s AND id <= %(high)s AND folder IS NULL
+"""
+
+
+def backfill_msg_folder(apps, schema_editor):
+    Msg = apps.get_model("msgs", "Msg")
+
+    # schema_editor is None when this is run out of band via apply_manual
+    conn = schema_editor.connection if schema_editor else default_connection
+
+    id_range = Msg.objects.aggregate(low=Min("id"), high=Max("id"))
+    lowest, highest = id_range["low"], id_range["high"]
+    if lowest is None:  # no messages at all
+        return
+
+    num_updated = 0
+    batch_high = highest
+
+    while batch_high >= lowest:
+        batch_low = max(batch_high - BATCH_SIZE + 1, lowest)
+
+        with conn.cursor() as cursor:
+            cursor.execute(SQL_BACKFILL_FOLDER, {"low": batch_low, "high": batch_high})
+            num_updated += cursor.rowcount
+
+        print(f"Backfilled folder on {num_updated} messages (down to id={batch_low})")
+
+        batch_high = batch_low - 1
+
+
+def apply_manual():  # pragma: no cover
+    from django.apps import apps
+
+    backfill_msg_folder(apps, None)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("msgs", "0309_msg_folder"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_msg_folder, migrations.RunPython.noop),
+    ]

--- a/temba/msgs/migrations/0310_backfill_msg_folder.py
+++ b/temba/msgs/migrations/0310_backfill_msg_folder.py
@@ -6,15 +6,21 @@ from django.db.models import Max, Min
 # precedence: being deleted, and then being unhandled, both come before the user facing folders, so that a message
 # which is archived or deleted whilst still pending doesn't land in Archived.
 #
-# The branches are exhaustive over the states the database allows, because the temba_msg_on_change trigger rejects
-# the only two combinations that would otherwise fall through - an incoming message that isn't pending or handled,
-# and an outgoing message that is archived. Should one somehow exist, it keeps its null folder.
+# A message whose state matches no branch keeps its null folder rather than being guessed at. The temba_msg_on_change
+# trigger rules out most of those - an incoming message that isn't pending or handled, and an outgoing message that is
+# archived - but not every one: an outgoing message that is somehow pending or handled is legal and falls through.
 #
 # The table is far too large to scan for null folders, so we walk the primary key range in batches instead, newest
 # first so that the messages users are most likely to be looking at are filled in first. Each batch is its own
 # transaction, so an interrupted run can be resumed from the last id it reported.
+#
+# Batching by id range is what gets each statement served by the primary key, but the size is chosen by what one
+# statement should cost rather than by that: msgs_msg carries a FOR EACH ROW trigger, so a batch is that many plpgsql
+# calls, that many row locks held until it commits, and a WAL burst to match - all on the rows courier and mailroom
+# are concurrently writing. Hence a size that keeps a batch cheap on the dense recent end of the table, where ids and
+# rows are close to one to one.
 
-BATCH_SIZE = 1_000_000  # ids per batch, not rows - ids are sparse wherever messages have been deleted
+BATCH_SIZE = 100_000  # ids per batch, not rows - ids are sparse wherever messages have been deleted
 
 SQL_BACKFILL_FOLDER = """
 UPDATE msgs_msg SET folder = CASE

--- a/temba/msgs/tests/test_migrations.py
+++ b/temba/msgs/tests/test_migrations.py
@@ -1,6 +1,8 @@
 from importlib import import_module
 from unittest.mock import patch
 
+from django.utils import timezone
+
 from temba.msgs.models import Msg
 from temba.tests import MigrationTest
 
@@ -38,10 +40,18 @@ class BackfillMsgFolderTest(MigrationTest):
         self.inbox = self.create_incoming_msg(contact, "Hi")
         self.handled = self.create_incoming_msg(contact, "Hi", flow=flow)
         self.archived = self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_ARCHIVED)
-        self.outbox = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_QUEUED)
-        self.sent = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_SENT)
         self.failed = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_FAILED)
         self.pending = self.create_incoming_msg(contact, "Hi", status=Msg.STATUS_PENDING)
+
+        # the outbox and sent folders each fold in several statuses
+        self.outbox = {
+            s: self.create_outgoing_msg(contact, "Hi", status=s)
+            for s in (Msg.STATUS_INITIALIZING, Msg.STATUS_QUEUED, Msg.STATUS_ERRORED)
+        }
+        self.sent = {
+            s: self.create_outgoing_msg(contact, "Hi", status=s, sent_on=timezone.now())
+            for s in (Msg.STATUS_WIRED, Msg.STATUS_SENT, Msg.STATUS_DELIVERED, Msg.STATUS_READ)
+        }
 
         # deleted and unhandled take precedence over the user facing folders
         self.deleted = self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_DELETED_BY_USER)
@@ -56,6 +66,9 @@ class BackfillMsgFolderTest(MigrationTest):
         self.already_set = self.create_incoming_msg(contact, "Hi")
         Msg.objects.filter(id=self.already_set.id).update(folder=Msg.FOLDER_ARCHIVED)
 
+        # an outgoing message that is pending belongs to no folder - unlikely, but the database permits it
+        self.underivable = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_PENDING)
+
     def test_migration(self):
         def assert_folder(msg, expected):
             msg.refresh_from_db()
@@ -64,15 +77,19 @@ class BackfillMsgFolderTest(MigrationTest):
         assert_folder(self.inbox, Msg.FOLDER_INBOX)
         assert_folder(self.handled, Msg.FOLDER_HANDLED)
         assert_folder(self.archived, Msg.FOLDER_ARCHIVED)
-        assert_folder(self.outbox, Msg.FOLDER_OUTBOX)
-        assert_folder(self.sent, Msg.FOLDER_SENT)
         assert_folder(self.failed, Msg.FOLDER_FAILED)
         assert_folder(self.pending, Msg.FOLDER_PENDING)
         assert_folder(self.deleted, Msg.FOLDER_DELETED)
         assert_folder(self.deleted_by_sender, Msg.FOLDER_DELETED)
         assert_folder(self.pending_archived, Msg.FOLDER_PENDING)
 
+        for msg in self.outbox.values():
+            assert_folder(msg, Msg.FOLDER_OUTBOX)
+        for msg in self.sent.values():
+            assert_folder(msg, Msg.FOLDER_SENT)
+
         assert_folder(self.already_set, Msg.FOLDER_ARCHIVED)  # not recalculated
+        assert_folder(self.underivable, None)  # left alone rather than guessed at
 
 
 class BackfillMsgFolderPagingTest(MigrationTest):

--- a/temba/msgs/tests/test_migrations.py
+++ b/temba/msgs/tests/test_migrations.py
@@ -1,3 +1,7 @@
+from importlib import import_module
+from unittest.mock import patch
+
+from temba.msgs.models import Msg
 from temba.tests import MigrationTest
 
 
@@ -20,3 +24,94 @@ class BackfillBroadcastUUIDsTest(MigrationTest):
         self.assertIsNotNone(self.bcast1.uuid)
         self.bcast2.refresh_from_db()
         self.assertEqual("01997d23-81ec-73c2-a3da-4d8d69025931", str(self.bcast2.uuid))  # unchanged
+
+
+class BackfillMsgFolderTest(MigrationTest):
+    app = "msgs"
+    migrate_from = "0309_msg_folder"
+    migrate_to = "0310_backfill_msg_folder"
+
+    def setUpBeforeMigration(self, apps):
+        contact = self.create_contact("Bob", phone="+1234567890")
+        flow = self.create_flow("Test")
+
+        self.inbox = self.create_incoming_msg(contact, "Hi")
+        self.handled = self.create_incoming_msg(contact, "Hi", flow=flow)
+        self.archived = self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_ARCHIVED)
+        self.outbox = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_QUEUED)
+        self.sent = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_SENT)
+        self.failed = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_FAILED)
+        self.pending = self.create_incoming_msg(contact, "Hi", status=Msg.STATUS_PENDING)
+
+        # deleted and unhandled take precedence over the user facing folders
+        self.deleted = self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_DELETED_BY_USER)
+        self.deleted_by_sender = self.create_incoming_msg(
+            contact, "Hi", status=Msg.STATUS_PENDING, visibility=Msg.VISIBILITY_DELETED_BY_SENDER
+        )
+        self.pending_archived = self.create_incoming_msg(
+            contact, "Hi", status=Msg.STATUS_PENDING, visibility=Msg.VISIBILITY_ARCHIVED
+        )
+
+        # a message that already has a folder shouldn't be recalculated
+        self.already_set = self.create_incoming_msg(contact, "Hi")
+        Msg.objects.filter(id=self.already_set.id).update(folder=Msg.FOLDER_ARCHIVED)
+
+    def test_migration(self):
+        def assert_folder(msg, expected):
+            msg.refresh_from_db()
+            self.assertEqual(expected, msg.folder, f"folder mismatch for msg #{msg.id}")
+
+        assert_folder(self.inbox, Msg.FOLDER_INBOX)
+        assert_folder(self.handled, Msg.FOLDER_HANDLED)
+        assert_folder(self.archived, Msg.FOLDER_ARCHIVED)
+        assert_folder(self.outbox, Msg.FOLDER_OUTBOX)
+        assert_folder(self.sent, Msg.FOLDER_SENT)
+        assert_folder(self.failed, Msg.FOLDER_FAILED)
+        assert_folder(self.pending, Msg.FOLDER_PENDING)
+        assert_folder(self.deleted, Msg.FOLDER_DELETED)
+        assert_folder(self.deleted_by_sender, Msg.FOLDER_DELETED)
+        assert_folder(self.pending_archived, Msg.FOLDER_PENDING)
+
+        assert_folder(self.already_set, Msg.FOLDER_ARCHIVED)  # not recalculated
+
+
+class BackfillMsgFolderPagingTest(MigrationTest):
+    """
+    The backfill walks the id range in batches of BATCH_SIZE ids, so with a realistic batch size a test fixture never
+    runs the loop more than once. Shrink it so that advancing between batches is actually exercised.
+    """
+
+    app = "msgs"
+    migrate_from = "0309_msg_folder"
+    migrate_to = "0310_backfill_msg_folder"
+
+    def setUp(self):
+        # has to be patched before super() runs the migration
+        migration = import_module("temba.msgs.migrations.0310_backfill_msg_folder")
+        patcher = patch.object(migration, "BATCH_SIZE", 1)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        super().setUp()
+
+    def setUpBeforeMigration(self, apps):
+        contact = self.create_contact("Bob", phone="+1234567890")
+
+        # enough messages to span several batches
+        self.msgs = [self.create_incoming_msg(contact, f"Hi {m}") for m in range(5)]
+
+    def test_migration(self):
+        # every message filled in, so no batch was skipped
+        for msg in self.msgs:
+            msg.refresh_from_db()
+            self.assertEqual(Msg.FOLDER_INBOX, msg.folder, f"folder mismatch for msg #{msg.id}")
+
+
+class BackfillMsgFolderNoMessagesTest(MigrationTest):
+    app = "msgs"
+    migrate_from = "0309_msg_folder"
+    migrate_to = "0310_backfill_msg_folder"
+
+    def test_migration(self):
+        # a workspace with no messages at all has no id range to walk
+        self.assertEqual(0, Msg.objects.count())


### PR DESCRIPTION
## Summary

`Msg.folder` was added in `0309_msg_folder` as a nullable denormalized column that mailroom and courier write for new messages. This adds `0310_backfill_msg_folder` to fill it in for the messages that predate that, so that a null folder eventually means "not written yet" for no message at all.

## Changes

**`temba/msgs/migrations/0310_backfill_msg_folder.py`**

- Backfills `folder` with a raw SQL `UPDATE ... SET folder = CASE ...` that mirrors `Msg.derive_folder`, preserving its precedence: deleted first, then unhandled incoming, then the six user-facing folders.
- Walks the primary key range in batches rather than filtering on `folder IS NULL`. There is no index on `folder`, so the usual "select a page of rows needing work" backfill pattern would sequentially scan the whole message table on every batch; an id range is served by the primary key.
- Batches run newest first, so the messages users are most likely to be looking at are filled in first.
- `atomic = False`, so each batch commits as it goes. An interrupted run resumes from the id it last reported rather than rolling back, which matters on a table this size.
- Exposes `apply_manual()` like the other backfills in this app, for running out of band.

**`temba/msgs/tests/test_migrations.py`**

- `BackfillMsgFolderTest` covers all eight folder codes — including each status the outbox and sent branches fold together — the precedence cases, that a message which already has a folder isn't recalculated, and that one belonging to no folder is left null.
- `BackfillMsgFolderPagingTest` shrinks the batch size so that advancing between batches is actually exercised; with a realistic size a test fixture never runs the loop more than once.
- `BackfillMsgFolderNoMessagesTest` covers the empty-table case.

## Behavior examples

The `CASE` derives the same folder that `Msg.derive_folder` does:

| direction | visibility | status | flow | folder |
|---|---|---|---|---|
| in | visible | handled | null | `I` (inbox) |
| in | visible | handled | set | `W` (handled) |
| in | archived | handled | — | `A` (archived) |
| out | visible | initializing / queued / errored | — | `O` (outbox) |
| out | visible | wired / sent / delivered / read | — | `S` (sent) |
| out | visible | failed | — | `X` (failed) |
| in | any | pending | — | `P` (pending) |
| any | deleted by user/sender | any | — | `D` (deleted) |

The last two rows are the precedence cases: a message archived or deleted while still pending is pending or deleted, not archived, so it doesn't show up in the Archived folder.

A message matching no branch keeps its null folder rather than being guessed at. The `temba_msg_on_change` trigger rules out most such states — an incoming message that is neither pending nor handled, and an outgoing message that is archived — but not every one: an outgoing message that is somehow pending or handled is legal and falls through. That is gentler than `derive_folder`, which asserts.

### Batch size

`BATCH_SIZE` bounds ids per batch, not rows, since ids are sparse wherever messages have been deleted. It is set by what a single statement should cost rather than by what the primary key can serve: `msgs_msg` carries a `FOR EACH ROW` trigger, so a batch is that many plpgsql calls, that many row locks held until it commits, and a WAL burst to match — all on the rows courier and mailroom are concurrently writing. On the dense recent end of the table ids and rows are close to one to one, so 100k keeps a batch cheap there while still being an index range scan.

The statement-level `temba_msg_on_update` trigger is unaffected: `temba_msg_countscope` is derived from direction/visibility/status/flow_id and not from `folder`, so a folder-only update produces no distinct old/new scope and inserts no `orgs_itemcount` rows.

## Test plan

- [x] `python manage.py test temba.msgs` — 61 tests, all passing
- [x] New migration module at 100% statement coverage
- [x] Mutation-checked the new assertions: dropping `'R'` from the sent status list fails `BackfillMsgFolderTest`
- [x] `python manage.py makemigrations --check` — no changes detected
- [x] `code_check.py` — clean