### PR TITLE
Let teams be explicitly unrestricted by topic

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -3685,6 +3685,12 @@ msgstr ""
 msgid "Unable to refresh all templates. See the log for details."
 msgstr ""
 
+msgid "All topics"
+msgstr ""
+
+msgid "Members can access tickets of any topic, including topics created later."
+msgstr ""
+
 #, python-format
 msgid "Teams can have at most %(limit)d topics."
 msgstr ""
@@ -6395,6 +6401,9 @@ msgstr ""
 
 #, python-format
 msgid "You are about to delete the <b>%(object)s</b> team. There is no way to undo this. Are you sure?"
+msgstr ""
+
+msgid "Ticket search is not currently supported for teams that are restricted to specific topics."
 msgstr ""
 
 msgid "Agent users can be organized into teams to restrict which ticket topics they can access."

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 20:21+0000\n"
+"POT-Creation-Date: 2026-09-01 20:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -3689,6 +3689,9 @@ msgid "All topics"
 msgstr ""
 
 msgid "Members can access tickets of any topic, including topics created later."
+msgstr ""
+
+msgid "Select at least one topic or allow access to all topics."
 msgstr ""
 
 #, python-format

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:21+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -3711,6 +3711,12 @@ msgstr "Sus plantillas se han obtenido y actualizado."
 msgid "Unable to refresh all templates. See the log for details."
 msgstr "No se pudieron actualizar todas las plantillas. Consulte el registro para obtener más detalles."
 
+msgid "All topics"
+msgstr "Todos los temas"
+
+msgid "Members can access tickets of any topic, including topics created later."
+msgstr "Los miembros pueden acceder a los tickets de cualquier tema, incluidos los temas creados más adelante."
+
 #, python-format
 msgid "Teams can have at most %(limit)d topics."
 msgstr "Los equipos pueden tener como máximo %(limit)d temas."
@@ -6578,6 +6584,9 @@ msgstr "Lo sentimos, el equipo <b>%(object)s</b> no se puede eliminar mientras s
 #, python-format
 msgid "You are about to delete the <b>%(object)s</b> team. There is no way to undo this. Are you sure?"
 msgstr "Está a punto de eliminar el equipo <b>%(object)s</b>. No hay forma de deshacer esto. ¿Está seguro?"
+
+msgid "Ticket search is not currently supported for teams that are restricted to specific topics."
+msgstr "La búsqueda de tickets no está disponible actualmente para los equipos restringidos a temas específicos."
 
 msgid "Agent users can be organized into teams to restrict which ticket topics they can access."
 msgstr "Los usuarios agentes se pueden organizar en equipos para restringir a qué temas de tickets pueden acceder."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 20:21+0000\n"
+"POT-Creation-Date: 2026-09-01 20:36+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -3716,6 +3716,9 @@ msgstr "Todos los temas"
 
 msgid "Members can access tickets of any topic, including topics created later."
 msgstr "Los miembros pueden acceder a los tickets de cualquier tema, incluidos los temas creados más adelante."
+
+msgid "Select at least one topic or allow access to all topics."
+msgstr "Seleccione al menos un tema o permita el acceso a todos los temas."
 
 #, python-format
 msgid "Teams can have at most %(limit)d topics."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 20:21+0000\n"
+"POT-Creation-Date: 2026-09-01 20:36+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -3716,6 +3716,9 @@ msgstr "Tous les sujets"
 
 msgid "Members can access tickets of any topic, including topics created later."
 msgstr "Les membres peuvent accéder aux billets de n'importe quel sujet, y compris les sujets créés ultérieurement."
+
+msgid "Select at least one topic or allow access to all topics."
+msgstr "Sélectionnez au moins un sujet ou autorisez l'accès à tous les sujets."
 
 #, python-format
 msgid "Teams can have at most %(limit)d topics."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:21+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -3711,6 +3711,12 @@ msgstr "Vos modèles ont été récupérés et actualisés."
 msgid "Unable to refresh all templates. See the log for details."
 msgstr "Impossible d'actualiser tous les modèles. Consultez le journal pour plus de détails."
 
