### PR TITLE
Correct stale folders in Msg.folder backfill migration as well as missing ones

### DIFF
--- a/temba/msgs/migrations/0310_backfill_msg_folder.py
+++ b/temba/msgs/migrations/0310_backfill_msg_folder.py
@@ -1,17 +1,28 @@
 from django.db import connection as default_connection, migrations
 from django.db.models import Max, Min
 
-# Msg.folder is denormalized from direction/visibility/status/flow and is written by mailroom and courier for new
-# messages - this fills it in for the messages that predate that. The CASE mirrors Msg.derive_folder, including its
-# precedence: being deleted, and then being unhandled, both come before the user facing folders, so that a message
-# which is archived or deleted whilst still pending doesn't land in Archived.
+# Msg.folder is denormalized from direction/visibility/status/flow and is written by mailroom and courier - this fills
+# it in for the messages that predate that, and corrects the ones where it was written and has since gone stale. The
+# stale ones exist because for a window after the column was introduced some state changes were still being applied by
+# code that predated it and so didn't maintain it - an outgoing message's status being updated from an Android
+# relayer's sync, and incoming messages being archived in bulk for a contact. Both saved the columns folder is derived
+# from without saving folder, leaving e.g. a sent message still filed under Outbox, or an archived one still under
+# Inbox. Nothing writes message state that way any more, but the rows they left behind are wrong.
 #
-# A message whose state matches no branch keeps its null folder rather than being guessed at. The temba_msg_on_change
-# trigger rules out most of those - an incoming message that isn't pending or handled, and an outgoing message that is
-# archived - but not every one: an outgoing message that is somehow pending or handled is legal and falls through.
+# So this works by comparison rather than by absence: recompute the folder every message should have and write it
+# wherever it disagrees with what's stored, which covers the never-written and the stale cases in one pass without
+# needing to know which messages fall into which. The CASE mirrors Msg.derive_folder, including its precedence: being
+# deleted, and then being unhandled, both come before the user facing folders, so that a message which is archived or
+# deleted whilst still pending doesn't land in Archived.
 #
-# The table is far too large to scan for null folders, so we walk the primary key range in batches instead, newest
-# first so that the messages users are most likely to be looking at are filled in first. Each batch is its own
+# A message whose state matches no branch keeps the folder it has rather than being guessed at - or having a folder
+# cleared. The temba_msg_on_change trigger rules out most of those - an incoming message that isn't pending or handled,
+# and an outgoing message that is archived - but not every one: an outgoing message that is somehow pending or handled
+# is legal and falls through.
+#
+# The table is far too large to scan for messages needing this, so we walk the primary key range in batches instead,
+# newest first so that the messages users are most likely to be looking at are corrected first - which is also where
+# the stale ones are, since they can only exist from the column's introduction onwards. Each batch is its own
 # transaction, so an interrupted run can be resumed from the last id it reported.
 #
 # Batching by id range is what gets each statement served by the primary key, but the size is chosen by what one
@@ -24,18 +35,25 @@ from django.db.models import Max, Min
 
 BATCH_SIZE = 10_000  # ids per batch, not rows - ids are sparse wherever messages have been deleted
 
+# the folder is derived in a CTE so that the update itself is a primary key join touching only the rows that actually
+# disagree - the triggers above then see a batch sized by the corrections made, not by the ids walked
 SQL_BACKFILL_FOLDER = """
-UPDATE msgs_msg SET folder = CASE
-    WHEN visibility IN ('D', 'X') THEN 'D'                                                   -- deleted
-    WHEN direction = 'I' AND status = 'P' THEN 'P'                                           -- pending
-    WHEN direction = 'I' AND visibility = 'V' AND status = 'H' AND flow_id IS NULL THEN 'I'  -- inbox
-    WHEN direction = 'I' AND visibility = 'V' AND status = 'H' THEN 'W'                      -- handled
-    WHEN direction = 'I' AND visibility = 'A' AND status = 'H' THEN 'A'                      -- archived
-    WHEN direction = 'O' AND visibility = 'V' AND status IN ('I', 'Q', 'E') THEN 'O'         -- outbox
-    WHEN direction = 'O' AND visibility = 'V' AND status IN ('W', 'S', 'D', 'R') THEN 'S'    -- sent
-    WHEN direction = 'O' AND visibility = 'V' AND status = 'F' THEN 'X'                      -- failed
-END
-WHERE id >= %(low)s AND id <= %(high)s AND folder IS NULL
+WITH derived AS (
+    SELECT id, CASE
+        WHEN visibility IN ('D', 'X') THEN 'D'                                                   -- deleted
+        WHEN direction = 'I' AND status = 'P' THEN 'P'                                           -- pending
+        WHEN direction = 'I' AND visibility = 'V' AND status = 'H' AND flow_id IS NULL THEN 'I'  -- inbox
+        WHEN direction = 'I' AND visibility = 'V' AND status = 'H' THEN 'W'                      -- handled
+        WHEN direction = 'I' AND visibility = 'A' AND status = 'H' THEN 'A'                      -- archived
+        WHEN direction = 'O' AND visibility = 'V' AND status IN ('I', 'Q', 'E') THEN 'O'         -- outbox
+        WHEN direction = 'O' AND visibility = 'V' AND status IN ('W', 'S', 'D', 'R') THEN 'S'    -- sent
+        WHEN direction = 'O' AND visibility = 'V' AND status = 'F' THEN 'X'                      -- failed
+    END AS folder
+    FROM msgs_msg WHERE id >= %(low)s AND id <= %(high)s
+)
+UPDATE msgs_msg m SET folder = d.folder
+FROM derived d
+WHERE m.id = d.id AND d.folder IS NOT NULL AND m.folder IS DISTINCT FROM d.folder
 """
 
 

