### PR TITLE
Make SSO login warning message configurable per domain

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -5341,21 +5341,10 @@ msgstr ""
 msgid "We tried our best, but there was an error processing your request. If this keeps happening, please refresh your browser."
 msgstr ""
 
-#, python-format
-msgid "Sign In with %(provider)s"
-msgstr ""
-
 msgid "Use Single Sign-On"
 msgstr ""
 
 msgid "Ok"
-msgstr ""
-
-#, python-format
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use <b>Sign In with %(provider)s</b> the next time you sign in."
-msgstr ""
-
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use the single sign-on option the next time you sign in."
 msgstr ""
 
 msgid "Are you sure you want to continue? This cannot be undone."
@@ -6325,6 +6314,10 @@ msgstr ""
 
 #, python-format
 msgid "Accept Invitation with %(provider)s"
+msgstr ""
+
+#, python-format
+msgid "Sign In with %(provider)s"
 msgstr ""
 
 #, python-format

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:57+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -5380,22 +5380,11 @@ msgstr "¡Oh, no!"
 msgid "We tried our best, but there was an error processing your request. If this keeps happening, please refresh your browser."
 msgstr "Hicimos todo lo posible, pero se produjo un error al procesar su solicitud. Si esto sigue ocurriendo, actualice su navegador."
 
-#, python-format
-msgid "Sign In with %(provider)s"
-msgstr "Iniciar sesión con %(provider)s"
-
 msgid "Use Single Sign-On"
 msgstr "Usar inicio de sesión único"
 
 msgid "Ok"
 msgstr "Ok"
-
-#, python-format
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use <b>Sign In with %(provider)s</b> the next time you sign in."
-msgstr "El inicio de sesión con correo electrónico y contraseña dejará de estar disponible para su organización. Para mantener el acceso a su cuenta, use <b>Iniciar sesión con %(provider)s</b> la próxima vez que inicie sesión."
-
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use the single sign-on option the next time you sign in."
-msgstr "El inicio de sesión con correo electrónico y contraseña dejará de estar disponible para su organización. Para mantener el acceso a su cuenta, use la opción de inicio de sesión único la próxima vez que inicie sesión."
 
 msgid "Are you sure you want to continue? This cannot be undone."
 msgstr "Estás seguro de que quieres continuar? Esto no se puede deshacer."
@@ -6506,6 +6495,10 @@ msgstr "Cuenta de terceros desconectada"
 #, python-format
 msgid "Accept Invitation with %(provider)s"
 msgstr "Aceptar invitación con %(provider)s"
+
+#, python-format
+msgid "Sign In with %(provider)s"
+msgstr "Iniciar sesión con %(provider)s"
 
 #, python-format
 msgid "The page you are requesting belongs to a different workspace, <b>%(org)s</b>. To see it, you will need to service their account."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:57+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -5380,22 +5380,11 @@ msgstr "Oups !"
 msgid "We tried our best, but there was an error processing your request. If this keeps happening, please refresh your browser."
 msgstr "Nous avons fait de notre mieux, mais une erreur s'est produite lors du traitement de votre requête. Si cela se reproduit, veuillez actualiser votre navigateur."
 
-#, python-format
-msgid "Sign In with %(provider)s"
-msgstr "Se connecter avec %(provider)s"
-
 msgid "Use Single Sign-On"
 msgstr "Utiliser l'authentification unique"
 
 msgid "Ok"
 msgstr "OK"
-
-#, python-format
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use <b>Sign In with %(provider)s</b> the next time you sign in."
-msgstr "La connexion par adresse e-mail et mot de passe va être supprimée pour votre organisation. Pour conserver l'accès à votre compte, utilisez <b>Se connecter avec %(provider)s</b> lors de votre prochaine connexion."
-
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use the single sign-on option the next time you sign in."
-msgstr "La connexion par adresse e-mail et mot de passe va être supprimée pour votre organisation. Pour conserver l'accès à votre compte, utilisez l'option d'authentification unique lors de votre prochaine connexion."
 
 msgid "Are you sure you want to continue? This cannot be undone."
 msgstr "Es-tu sur de vouloir continuer? Ça ne peut pas être annulé."