+msgid "All topics"
+msgstr "Tous les sujets"
+
+msgid "Members can access tickets of any topic, including topics created later."
+msgstr "Les membres peuvent accéder aux billets de n'importe quel sujet, y compris les sujets créés ultérieurement."
+
 #, python-format
 msgid "Teams can have at most %(limit)d topics."
 msgstr "Les équipes ne peuvent avoir que %(limit)d sujets au maximum."
@@ -6576,6 +6582,9 @@ msgstr "Désolé, l'équipe <b>%(object)s</b> ne peut pas être supprimée tant 
 #, python-format
 msgid "You are about to delete the <b>%(object)s</b> team. There is no way to undo this. Are you sure?"
 msgstr "Vous êtes sur le point de supprimer l'équipe <b>%(object)s</b>. Cette action est irréversible. Voulez-vous continuer ?"
+
+msgid "Ticket search is not currently supported for teams that are restricted to specific topics."
+msgstr "La recherche de billets n'est pas encore prise en charge pour les équipes limitées à des sujets spécifiques."
 
 msgid "Agent users can be organized into teams to restrict which ticket topics they can access."
 msgstr "Les utilisateurs agents peuvent être organisés en équipes afin de restreindre les sujets de billets auxquels ils ont accès."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 20:21+0000\n"
+"POT-Creation-Date: 2026-09-01 20:36+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -3720,6 +3720,9 @@ msgstr "Todos os tópicos"
 
 msgid "Members can access tickets of any topic, including topics created later."
 msgstr "Os membros podem acessar tickets de qualquer tópico, incluindo tópicos criados posteriormente."
+
+msgid "Select at least one topic or allow access to all topics."
+msgstr "Selecione pelo menos um tópico ou permita o acesso a todos os tópicos."
 
 #, python-format
 msgid "Teams can have at most %(limit)d topics."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:21+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -3715,6 +3715,12 @@ msgstr "Seus templates foram buscados e atualizados."
 msgid "Unable to refresh all templates. See the log for details."
 msgstr "Não foi possível atualizar todos os templates. Veja o log para mais detalhes."
 
+msgid "All topics"
+msgstr "Todos os tópicos"
+
+msgid "Members can access tickets of any topic, including topics created later."
+msgstr "Os membros podem acessar tickets de qualquer tópico, incluindo tópicos criados posteriormente."
+
 #, python-format
 msgid "Teams can have at most %(limit)d topics."
 msgstr "Equipes podem ter no máximo %(limit)d tópicos."
@@ -6569,6 +6575,9 @@ msgstr "Desculpe, a equipe <b>%(object)s</b> não pode ser deletada enquanto ain
 #, python-format
 msgid "You are about to delete the <b>%(object)s</b> team. There is no way to undo this. Are you sure?"
 msgstr "Você está prestes a deletar a equipe <b>%(object)s</b>. Não é possível reverter isso. Você tem certeza?"
+
+msgid "Ticket search is not currently supported for teams that are restricted to specific topics."
+msgstr "A pesquisa de tickets não é suportada atualmente para equipes restritas a tópicos específicos."
 
 msgid "Agent users can be organized into teams to restrict which ticket topics they can access."
 msgstr "Usuários agentes podem ser organizados em equipes para restringir a quais tópicos de ticket eles têm acesso."

--- a/temba/tickets/forms.py
+++ b/temba/tickets/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views.mixins import UniqueNameMixin
+from temba.utils.fields import CheckboxWidget
 
 from .models import Shortcut, Team, Topic
 
@@ -18,6 +19,13 @@ class ShortcutForm(UniqueNameMixin, forms.ModelForm):
 
 
 class TeamForm(UniqueNameMixin, forms.ModelForm):
+    all_topics = forms.BooleanField(
+        label=_("All topics"),
+        help_text=_("Members can access tickets of any topic, including topics created later."),
+        required=False,
+        initial=True,
+        widget=CheckboxWidget(attrs={"widget_only": True}),
+    )
     topics = forms.ModelMultipleChoiceField(queryset=Topic.objects.none(), required=False)
 
     def __init__(self, org, *args, **kwargs):
