### PR TITLE
Add msgs_by_folder index ahead of message folders reading from Msg.folder

### DIFF
--- a/temba/msgs/migrations/0311_msg_msgs_by_folder.py
+++ b/temba/msgs/migrations/0311_msg_msgs_by_folder.py
@@ -1,0 +1,40 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+from django.db.migrations.operations.models import AddIndex
+
+
+class AddIndexConcurrentlyPlainReverse(AddIndexConcurrently):
+    """
+    Adds the index concurrently but reverses with a plain drop, so that migration tests - which roll the graph
+    backwards inside a transaction - can unapply it.
+    """
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        AddIndex.database_backwards(self, app_label, schema_editor, from_state, to_state)
+
+
+class Migration(migrations.Migration):
+    # an index build on the messages table can't hold ACCESS EXCLUSIVE for its duration, so it's created concurrently.
+    # Nothing reads it yet - it's added ahead of the folder views and API folders switching to filter by folder and
+    # order by uuid (time ordered, as message uuids are v7) so that the switch doesn't wait on the build.
+    # Installations large enough to care can build it by hand ahead of the deploy and fake this migration:
+    #
+    #   CREATE INDEX CONCURRENTLY msgs_by_folder ON msgs_msg (org_id, folder, uuid DESC)
+    #   WHERE folder IN ('I', 'W', 'A', 'O', 'S', 'X');
+    #
+    atomic = False
+
+    dependencies = [
+        ("msgs", "0310_backfill_msg_folder"),
+    ]
+
+    operations = [
+        AddIndexConcurrentlyPlainReverse(
+            model_name="msg",
+            index=models.Index(
+                name="msgs_by_folder",
+                fields=["org", "folder", "-uuid"],
+                condition=models.Q(("folder__in", ("I", "W", "A", "O", "S", "X"))),
+            ),
+        ),
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -897,6 +897,14 @@ class Msg(models.Model):
                 fields=["org", "-sent_on", "-id"],
                 condition=Q(direction="O", visibility="V", status__in=("W", "S", "D", "R")),
             ),
+            # will replace the five folder indexes above once the folder views and API folders read from folder and
+            # order by uuid (which is time ordered as message uuids are v7). Partial on the user facing folders so it
+            # doesn't also index every pending and deleted message.
+            models.Index(
+                name="msgs_by_folder",
+                fields=["org", "folder", "-uuid"],
+                condition=Q(folder__in=("I", "W", "A", "O", "S", "X")),
+            ),
         ]
         constraints = [
             models.CheckConstraint(name="direction_is_in_or_out", condition=Q(direction="I") | Q(direction="O")),


### PR DESCRIPTION
## Summary

Adds a single partial index on `msgs_msg (org_id, folder, uuid DESC)` covering the six user facing folder codes. Nothing reads it yet — now that `Msg.folder` is backfilled, this is the index the folder views and API folders will switch to: filtering by `folder` and ordering by `uuid`, which is time ordered as message uuids are v7. It's built ahead of that switch rather than making it wait on the build. Once the switch has landed it replaces the five per-folder partial indexes (`msgs_inbox`, `msgs_flows`, `msgs_archived`, `msgs_outbox_and_failed`, `msgs_sent`).

Ordering by `uuid` rather than `(created_on, id)` is deliberate: it's a step towards not depending on `id` for messages, and one uuid key is the same width as `timestamptz + bigint` so the index is no larger for it. The `before`/`after` created_on filters on the API and the export's date range will be translated to uuid bounds when the reads switch, so they stay index conditions.

## Changes

- `Msg.Meta.indexes`: new `msgs_by_folder` index on `["org", "folder", "-uuid"]` with condition `folder IN ('I', 'W', 'A', 'O', 'S', 'X')` — partial so that every pending (`P`) and deleted (`D`) message isn't also indexed.
- Migration `0311_msg_msgs_by_folder`: creates it with `CREATE INDEX CONCURRENTLY` (non-atomic migration), reversing with a plain drop so migration tests can roll it back inside a transaction, following the existing pattern. Includes the equivalent SQL for operators who'd rather build it by hand ahead of a deploy and fake the migration.

One index rather than one per ordering: the Sent folder currently orders by `sent_on` (with its own `msgs_sent` index) and will order by `uuid` like the other folders when it switches to reading `folder`.

## Test plan

- [x] `makemigrations --check` reports no changes
- [x] `sqlmigrate msgs 0311` produces `CREATE INDEX CONCURRENTLY "msgs_by_folder" ON "msgs_msg" ("org_id", "folder", "uuid" DESC) WHERE "folder" IN ('I', 'W', 'A', 'O', 'S', 'X')`
- [x] `EXPLAIN` of the intended read shape (`org_id = ? AND folder = ? AND uuid <= ? AND uuid >= ? ORDER BY uuid DESC LIMIT n`) is a single index scan on `msgs_by_folder` — Postgres proves the `folder = ?` equality implies the partial predicate
- [x] `temba.msgs` test suite passes (including the migration tests, which apply and unapply this migration)
- [x] `code_check.py` passes