### PR TITLE
Add display label for new consolidated receive channel log type

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-27 20:36+0000\n"
+"POT-Creation-Date: 2026-08-31 22:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -418,6 +418,9 @@ msgid "Message Send"
 msgstr ""
 
 msgid "Message Status"
+msgstr ""
+
+msgid "Receive"
 msgstr ""
 
 msgid "Message Receive"
@@ -835,9 +838,6 @@ msgid "The URL we will POST to when sending messages, with variable substitution
 msgstr ""
 
 msgid "Connect External Service"
-msgstr ""
-
-msgid "Receive"
 msgstr ""
 
 msgid "Send"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-27 20:36+0000\n"
+"POT-Creation-Date: 2026-08-31 22:54+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -434,6 +434,9 @@ msgstr "Envío de mensaje"
 msgid "Message Status"
 msgstr "Estado del mensaje"
 
+msgid "Receive"
+msgstr "Recibir"
+
 msgid "Message Receive"
 msgstr "Recepción de mensaje"
 
@@ -850,9 +853,6 @@ msgstr "La URL a la que llamaremos (POST) cuando enviemos mensajes, con sustituc
 
 msgid "Connect External Service"
 msgstr "Conectar Servicio Externo"
-
-msgid "Receive"
-msgstr "Recibir"
 
 msgid "Send"
 msgstr "Enviar"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-27 20:36+0000\n"
+"POT-Creation-Date: 2026-08-31 22:54+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -434,6 +434,9 @@ msgstr "Envoi de message"
 msgid "Message Status"
 msgstr "Statut du message"
 
+msgid "Receive"
+msgstr "Recevoir"
+
 msgid "Message Receive"
 msgstr "Réception de message"
 
@@ -850,9 +853,6 @@ msgstr "L'URL vers laquelle nous allons effectuer une requête POST lors de l'en
 
 msgid "Connect External Service"
 msgstr "Connecter un service externe"
-
-msgid "Receive"
-msgstr "Recevoir"
 
 msgid "Send"
 msgstr "Envoyer"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-27 20:36+0000\n"
+"POT-Creation-Date: 2026-08-31 22:54+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -438,6 +438,9 @@ msgstr "Envio de mensagem"
 msgid "Message Status"
 msgstr "Estado da mensagem"
 
+msgid "Receive"
+msgstr "Receber"
+
 msgid "Message Receive"
 msgstr "Recebimento de mensagem"
 
@@ -854,9 +857,6 @@ msgstr "Que URL nós ENVIAREMOS para quando mensagens estiverem sendo enviadas, 
 
 msgid "Connect External Service"
 msgstr "Conectar serviço externo"
-
-msgid "Receive"
-msgstr "Receber"
 
 msgid "Send"
 msgstr "Enviar"

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -818,9 +818,13 @@ class ChannelLog:
     LOG_TYPE_UNKNOWN = "unknown"
     LOG_TYPE_MSG_SEND = "msg_send"
     LOG_TYPE_MSG_STATUS = "msg_status"
+    LOG_TYPE_RECEIVE = "receive"
+
+    # deprecated receive types, replaced by LOG_TYPE_RECEIVE, but kept for logs already in storage
     LOG_TYPE_MSG_RECEIVE = "msg_receive"
     LOG_TYPE_EVENT_RECEIVE = "event_receive"
     LOG_TYPE_MULTI_RECEIVE = "multi_receive"
+
     LOG_TYPE_IVR_START = "ivr_start"
     LOG_TYPE_IVR_INCOMING = "ivr_incoming"
     LOG_TYPE_IVR_CALLBACK = "ivr_callback"
@@ -834,6 +838,7 @@ class ChannelLog:
         LOG_TYPE_UNKNOWN: _("Other Event"),
         LOG_TYPE_MSG_SEND: _("Message Send"),
         LOG_TYPE_MSG_STATUS: _("Message Status"),
+        LOG_TYPE_RECEIVE: _("Receive"),
         LOG_TYPE_MSG_RECEIVE: _("Message Receive"),
         LOG_TYPE_EVENT_RECEIVE: _("Event Receive"),
         LOG_TYPE_MULTI_RECEIVE: _("Events Receive"),


### PR DESCRIPTION
## Summary

Courier now writes a single `receive` channel log type for everything a provider sends about a contact, replacing the three separate types that previously covered incoming messages and events. Without a display entry for it, the log viewer rendered the raw value `receive` instead of a readable label.

## Changes

- adds `LOG_TYPE_RECEIVE = "receive"` and its `LOG_TYPE_DISPLAY` entry, `_("Receive")`
- keeps `msg_receive`, `event_receive` and `multi_receive` and their labels, grouped under a comment marking them deprecated but retained — channel logs already in storage keep the value they were written with, so those keys must stay resolvable
- regenerates the PO files

`msg_status` is unaffected. It stays a distinct type so operators can still filter for it when tracing a message stuck in `sent`.

## Behavior

A log written with the new type renders as **Receive**; previously it fell through `LOG_TYPE_DISPLAY.get(log_type, log_type)` and rendered as the bare string `receive`. Logs carrying any of the three older types are unchanged and still render as before.

## Scope

Nothing else in the codebase enumerates or filters on these values — `LOG_TYPE_DISPLAY` is read only by `get_log_type_display()`, and no serializer, filter UI, template or test touches the log type set. (The `msg_received` / `event_received` hits elsewhere are mailroom contact-history event names in a separate namespace, and `HTTPLog.log_type` is a different model.) This is purely additive: no migration, no data rewrite.

## Localization

`"Receive"` already existed as a msgid for the channel role label and was already translated in es, fr and pt_BR, so the PO diff is only that entry moving position — no new untranslated string.

## Test plan

- `temba.channels` — 181 tests, all passing
- `code_check.py` clean: migrations, locale freshness, ruff format and lint