@@ -6504,6 +6493,10 @@ msgstr "Compte tiers déconnecté"
 #, python-format
 msgid "Accept Invitation with %(provider)s"
 msgstr "Accepter l'invitation avec %(provider)s"
+
+#, python-format
+msgid "Sign In with %(provider)s"
+msgstr "Se connecter avec %(provider)s"
 
 #, python-format
 msgid "The page you are requesting belongs to a different workspace, <b>%(org)s</b>. To see it, you will need to service their account."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-31 22:54+0000\n"
+"POT-Creation-Date: 2026-09-01 20:57+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -5384,22 +5384,11 @@ msgstr "Opa!"
 msgid "We tried our best, but there was an error processing your request. If this keeps happening, please refresh your browser."
 msgstr "Nós tentamos o nosso melhor, mas ocorreu um erro ao processar a sua requisição. Se isso continuar acontecendo, por favor atualize o seu navegador."
 
-#, python-format
-msgid "Sign In with %(provider)s"
-msgstr "Entrar com %(provider)s"
-
 msgid "Use Single Sign-On"
 msgstr "Usar login único (SSO)"
 
 msgid "Ok"
 msgstr "Ok"
-
-#, python-format
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use <b>Sign In with %(provider)s</b> the next time you sign in."
-msgstr "Entrar com e-mail e senha deixará de existir para a sua organização. Para manter o acesso à sua conta, por favor use <b>Entrar com %(provider)s</b> na próxima vez que você entrar."
-
-msgid "Signing in with an email and password is going away for your organization. To keep access to your account, please use the single sign-on option the next time you sign in."
-msgstr "Entrar com e-mail e senha deixará de existir para a sua organização. Para manter o acesso à sua conta, por favor use a opção de login único na próxima vez que você entrar."
 
 msgid "Are you sure you want to continue? This cannot be undone."
 msgstr "Você tem certeza que quer continuar? Isso não pode ser desfeito."
@@ -6497,6 +6486,10 @@ msgstr "Conta de terceiros desconectada"
 #, python-format
 msgid "Accept Invitation with %(provider)s"
 msgstr "Aceitar convite com %(provider)s"
+
+#, python-format
+msgid "Sign In with %(provider)s"
+msgstr "Entrar com %(provider)s"
 
 #, python-format
 msgid "The page you are requesting belongs to a different workspace, <b>%(org)s</b>. To see it, you will need to service their account."

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -988,8 +988,8 @@ SOCIALACCOUNT_PROVIDERS = {}
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 SOCIALACCOUNT_LOGIN_ON_GET = True
 
-# maps email domains to the SSO provider (an allauth provider or app id) their users should be logging in with,
-# used to warn those still logging in with a password
+# maps email domains whose users should be logging in with SSO to the (translatable) warning shown to those still
+# logging in with a password
 SSO_LOGIN_WARNING_DOMAINS = {}
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 

--- a/temba/users/adapter.py
+++ b/temba/users/adapter.py
@@ -2,7 +2,7 @@ from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.models import EmailAddress
 from allauth.core import context as allauth_context
 from allauth.mfa.adapter import DefaultMFAAdapter
-from allauth.socialaccount.adapter import DefaultSocialAccountAdapter, get_adapter as get_socialaccount_adapter
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.signals import social_account_added
 
 from django.conf import settings
@@ -63,14 +63,10 @@ class TembaAccountAdapter(InviteAdapterMixin, DefaultAccountAdapter):
         # users whose email domain should be using SSO get a warning when they login with a password instead
         is_sso = bool(signal_kwargs and signal_kwargs.get("sociallogin"))
         domain = user.email.rsplit("@", 1)[-1].lower() if user.email else ""