@@ -28,6 +36,11 @@ class TeamForm(UniqueNameMixin, forms.ModelForm):
 
     def clean_topics(self):
         topics = self.cleaned_data["topics"]
+
+        # topics are ignored for a team that can access all topics
+        if self.cleaned_data.get("all_topics"):
+            return topics.none()
+
         if len(topics) > Team.max_topics:
             raise forms.ValidationError(
                 _("Teams can have at most %(limit)d topics."), params={"limit": Team.max_topics}
@@ -36,7 +49,7 @@ class TeamForm(UniqueNameMixin, forms.ModelForm):
 
     class Meta:
         model = Team
-        fields = ("name", "topics")
+        fields = ("name", "all_topics", "topics")
 
 
 class TopicForm(UniqueNameMixin, forms.ModelForm):

--- a/temba/tickets/forms.py
+++ b/temba/tickets/forms.py
@@ -41,6 +41,9 @@ class TeamForm(UniqueNameMixin, forms.ModelForm):
         if self.cleaned_data.get("all_topics"):
             return topics.none()
 
+        if not topics:
+            raise forms.ValidationError(_("Select at least one topic or allow access to all topics."))
+
         if len(topics) > Team.max_topics:
             raise forms.ValidationError(
                 _("Teams can have at most %(limit)d topics."), params={"limit": Team.max_topics}

--- a/temba/tickets/tests/test_teamcrudl.py
+++ b/temba/tickets/tests/test_teamcrudl.py
@@ -20,7 +20,7 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertRequestDisallowed(create_url, [None, self.agent, self.editor])
 
-        self.assertCreateFetch(create_url, [self.admin], form_fields=("name", "topics"))
+        self.assertCreateFetch(create_url, [self.admin], form_fields={"name": None, "all_topics": True, "topics": None})
 
         sales = Topic.create(self.org, self.admin, "Sales")
         for n in range(Team.max_topics + 1):
@@ -74,11 +74,38 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
         team = Team.objects.get(name="Sales")
+        self.assertFalse(team.all_topics)
         self.assertEqual({sales}, set(team.topics.all()))
 
         # check we get the limit warning when we've reached the limit
         response = self.requestView(create_url, self.admin)
         self.assertContains(response, "You have reached the per-workspace limit")
+
+    def test_create_all_topics(self):
+        self.org.features = [Org.FEATURE_TEAMS]
+        self.org.save(update_fields=("features",))
+
+        create_url = reverse("tickets.team_create")
+
+        for n in range(Team.max_topics + 1):
+            Topic.create(self.org, self.admin, f"Topic {n}")
+
+        # selected topics are ignored (and the topic limit doesn't apply) when a team can access all topics
+        self.assertCreateSubmit(
+            create_url,
+            self.admin,
+            {"name": "Everything", "all_topics": True, "topics": [t.id for t in self.org.topics.all()]},
+            new_obj_query=Team.objects.filter(name="Everything", is_system=False),
+            success_status=302,
+        )
+
+        team = Team.objects.get(name="Everything")
+        self.assertTrue(team.all_topics)
+        self.assertEqual(set(), set(team.topics.all()))
+
+        # agents in this team aren't restricted to any topics
+        self.org.add_user(self.agent, OrgRole.AGENT, team=team)
+        self.assertIsNone(Topic.get_restriction(self.org, self.agent))
 
     def test_update(self):
         sales = Topic.create(self.org, self.admin, "Sales")
@@ -89,7 +116,9 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertRequestDisallowed(update_url, [None, self.agent, self.editor, self.admin2])
 
-        self.assertUpdateFetch(update_url, [self.admin], form_fields=["name", "topics"])
+        self.assertUpdateFetch(
+            update_url, [self.admin], form_fields={"name": "Sales", "all_topics": False, "topics": [sales]}
+        )
 
         # names must be unique (case-insensitive)
         self.assertUpdateSubmit(
@@ -106,7 +135,33 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
 
         team.refresh_from_db()
         self.assertEqual(team.name, "Marketing")
+        self.assertFalse(team.all_topics)
         self.assertEqual({marketing}, set(team.topics.all()))
+
+        # switching to all topics clears any selected topics
+        self.assertUpdateSubmit(
+            update_url,
+            self.admin,
+            {"name": "Marketing", "all_topics": True, "topics": [marketing.id]},
+            success_status=302,
+        )
+
+        team.refresh_from_db()
+        self.assertTrue(team.all_topics)
+        self.assertEqual(set(), set(team.topics.all()))
+
+        self.assertUpdateFetch(
+            update_url, [self.admin], form_fields={"name": "Marketing", "all_topics": True, "topics": []}
+        )
+
+        # and back to a subset of topics
+        self.assertUpdateSubmit(
+            update_url, self.admin, {"name": "Marketing", "topics": [sales.id, marketing.id]}, success_status=302
+        )
+
+        team.refresh_from_db()
+        self.assertFalse(team.all_topics)
+        self.assertEqual({sales, marketing}, set(team.topics.all()))
 
         # can't edit a system team
         self.assertRequestDisallowed(reverse("tickets.team_update", args=[self.org.default_team.uuid]), [self.admin])

--- a/temba/tickets/tests/test_teamcrudl.py
+++ b/temba/tickets/tests/test_teamcrudl.py
@@ -31,13 +31,16 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
             create_url,
             self.admin,
             {"name": "", "topics": []},
-            form_errors={"name": "This field is required."},
+            form_errors={
+                "name": "This field is required.",
+                "topics": "Select at least one topic or allow access to all topics.",
+            },
         )
 
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "all topics", "topics": []},
+            {"name": "all topics", "all_topics": True, "topics": []},
             form_errors={"name": "Must be unique."},
         )
 
