### PR TITLE
Make cross-ticket search work from any page in the tickets section

### DIFF
--- a/temba/tickets/tests/test_shortcutcrudl.py
+++ b/temba/tickets/tests/test_shortcutcrudl.py
@@ -150,4 +150,7 @@ class ShortcutCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertRequestDisallowed(list_url, [None, self.agent])
 
-        self.assertListFetch(list_url, [self.editor, self.admin], context_objects=[shortcut1, shortcut2])
+        response = self.assertListFetch(list_url, [self.editor, self.admin], context_objects=[shortcut1, shortcut2])
+
+        # the search button is part of the tickets section menu so search has to be mounted here too
+        self.assertContains(response, "<temba-ticket-search")

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -191,6 +191,9 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "Analytics")
         self.assertContains(response, "Tickets Opened")
 
+        # the search button is part of the tickets section menu so search has to be mounted here too
+        self.assertContains(response, "<temba-ticket-search")
+
         # org doesn't have the teams feature so response count chart shouldn't be split by team
         self.assertFalse(response.context["has_teams"])
         self.assertNotContains(response, 'dataname="Teams"')

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -70,6 +70,23 @@ def shortcuts_url(org) -> str:
     return reverse("tickets.shortcut_list")
 
 
+class SearchMixin:
+    """
+    Mounts cross-ticket search (see tickets/search.html) on a page in the tickets section. The search button is part of
+    the section menu (see TicketCRUDL.Menu) rather than any one page, so every page there needs to be able to open it.
+    """
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # cross-ticket search is only available to users who can access all topics (see TicketCRUDL.Search)
+        context["can_search"] = (
+            self.has_org_perm("tickets.ticket_list")
+            and Topic.get_restriction(self.request.org, self.request.user) is None
+        )
+        return context
+
+
 class ShortcutCRUDL(SmartCRUDL):
     model = Shortcut
     actions = ("create", "update", "delete", "list")
@@ -95,7 +112,7 @@ class ShortcutCRUDL(SmartCRUDL):
         def get_redirect_url(self, **kwargs):
             return shortcuts_url(self.request.org)
 
-    class List(SpaMixin, ContextMenuMixin, BaseListView):
+    class List(SpaMixin, SearchMixin, ContextMenuMixin, BaseListView):
         menu_path = "/ticket/shortcuts"
 
         def derive_queryset(self, **kwargs):
@@ -289,7 +306,7 @@ class TicketCRUDL(SmartCRUDL):
 
             return menu
 
-    class Analytics(SpaMixin, ContextMenuMixin, OrgPermsMixin, SmartTemplateView):
+    class Analytics(SpaMixin, SearchMixin, ContextMenuMixin, OrgPermsMixin, SmartTemplateView):
         permission = "tickets.ticket_analytics"
         title = _("Analytics")
         menu_path = "/ticket/analytics"
@@ -314,7 +331,7 @@ class TicketCRUDL(SmartCRUDL):
 
             return response_from_workbook(workbook, f"ticket-stats-{timezone.now().strftime('%Y-%m-%d')}.xlsx")
 
-    class List(SpaMixin, ContextMenuMixin, OrgPermsMixin, SmartListView):
+    class List(SpaMixin, SearchMixin, ContextMenuMixin, OrgPermsMixin, SmartListView):
         """
         Placeholder view for the ticketing frontend components which fetch tickets from the folders view below.
         """
@@ -393,9 +410,6 @@ class TicketCRUDL(SmartCRUDL):
             context["user_role"] = membership.role_code if membership else OrgRole.ADMINISTRATOR.code
             context["can_assign"] = membership.can_assign if membership else True
             context["can_reply_non_own"] = membership.can_reply_non_own if membership else True
-
-            # cross-ticket search is only available to users who can access all topics (see TicketCRUDL.Search)
-            context["can_search"] = Topic.get_restriction(self.request.org, self.request.user) is None
 
             return context
 

--- a/templates/tickets/search.html
+++ b/templates/tickets/search.html
@@ -1,0 +1,60 @@
+{% comment %}
+  Cross-ticket search, included by every page in the tickets section - the search button lives in the section menu
+  (see TicketCRUDL.Menu) so it has to open from wherever the user happens to be, not just the ticket list.
+{% endcomment %}
+{% if can_search %}
+  <script>
+    function handleTicketSearchSelected(event) {
+      const result = event.detail;
+
+      // once the ticket's chat loads, re-run the search within it, landing
+      // on the matched message
+      window.pendingTicketSearch = {
+        query: result.query,
+        event: result.event,
+        ticketUuid: result.ticket.uuid,
+        expires: Date.now() + 15000
+      };
+
+      const path = `/ticket/all/${result.ticket.uuid}/`;
+      if (typeof spaGet !== 'undefined') {
+        spaGet(path);
+      } else {
+        document.location.href = path;
+      }
+    }
+
+    // cmd/ctrl+F and the menu's search button (see TicketCRUDL.Menu) open ticket
+    // search while a page in the tickets section is loaded (the handlers are
+    // stored on window so SPA navigations don't stack up listeners). they're
+    // no-ops once we navigate away - the modal isn't in the DOM anymore
+    if (window.handleTicketSearchHotkey) {
+      document.removeEventListener("keydown", window.handleTicketSearchHotkey);
+    }
+    window.handleTicketSearchHotkey = function(event) {
+      const search = document.querySelector("temba-ticket-search");
+      if (!search) {
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+        search.show();
+      }
+    };
+    document.addEventListener("keydown", window.handleTicketSearchHotkey);
+
+    if (window.handleTicketSearchShow) {
+      document.removeEventListener("temba-ticket-search-show", window.handleTicketSearchShow);
+    }
+    window.handleTicketSearchShow = function() {
+      const search = document.querySelector("temba-ticket-search");
+      if (search) {
+        search.show();
+      }
+    };
+    document.addEventListener("temba-ticket-search-show", window.handleTicketSearchShow);
+  </script>
+  <temba-ticket-search endpoint="{% url 'tickets.ticket_search' %}"
+                       -temba-search-result-selected="handleTicketSearchSelected(event)">
+  </temba-ticket-search>
+{% endif %}

