### PR TITLE
Remove undocumented message archiving actions from contact bulk actions endpoint

### DIFF
--- a/temba/api/tests/test_support.py
+++ b/temba/api/tests/test_support.py
@@ -16,16 +16,16 @@ class RecordDeprecatedTest(TembaTest):
         key = f"warnings:{timezone.now():%Y-%m}"
         r.delete(key)  # other tests may have recorded into this month's bucket
 
-        record_deprecated(self.org, "contact_actions#archive_messages")
-        record_deprecated(self.org, "contact_actions#archive_messages")
-        record_deprecated(self.org, "contact_actions#archive")
-        record_deprecated(self.org2, "contact_actions#archive_messages")
+        record_deprecated(self.org, "messages#filter:id")
+        record_deprecated(self.org, "messages#filter:id")
+        record_deprecated(self.org, "definitions#get")
+        record_deprecated(self.org2, "messages#filter:id")
 
         self.assertEqual(
             {
-                f"api:deprecated:{self.org.id}/contact_actions#archive_messages": b"2",
-                f"api:deprecated:{self.org.id}/contact_actions#archive": b"1",
-                f"api:deprecated:{self.org2.id}/contact_actions#archive_messages": b"1",
+                f"api:deprecated:{self.org.id}/messages#filter:id": b"2",
+                f"api:deprecated:{self.org.id}/definitions#get": b"1",
+                f"api:deprecated:{self.org2.id}/messages#filter:id": b"1",
             },
             {f.decode(): c for f, c in r.hgetall(key).items()},
         )
@@ -37,4 +37,4 @@ class RecordDeprecatedTest(TembaTest):
         with patch("temba.api.support.get_valkey_connection") as mock_get_conn:
             mock_get_conn.side_effect = ValueError("boom")
 
-            record_deprecated(self.org, "contact_actions#archive_messages")  # no exception
+            record_deprecated(self.org, "messages#filter:id")  # no exception

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -26,7 +26,6 @@ from temba.utils import json
 from temba.utils.fields import NameValidator
 
 from ..models import BulkActionFailure, Resthook, ResthookSubscriber, WebHookEvent
-from ..support import record_deprecated
 from ..validators import UniqueForOrgValidator
 from . import fields
 
@@ -947,11 +946,9 @@ class ContactBulkActionSerializer(WriteSerializer):
     BLOCK = "block"
     UNBLOCK = "unblock"
     INTERRUPT = "interrupt"
-    ARCHIVE_MESSAGES = "archive_messages"
     DELETE = "delete"
-    ARCHIVE = "archive"  # backward compatibility
 
-    ACTIONS = (ADD, REMOVE, BLOCK, UNBLOCK, INTERRUPT, ARCHIVE_MESSAGES, DELETE, ARCHIVE)
+    ACTIONS = (ADD, REMOVE, BLOCK, UNBLOCK, INTERRUPT, DELETE)
     ACTIONS_WITH_GROUP = (ADD, REMOVE)
 
     contacts = fields.ContactField(many=True)
@@ -995,11 +992,6 @@ class ContactBulkActionSerializer(WriteSerializer):
             Contact.bulk_change_group(user, contacts, group, add=False, via_api=True)
         elif action == self.INTERRUPT:
             Contact.bulk_interrupt(user, contacts)
-        elif action == self.ARCHIVE_MESSAGES or action == self.ARCHIVE:
-            # tracked separately for each action name so we can see if the older alias can be dropped on its own
-            record_deprecated(self.context["org"], f"contact_actions#{action}")
-
-            Msg.archive_all_for_contacts(contacts)
         elif action == self.BLOCK:
             Contact.bulk_change_status(user, contacts, modifiers.Status.BLOCKED, via_api=True)
         elif action == self.UNBLOCK:

--- a/temba/api/v2/tests/test_contact_actions.py
+++ b/temba/api/v2/tests/test_contact_actions.py
@@ -186,26 +186,14 @@ class ContactActionsEndpointTest(APITest):
 
         self.assertEqual([call(self.org, self.admin, [contact1, contact2])], mr_mocks.calls["contact_interrupt"])
 