@@ -45,7 +48,7 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "\\ministry", "topics": []},
+            {"name": "\\ministry", "topics": [sales.id]},
             form_errors={"name": "Cannot contain the character: \\"},
         )
 
@@ -53,7 +56,7 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "X" * 65, "topics": []},
+            {"name": "X" * 65, "topics": [sales.id]},
             form_errors={"name": "Ensure this value has at most 64 characters (it has 65)."},
         )
 
@@ -124,8 +127,17 @@ class TeamCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "all topics"},
+            {"name": "all topics", "topics": [sales.id]},
             form_errors={"name": "Must be unique."},
+            object_unchanged=team,
+        )
+
+        # a team restricted by topic must have at least one topic
+        self.assertUpdateSubmit(
+            update_url,
+            self.admin,
+            {"name": "Sales", "topics": []},
+            form_errors={"topics": "Select at least one topic or allow access to all topics."},
             object_unchanged=team,
         )
 

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -166,7 +166,13 @@ class TeamCRUDL(SmartCRUDL):
         success_url = "@tickets.team_list"
 
         def save(self, obj):
-            return Team.create(self.request.org, self.request.user, obj.name, topics=self.form.cleaned_data["topics"])
+            return Team.create(
+                self.request.org,
+                self.request.user,
+                obj.name,
+                topics=self.form.cleaned_data["topics"],
+                all_topics=self.form.cleaned_data["all_topics"],
+            )
 
     class Update(BaseUpdateModal):
         form_class = TeamForm

--- a/templates/tickets/team_create.html
+++ b/templates/tickets/team_create.html
@@ -1,1 +1,14 @@
 {% extends "orgs/base/create.html" %}
+{% load i18n %}
+
+{% block fields %}
+  {% if limit_reached %}
+    {{ block.super }}
+  {% else %}
+    {% include "tickets/team_fields.html" %}
+  {% endif %}
+{% endblock fields %}
+{% block modal-script %}
+  {{ block.super }}
+  {% if not limit_reached %}{% include "tickets/team_script.html" with modax_id="#new-team" %}{% endif %}
+{% endblock modal-script %}