--- a/temba/msgs/tests/test_migrations.py
+++ b/temba/msgs/tests/test_migrations.py
@@ -87,6 +87,8 @@ class BackfillMsgFolderTest(MigrationTest):
             status=Msg.STATUS_PENDING, folder=Msg.FOLDER_OUTBOX
         )
 
+        self.counts_before = self.org.counts.prefix("msgs:folder:").scope_totals()
+
     def test_migration(self):
         def assert_folder(msg, expected):
             msg.refresh_from_db()
@@ -113,6 +115,12 @@ class BackfillMsgFolderTest(MigrationTest):
         # a message that derives no folder is left alone rather than guessed at, either way round
         assert_folder(self.underivable, None)
         assert_folder(self.underivable_with_folder, Msg.FOLDER_OUTBOX)
+
+        # folder counts are scoped by the columns folder is derived from and not by folder itself, so correcting one
+        # can't move them - pinned down here because folder is a denormalization of nearly what that scope computes,
+        # and a future change that had it read folder instead would make this migration emit spurious deltas
+        self.assertTrue(self.counts_before)  # guard against the comparison below being two empty dicts
+        self.assertEqual(self.counts_before, self.org.counts.prefix("msgs:folder:").scope_totals())
 
 
 class BackfillMsgFolderPagingTest(MigrationTest):

--- a/temba/msgs/tests/test_migrations.py
+++ b/temba/msgs/tests/test_migrations.py
@@ -69,9 +69,23 @@ class BackfillMsgFolderTest(MigrationTest):
         # all of the above predate the folder column being written
         self.org.msgs.update(folder=None)
 
-        # a message that already has a folder shouldn't be recalculated
-        self.already_set = self.create_incoming_msg(contact, "Hi")
-        Msg.objects.filter(id=self.already_set.id).update(folder=Msg.FOLDER_ARCHIVED)
+        # messages whose folder was written and has since gone stale, as updating an outgoing message's status from
+        # an Android relayer's sync and archiving a contact's incoming messages in bulk both used to leave them
+        self.stale_sent = self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_SENT)
+        Msg.objects.filter(id=self.stale_sent.id).update(folder=Msg.FOLDER_OUTBOX)
+
+        self.stale_archived = self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_ARCHIVED)
+        Msg.objects.filter(id=self.stale_archived.id).update(folder=Msg.FOLDER_INBOX)
+
+        # a message whose folder agrees with its state is left as it is
+        self.correct = self.create_incoming_msg(contact, "Hi")
+        Msg.objects.filter(id=self.correct.id).update(folder=Msg.FOLDER_INBOX)
+
+        # an underivable message keeps the folder it has rather than having it cleared
+        self.underivable_with_folder = self.create_outgoing_msg(contact, "Hi")
+        Msg.objects.filter(id=self.underivable_with_folder.id).update(
+            status=Msg.STATUS_PENDING, folder=Msg.FOLDER_OUTBOX
+        )
 
     def test_migration(self):
         def assert_folder(msg, expected):
@@ -92,8 +106,13 @@ class BackfillMsgFolderTest(MigrationTest):
         for msg in self.sent.values():
             assert_folder(msg, Msg.FOLDER_SENT)
 
-        assert_folder(self.already_set, Msg.FOLDER_ARCHIVED)  # not recalculated
-        assert_folder(self.underivable, None)  # left alone rather than guessed at
+        assert_folder(self.stale_sent, Msg.FOLDER_SENT)  # corrected, not just filled in
+        assert_folder(self.stale_archived, Msg.FOLDER_ARCHIVED)
+        assert_folder(self.correct, Msg.FOLDER_INBOX)  # unchanged
+
+        # a message that derives no folder is left alone rather than guessed at, either way round
+        assert_folder(self.underivable, None)
+        assert_folder(self.underivable_with_folder, Msg.FOLDER_OUTBOX)
 
 
 class BackfillMsgFolderPagingTest(MigrationTest):
@@ -118,9 +137,10 @@ class BackfillMsgFolderPagingTest(MigrationTest):
     def setUpBeforeMigration(self, apps):
         contact = self.create_contact("Bob", phone="+1234567890")
 