-        warn_domains = {d.lower(): p for d, p in settings.SSO_LOGIN_WARNING_DOMAINS.items()}
+        warn_domains = {d.lower() for d in settings.SSO_LOGIN_WARNING_DOMAINS}
         if not is_sso and domain in warn_domains:
-            try:
-                provider_name = get_socialaccount_adapter().get_provider(request, warn_domains[domain]).name
-            except Exception:
-                provider_name = None  # misconfigured provider id still warns, just without naming the provider
-
-            request.session["sso_login_warning"] = {"provider": provider_name}
+            # the message itself is looked up when rendered so that it's translated to the user's language
+            request.session["sso_login_warning"] = domain
 
         return super().post_login(
             request,

--- a/temba/users/tests/test_auth.py
+++ b/temba/users/tests/test_auth.py
@@ -5,6 +5,7 @@ from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
+from django.utils.functional import lazystr
 
 from temba.orgs.models import Invitation, OrgRole
 from temba.tests.base import TembaTest
@@ -83,8 +84,7 @@ class UserAuthTest(TembaTest):
         self.assertTrue(emails.filter(email="newemail@temba.io").exists())
 
     @override_settings(
-        SSO_LOGIN_WARNING_DOMAINS={"SSO-Corp.com": "google", "no-sso-corp.com": "acme"},
-        SOCIALACCOUNT_PROVIDERS={"google": {"APPS": [{"client_id": "test-id", "secret": "test-secret", "key": ""}]}},
+        SSO_LOGIN_WARNING_DOMAINS={"SSO-Corp.com": lazystr("Use <b>Sign In with SSO Corp</b> next time.")}
     )
     def test_sso_login_warning(self):
         login_url = reverse("account_login")
@@ -103,25 +103,25 @@ class UserAuthTest(TembaTest):
 
         self.client.logout()
 
-        # but a user whose email domain should be using SSO gets a warning named after the mapped provider
+        # but a user whose email domain should be using SSO gets the warning configured for that domain, escaped
         user = create_verified_user("uma@sso-corp.com")
 
         response = self.client.post(login_url, {"login": user.email, "password": self.default_password}, follow=True)
         self.assertContains(response, "sso-login-warning")
-        self.assertContains(response, 'header="Sign In with Google"')
+        self.assertContains(response, 'header="Use Single Sign-On"')
+        self.assertContains(response, "Use &lt;b&gt;Sign In with SSO Corp&lt;/b&gt; next time.")
 
         # only on the first page load after login
         response = self.client.get(response.request["PATH_INFO"])
         self.assertNotContains(response, "sso-login-warning")
 
-        self.client.logout()
+        # a flagged domain that is no longer configured doesn't warn
+        session = self.client.session
+        session["sso_login_warning"] = "old-corp.com"
+        session.save()
 
-        # a domain mapped to a provider that isn't configured still warns, just generically
-        user2 = create_verified_user("ursula@no-sso-corp.com")
-
-        response = self.client.post(login_url, {"login": user2.email, "password": self.default_password}, follow=True)
-        self.assertContains(response, "sso-login-warning")
-        self.assertContains(response, 'header="Use Single Sign-On"')
+        response = self.client.get(response.request["PATH_INFO"])
+        self.assertNotContains(response, "sso-login-warning")
 
     def test_signup(self):
         signup_url = reverse("account_signup")

--- a/temba/utils/templatetags/temba.py
+++ b/temba/utils/templatetags/temba.py
@@ -1,6 +1,7 @@
 import json
 from datetime import timezone as tzone
 
+from django.conf import settings
 from django.template.defaultfilters import register
 from django.urls import reverse
 from django.utils.html import escapejs
@@ -147,8 +148,14 @@ def absolute_url(context, url_pattern):
 
 
 @register.simple_tag(takes_context=True)
-def pop_session(context, key):
+def sso_login_warning(context):
     """
-    Removes and returns a value from the request session - for one-time flags such as login warnings.
+    Returns the warning for a user who just logged in with a password but should be using SSO, or None. The warning is
+    a one-time flag in the session and the message is looked up here so it's translated to the user's language.
     """
-    return context["request"].session.pop(key, None)
+    domain = context["request"].session.pop("sso_login_warning", None)
+    if not domain:
+        return None
+
+    messages = {d.lower(): m for d, m in settings.SSO_LOGIN_WARNING_DOMAINS.items()}
+    return str(messages.get(domain, "")) or None

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -211,13 +211,9 @@
           {% endblock error-dialog %}
           <temba-toast duration="5000" error-sticky>
           </temba-toast>
-          {% pop_session "sso_login_warning" as sso_login_warning %}
+          {% sso_login_warning as sso_login_warning %}
           {% if sso_login_warning %}
-            {% if sso_login_warning.provider %}
-              {% blocktrans with provider=sso_login_warning.provider asvar sso_warning_title %}Sign In with {{ provider }}{% endblocktrans %}
-            {% else %}
-              {% trans "Use Single Sign-On" as sso_warning_title %}
-            {% endif %}
+            {% trans "Use Single Sign-On" as sso_warning_title %}
             {% trans "Ok" as sso_warning_button %}
             <temba-dialog open
                           header="{{ sso_warning_title }}"
@@ -225,19 +221,7 @@
                           primaryButtonName=""
                           hideOnClick
                           id="sso-login-warning">
-              <div class="p-6">
-                {% if sso_login_warning.provider %}
-                  {% blocktrans trimmed with provider=sso_login_warning.provider %}
-                    Signing in with an email and password is going away for your organization. To keep access to your
-                    account, please use <b>Sign In with {{ provider }}</b> the next time you sign in.
-                  {% endblocktrans %}
-                {% else %}
-                  {% blocktrans trimmed %}
-                    Signing in with an email and password is going away for your organization. To keep access to your
-                    account, please use the single sign-on option the next time you sign in.
-                  {% endblocktrans %}
-                {% endif %}
-              </div>
+              <div class="p-6">{{ sso_login_warning }}</div>
             </temba-dialog>
           {% endif %}
           <div class="ajax-scripts"></div>


### PR DESCRIPTION
## Summary

The warning shown to users who log in with a password when their email domain should be using SSO previously named the SSO provider mapped to their domain, with the wording fixed in the template. Operators now configure the message itself per domain, so it can say what's actually happening for that organization, such as a cutoff date.

## Changes

- `SSO_LOGIN_WARNING_DOMAINS` now maps an email domain to the warning message (a lazy translatable string) rather than to an allauth provider id.
- `TembaAccountAdapter.post_login` stores just the matched domain in the session instead of resolving a provider name at login time.
- New `sso_login_warning` template tag pops that flag and looks up the message when the page renders, so it's translated to the logged-in user's language rather than the language of the anonymous login request. Replaces the generic `pop_session` tag, which had no other use.
- `frame.html` keeps the "Use Single Sign-On" dialog header and renders the configured message as escaped plain text.
- Locale catalogs regenerated for the removed template strings.

## Behavior examples

| Setting | Before | After |
|---|---|---|
| `{"acme.org": "acme"}` | "Signing in with an email and password is going away... please use **Sign In with Acme**..." | n/a (value is now a message) |
| `{"acme.org": _("Password login ends Oct 1, please use Sign In with Acme.")}` | n/a | "Password login ends Oct 1, please use Sign In with Acme." |
| Session flag for a domain no longer configured | warned generically | no warning |

## Test plan

- [x] `temba.users.tests.test_auth` covers a matching domain (message shown, HTML-escaped), the one-time display, and a stale session flag for an unconfigured domain
- [x] `code_check.py` passes (ruff, djlint, locale files)