--- a/templates/tickets/team_fields.html
+++ b/templates/tickets/team_fields.html
@@ -1,0 +1,12 @@
+{% load smartmin i18n %}
+
+{% render_field 'name' %}
+{% render_field 'all_topics' %}
+<div class="topics hidden">
+  {% render_field 'topics' %}
+  <temba-alert level="warning" class="mb-4">
+    {% blocktrans trimmed %}
+      Ticket search is not currently supported for teams that are restricted to specific topics.
+    {% endblocktrans %}
+  </temba-alert>
+</div>

--- a/templates/tickets/team_script.html
+++ b/templates/tickets/team_script.html
@@ -1,0 +1,16 @@
+<script type="text/javascript">
+  var modalBody = getModax("{{ modax_id }}").shadowRoot;
+  var allTopics = modalBody.querySelector("temba-checkbox[name='all_topics']");
+  var topics = modalBody.querySelector(".topics");
+
+  function updateTopics() {
+    if (allTopics.checked) {
+      topics.classList.add("hidden");
+    } else {
+      topics.classList.remove("hidden");
+    }
+  }
+
+  updateTopics();
+  allTopics.addEventListener("change", updateTopics);
+</script>

--- a/templates/tickets/team_update.html
+++ b/templates/tickets/team_update.html
@@ -1,0 +1,10 @@
+{% extends "includes/modax.html" %}
+{% load i18n %}
+
+{% block fields %}
+  {% include "tickets/team_fields.html" %}
+{% endblock fields %}
+{% block modal-script %}
+  {{ block.super }}
+  {% include "tickets/team_script.html" with modax_id="#update-team" %}
+{% endblock modal-script %}


### PR DESCRIPTION
## Summary

Only the system "All Topics" team could be unrestricted by topic, and topic-restricted teams can't use cross-ticket search. This lets any team be explicitly marked as having access to all topics, and warns when a team is being restricted to a subset that search won't support. Adding every topic to a team isn't equivalent, since it silently breaks when a new topic is created.

## Changes

**Team form** (`temba/tickets/forms.py`)
- New `all_topics` checkbox, "All topics", with help text explaining it also covers topics created later. Defaults to checked for new teams.
- When checked, any selected topics are discarded and the per-team topic limit isn't enforced.
- When unchecked, at least one topic is required, so a team can no longer be gated to an empty set of topics through the UI.

**Team views** (`temba/tickets/views.py`)
- Create passes the flag through to `Team.create`. Update goes through the model form, so switching an existing team to all topics clears its topics and unchecking it restores gating.

**Templates** (`templates/tickets/`)
- `team_fields.html` renders name, the checkbox and a topics block holding the topic picker plus a warning: "Ticket search is not currently supported for teams that are restricted to specific topics."
- `team_script.html` shows that block only while the checkbox is unchecked, so the warning appears exactly when a subset of topics is being chosen.
- `team_create.html` and new `team_update.html` wire the shared fields and script into the create and edit modals. The team list and team detail pages already display "All" for unrestricted teams.

**Locale**
- Regenerated PO files with Spanish, French and Portuguese translations for the four new strings.

## Behavior examples

| Action | Before | After |
|---|---|---|
| Create a team with no topics selected | Team gated to zero topics, agents see nothing | "All topics" is checked by default, so the team is unrestricted like the system team |
| Uncheck "All topics" | n/a | Topic picker appears with a warning that ticket search isn't supported for the team |
| Uncheck "All topics" and select nothing | Team gated to zero topics | Error: "Select at least one topic or allow access to all topics." |
| Edit a gated team and check "All topics" | n/a | Selected topics are cleared and the team's agents can search tickets |
| Submit 11 topics with "All topics" checked | Error: at most 10 topics | Topics ignored, team created unrestricted |

## Test plan

- [x] Team CRUDL tests cover the new initial values, creating an all-topics team while ignoring selected topics, that agents in such a team have no topic restriction, the at-least-one-topic error on create and update, and updating a team in both directions
- [x] `temba.tickets`, user and invitation CRUDL suites pass
- [x] `code_check.py` clean, PO files current