-        # enough messages to span several batches, all predating the folder column being written
+        # enough messages to span several batches, alternately never written and written wrongly
         self.msgs = [self.create_incoming_msg(contact, f"Hi {m}") for m in range(5)]
-        self.org.msgs.update(folder=None)
+        for m, msg in enumerate(self.msgs):
+            Msg.objects.filter(id=msg.id).update(folder=None if m % 2 else Msg.FOLDER_OUTBOX)
 
     def test_migration(self):
         # every message filled in, so no batch was skipped


### PR DESCRIPTION
## Summary

The `Msg.folder` backfill migration selected rows with `folder IS NULL`, so it only filled in messages that predated the column. But a null folder isn't the only wrong state: for a window after the column was introduced, some message state changes were still applied by code that predated it and so didn't maintain it, leaving rows whose stored folder no longer matches the columns it's derived from. Those rows are non-null, so the migration skipped them.

It now selects rows by comparing against the recomputed folder rather than testing for null, which covers the never-written and the stale cases in a single pass.

## Changes

**`temba/msgs/migrations/0310_backfill_msg_folder.py`**

- The `CASE` moved into a CTE, and the statement became a primary key join updating only the rows that actually disagree:

  ```sql
  WITH derived AS (
      SELECT id, CASE ... END AS folder FROM msgs_msg WHERE id >= %(low)s AND id <= %(high)s
  )
  UPDATE msgs_msg m SET folder = d.folder
  FROM derived d
  WHERE m.id = d.id AND d.folder IS NOT NULL AND m.folder IS DISTINCT FROM d.folder
  ```

  The join shape matters for cost, not just style: `msgs_msg` has a `FOR EACH STATEMENT` update trigger with `OLD`/`NEW` transition tables, so sizing the update by the corrections found rather than by the ids walked keeps those tuplestores small.

- `d.folder IS NOT NULL` is what preserves the existing rule that a message whose state derives no folder isn't guessed at. Under the old null-only predicate that fell out for free; under a comparison a bare `IS DISTINCT FROM` would actively *clear* those rows' folders, so the guard is now load-bearing.

- `BATCH_SIZE` dropped from 100,000 to 10,000, and the comment explaining the choice now names the statement-level trigger's transition tables — the cost that grows worst with batch size, since past `work_mem` those tuplestores spill to disk.

- No cutoff or boundary search is needed. Below the point where folders were first written every row is null, so the comparison predicate selects exactly the rows the null predicate did; above it, it additionally catches the stale ones. Same walk, same I/O, one uniform pass.

**`temba/msgs/tests/test_migrations.py`**

- The `already_set` fixture asserted that a message with an existing folder "shouldn't be recalculated" — the inverse of the new behavior — so it's replaced by the two stale shapes plus a control that already agrees.
- The underivable case is now asserted both ways round: with a null folder and with a stored one, to pin down that neither is overwritten.
- The paging test alternates never-written and written-wrongly messages, so advancing between batches is exercised against both.
- Folder counts are captured before the migration and asserted unmoved after it. They're scoped by `temba_msg_countscope`, which derives from `direction`/`msg_type`/`visibility`/`status`/`flow_id` and never from `folder`, so a folder-only UPDATE emits no `orgs_itemcount` rows. That's worth pinning down because `folder` is a denormalization of very nearly what that scope computes, making "have countscope read folder" a natural future refactor — one that would quietly turn this migration's correcting pass into a source of spurious count deltas.

## Behavior examples

For an incoming handled message with no flow, whose derived folder is Inbox:

| stored `folder` | before | after |
|---|---|---|
| `NULL` | set to `I` | set to `I` |
| `A` (stale — e.g. archived, then restored) | left as `A` | corrected to `I` |
| `I` (already correct) | left as `I` | left as `I` |

And for a message deriving no folder at all (an outgoing message that is somehow pending, which the database permits):

| stored `folder` | before | after |
|---|---|---|
| `NULL` | left `NULL` | left `NULL` |
| `O` | left as `O` | left as `O` |

## Test plan

- [x] `temba.msgs` suite passes (61 tests)
- [x] `0310_backfill_msg_folder.py` at 100% statement coverage
- [x] Stale-to-`Sent` and stale-to-`Archived` rows are corrected, and a correct row is left untouched
- [x] A row deriving no folder keeps what it has, whether that's null or a value
- [x] Folder counts are unchanged across the migration, with a guard so the comparison can't pass on two empty dicts
- [x] The batch loop still advances correctly with `BATCH_SIZE` patched to 1
- [x] `manage.py makemigrations --check` reports no changes
- [x] `code_check.py` clean

## Notes for deploying

The migration hasn't been recorded as applied anywhere yet, so amending it in place is safe. Any in-flight manual run is executing the old logic and should be restarted — it re-walks from the newest id, and the range it already covered is idempotent under the new predicate.