-        # archive all messages for contacts 1 and 2
-        self.assertPost(
-            endpoint_url,
-            self.admin,
-            {"contacts": [contact1.uuid, contact2.uuid], "action": "archive_messages"},
-            status=204,
-        )
-        self.assertFalse(Msg.objects.filter(contact__in=[contact1, contact2], direction="I", visibility="V").exists())
-        self.assertTrue(Msg.objects.filter(contact=contact3, direction="I", visibility="V").exists())
-
-        # as a deprecated action, that's recorded so we can see if anything still uses it
-        self.assertPost(
-            endpoint_url,
-            self.admin,
-            {"contacts": [contact3.uuid], "action": "archive"},  # the older alias
-            status=204,
-        )
-
-        self.assertDeprecatedRecorded("contact_actions#archive_messages", 1)
-        self.assertDeprecatedRecorded("contact_actions#archive", 1)
+        # the removed message archiving actions are no longer accepted
+        for action in ("archive_messages", "archive"):
+            self.assertPost(
+                endpoint_url,
+                self.admin,
+                {"contacts": [contact1.uuid], "action": action},
+                errors={"action": f'"{action}" is not a valid choice.'},
+            )
 
         # delete contacts 1 and 2
         self.assertPost(

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -763,19 +763,6 @@ class Msg(models.Model):
         return folder.code
 
     @classmethod
-    def archive_all_for_contacts(cls, contacts):
-        """
-        Archives all incoming messages for the given contacts
-        """
-        msgs = Msg.objects.filter(direction=cls.DIRECTION_IN, visibility=cls.VISIBILITY_VISIBLE, contact__in=contacts)
-        msg_ids = list(msgs.values_list("pk", flat=True))
-
-        # update modified on in small batches to avoid long table lock, and having too many non-unique values for
-        # modified_on which is the primary ordering for the API
-        for batch in itertools.batched(msg_ids, 100):
-            Msg.objects.filter(pk__in=batch).update(visibility=cls.VISIBILITY_ARCHIVED, modified_on=timezone.now())
-
-    @classmethod
     def apply_action_label(cls, user, msgs, label):
         label.toggle_label(msgs, add=True)
 


### PR DESCRIPTION
## Summary

The API v2 contact actions endpoint accepted two undocumented actions, `archive_messages` and its older alias `archive`, which archived every incoming message for the given contacts. They were never listed in the endpoint documentation, and usage tracking showed nothing calling them. They were also the last remaining path that changed message visibility with a direct database update, leaving the denormalized `folder` field stale, so removing them retires that inconsistency along with the actions.

## Changes

- `temba/api/v2/serializers.py`: dropped `archive_messages` and `archive` from `ContactBulkActionSerializer.ACTIONS` and from `save()`, along with the deprecation recording they were the only user of.
- `temba/msgs/models.py`: removed `Msg.archive_all_for_contacts`, which those actions were the only caller of. Every remaining archive path goes through `Msg.bulk_archive` and mailroom, which maintains `folder`.
- `temba/api/v2/tests/test_contact_actions.py`: replaced the archiving assertions with a check that both action names are now rejected as invalid choices.
- `temba/api/tests/test_support.py`: switched its sample deprecated-feature strings to features that still exist.

## Behavior examples

| Request | Before | After |
|---|---|---|
| `POST /api/v2/contact_actions.json` with `"action": "archive_messages"` | 204, all incoming messages for the contacts archived | 400, `"archive_messages" is not a valid choice.` |
| `POST /api/v2/contact_actions.json` with `"action": "archive"` | 204, same as above | 400, `"archive" is not a valid choice.` |

The remaining actions (`add`, `remove`, `block`, `unblock`, `interrupt`, `delete`) are unchanged. Messages are still archived through the messages endpoint and the UI.

## Test plan

- `temba.api`, `temba.msgs` and `temba.contacts` test suites pass
- `code_check.py` clean (migrations, locale files, ruff)