--- a/templates/tickets/shortcut_list.html
+++ b/templates/tickets/shortcut_list.html
@@ -6,6 +6,7 @@
   </temba-modax>
   <temba-modax header="{{ _("Delete Shortcut") |escapejs }}" id="delete-shortcut">
   </temba-modax>
+  {% include "tickets/search.html" %}
 {% endblock modaxes %}
 {% block pre-table %}
   <div class="mb-4">

--- a/templates/tickets/ticket_analytics.html
+++ b/templates/tickets/ticket_analytics.html
@@ -126,6 +126,7 @@
       </tbody>
     </table>
   </div>
+  {% include "tickets/search.html" %}
 {% endblock content %}
 {% block extra-script %}
   {{ block.super }}

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -626,56 +626,6 @@
       reloadContent();
     }
 
-    function handleTicketSearchSelected(event) {
-      const result = event.detail;
-
-      // once the ticket's chat loads, re-run the search within it, landing
-      // on the matched message
-      window.pendingTicketSearch = {
-        query: result.query,
-        event: result.event,
-        ticketUuid: result.ticket.uuid,
-        expires: Date.now() + 15000
-      };
-
-      const path = `/ticket/all/${result.ticket.uuid}/`;
-      if (typeof spaGet !== 'undefined') {
-        spaGet(path);
-      } else {
-        document.location.href = path;
-      }
-    }
-
-    // cmd/ctrl+F and the menu's search button (see TicketCRUDL.Menu) open
-    // ticket search while this page is loaded (the handlers are stored on
-    // window so SPA navigations back here don't stack up listeners).
-    // they're no-ops for users without search - the modal isn't mounted for them
-    if (window.handleTicketSearchHotkey) {
-      document.removeEventListener("keydown", window.handleTicketSearchHotkey);
-    }
-    window.handleTicketSearchHotkey = function(event) {
-      const search = document.querySelector("temba-ticket-search");
-      if (!search) {
-        return;
-      }
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
-        event.preventDefault();
-        search.show();
-      }
-    };
-    document.addEventListener("keydown", window.handleTicketSearchHotkey);
-
-    if (window.handleTicketSearchShow) {
-      document.removeEventListener("temba-ticket-search-show", window.handleTicketSearchShow);
-    }
-    window.handleTicketSearchShow = function() {
-      const search = document.querySelector("temba-ticket-search");
-      if (search) {
-        search.show();
-      }
-    };
-    document.addEventListener("temba-ticket-search-show", window.handleTicketSearchShow);
-
     onSpload(function() {
       const details = document.querySelector("temba-contact-details");
       details.schemes = JSON.parse(document.getElementById("contact-urn-schemes").textContent);
@@ -838,10 +788,6 @@
         {{ contact_urn_schemes|json_script:"contact-urn-schemes" }}
       </div>
     </div>
-    {% if can_search %}
-      <temba-ticket-search endpoint="{% url 'tickets.ticket_search' %}"
-                           -temba-search-result-selected="handleTicketSearchSelected(event)">
-      </temba-ticket-search>
-    {% endif %}
+    {% include "tickets/search.html" %}
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Summary

The Search button lives in the tickets section menu, so it shows on every page in that section — but the search modal it opens was only mounted on the ticket list page, leaving the button dead on Shortcuts and Analytics. This moves the modal and its handlers into a shared include that every page in the section pulls in.

## Changes

- **`templates/tickets/search.html`** (new) — the `<temba-ticket-search>` mount plus its handlers (the menu's `temba-ticket-search-show` event, the cmd/ctrl+F hotkey, and result selection), moved verbatim out of `ticket_list.html`. Selecting a result still stashes the pending search on `window` and navigates to the ticket, which works from any starting page.
- **`temba/tickets/views.py`** — new `SearchMixin` sets `can_search` using the same condition the menu uses to decide whether to show the button (has `tickets.ticket_list` permission and isn't restricted to a subset of topics). Applied to `TicketCRUDL.List`, `TicketCRUDL.Analytics` and `ShortcutCRUDL.List`; the ticket list's own inline `can_search` is removed.
- **`templates/tickets/{ticket_list,ticket_analytics,shortcut_list}.html`** — include the new template.

Any page added to the section later needs only the mixin plus the include.

## Behavior examples

Clicking Search in the section menu:

| Page | Before | After |
|---|---|---|
| Ticket list / topic | opens search | opens search |
| Analytics | nothing happens | opens search |
| Shortcuts | nothing happens | opens search |

cmd/ctrl+F behaves the same way — it opens ticket search anywhere in the section, and is left alone elsewhere in the app. Users restricted to a subset of topics still get no search modal anywhere, matching the menu, which doesn't offer them the button.

## Test plan

- `temba.tickets` suite passes (41 tests), including new assertions that the search modal renders on the analytics and shortcuts pages, and the existing assertions that it is absent for a topic-restricted agent
- `code_check.py` clean; djlint reports no reformatting needed on the touched templates
- Verified the SPA re-executes scripts anywhere within swapped content (`setInnerHTML` in `static/js/temba.js`), so the include works regardless of which template block hosts it