### PR TITLE
Read message folders from Msg.folder, paging by uuid

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -193,9 +193,9 @@ class EndpointsTest(APITestMixin, TembaTest):
         # an unknown folder returns nothing
         self.assertGet(endpoint_url + "?folder=nope", [self.admin], results=[])
 
-        # ?folder=sent orders by sent_on rather than created_on
-        sent_old = self.create_outgoing_msg(contact1, "Old reply", sent_on=timezone.now() - timedelta(hours=2))
-        sent_new = self.create_outgoing_msg(contact1, "Newer reply", sent_on=timezone.now() - timedelta(minutes=5))
+        # ?folder=sent is ordered by creation like the other folders, not by sent_on
+        sent_old = self.create_outgoing_msg(contact1, "Old reply", sent_on=timezone.now() - timedelta(minutes=5))
+        sent_new = self.create_outgoing_msg(contact1, "Newer reply", sent_on=timezone.now() - timedelta(hours=2))
         self.assertGet(endpoint_url + "?folder=sent", [self.admin], results=[sent_new, sent_old])
 
         # ?label=<uuid> filters to that label's visible messages

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -242,9 +242,12 @@ class ModifiedOnCursorPagination(CursorPagination):
             return self.ordering
 
 
-class SentOnCursorPagination(CursorPagination):
-    ordering = ("-sent_on", "-id")
-    offset_cutoff = 100000
+class UUIDCursorPagination(CursorPagination):
+    """
+    For objects whose uuids are v7 and so time ordered
+    """
+
+    ordering = ("-uuid",)
 
 
 class DateJoinedCursorPagination(CursorPagination):

--- a/temba/api/v2/tests/test_messages.py
+++ b/temba/api/v2/tests/test_messages.py
@@ -148,6 +148,25 @@ class MessagesEndpointTest(APITest):
             results=[joe_msg4, joe_msg3, joe_msg2],
         )
 
+        # filter by before/after within a folder, which pages by uuid and so applies them as uuid bounds as well
+        self.assertGet(
+            endpoint_url + f"?folder=flows&before={format_datetime(joe_msg1.created_on)}",
+            [self.editor],
+            results=[joe_msg1],
+        )
+        self.assertGet(
+            endpoint_url + f"?folder=flows&after={format_datetime(joe_msg3.created_on)}",
+            [self.editor],
+            results=[joe_msg3],
+        )
+        self.assertGet(
+            endpoint_url
+            + f"?folder=flows&after={format_datetime(joe_msg1.created_on)}&before={format_datetime(joe_msg3.created_on)}",
+            [self.editor],
+            results=[joe_msg3, joe_msg1],
+        )
+        self.assertGet(endpoint_url + "?folder=flows&before=nope", [self.editor], results=[])
+
         # filter by broadcast (deprecated, so recorded)
         broadcast = self.create_broadcast(
             self.editor, {"eng": {"text": "A beautiful broadcast"}}, contacts=[joe, frank]

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2,6 +2,7 @@ import itertools
 from collections import defaultdict
 from datetime import date, timedelta
 from enum import Enum
+from functools import cached_property
 
 from rest_framework import generics, status
 from rest_framework.pagination import CursorPagination
@@ -41,7 +42,7 @@ from ..support import (
     InvalidQueryError,
     ModifiedOnCursorPagination,
     OrgUserRateThrottle,
-    SentOnCursorPagination,
+    UUIDCursorPagination,
     record_deprecated,
 )
 from ..views import BaseAPIView, BulkWriteAPIMixin, DeleteAPIMixin, ListAPIMixin, WriteAPIMixin
@@ -2195,7 +2196,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
 
     You can also filter by `folder` where folder is one of `inbox`, `flows`, `archived`, `outbox`, `sent` or `failed`.
 
-    The sort order for the `sent` folder is the sent date. All other requests are sorted by the message creation date.
+    Results are sorted by the message creation date, most recent first.
 
     Without any parameters this endpoint will return all incoming and outgoing messages ordered by creation date.
 
@@ -2279,14 +2280,12 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
 
     class Pagination(CreatedOnCursorPagination):
         """
-        Overridden paginator that switches depending on folder being requested.
+        Folder requests are paged by uuid, which is what the folder index is keyed on (and time ordered, as message
+        uuids are v7). Everything else is paged by created_on.
         """
 
-        ordering = {"sent": SentOnCursorPagination.ordering}
-
         def get_ordering(self, request, queryset, view=None):
-            folder = request.query_params.get("folder", "").lower()
-            return self.ordering.get(folder, CreatedOnCursorPagination.ordering)
+            return UUIDCursorPagination.ordering if view.folder else self.ordering
 
     model = Msg
     serializer_class = MsgReadSerializer
@@ -2305,15 +2304,29 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
         "failed": MsgFolder.FAILED,
     }
 
+    @cached_property
+    def folder(self):
+        """
+        The folder selected by the `folder` param, or None if there isn't one or it isn't valid
+        """
+        folder = self.request.query_params.get("folder")
+        return self.FOLDER_FILTERS.get(folder.lower()) if folder else None
+
     def derive_queryset(self):
         org = self.request.org
-        folder = self.request.query_params.get("folder")
 
-        if folder:
-            if msg_folder := self.FOLDER_FILTERS.get(folder.lower()):
-                return msg_folder.get_queryset(org)
-            else:
+        if self.request.query_params.get("folder"):
+            if not self.folder:
                 return self.model.objects.none()
+
+            # before/after are passed to the folder as uuid bounds so that they're conditions on the folder index -
+            # filter_queryset still applies them to created_on so that they're exact
+            try:
+                before, after = self.get_before_after()
+            except ValueError:
+                return self.model.objects.none()
+
+            return self.folder.get_queryset(org, after=after, before=before)
         else:
             return self.model.objects.filter(
                 org=org, visibility__in=(Msg.VISIBILITY_VISIBLE, Msg.VISIBILITY_ARCHIVED)

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -146,25 +146,28 @@ class ListAPIMixin(mixins.ListModelMixin):
         if sum([(1 if params.get(p) else 0) for p in self.exclusive_params]) > 1:
             raise InvalidQueryError("You may only specify one of the %s parameters" % ", ".join(self.exclusive_params))
 
+    def get_before_after(self) -> tuple:
+        """
+        Returns the parsed before/after params, raising ValueError if either is malformed
+        """
+        before = self.request.query_params.get("before")
+        after = self.request.query_params.get("after")
+
+        return iso8601.parse_date(before) if before else None, iso8601.parse_date(after) if after else None
+
     def filter_before_after(self, queryset, field):
         """
         Filters the queryset by the before/after params if are provided
         """
-        before = self.request.query_params.get("before")
-        if before:
-            try:
-                before = iso8601.parse_date(before)
-                queryset = queryset.filter(**{field + "__lte": before})
-            except ValueError:
-                queryset = queryset.filter(pk=-1)
+        try:
+            before, after = self.get_before_after()
+        except ValueError:
+            return queryset.filter(pk=-1)
 
-        after = self.request.query_params.get("after")
+        if before:
+            queryset = queryset.filter(**{field + "__lte": before})
         if after:
-            try:
-                after = iso8601.parse_date(after)
-                queryset = queryset.filter(**{field + "__gte": after})
-            except ValueError:
-                queryset = queryset.filter(pk=-1)
+            queryset = queryset.filter(**{field + "__gte": after})
 
         return queryset
 

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -13,7 +13,7 @@ from temba.api.support import (
     ListPagination,
     SearchCountMixin,
     SearchLengthMixin,
-    SentOnCursorPagination,
+    UUIDCursorPagination,
 )
 from temba.api.views import ListAPIMixin
 from temba.utils.uuid import is_uuid
@@ -96,13 +96,10 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
 
     class Pagination(SearchCountMixin, CreatedOnCursorPagination):
         """
-        Folders are ordered by `-created_on, -id`, and the sent folder by `-sent_on, -id`. Those are the orderings
-        the partial folder indexes are built on (`msgs_inbox`, `msgs_flows`, `msgs_archived`,
-        `msgs_outbox_and_failed`, `msgs_sent` — see Msg.Meta.indexes), so a page is an index-ordered read rather
-        than a sort. Ordering by `-uuid` instead would be time-ordered too (msg.uuid is uuid7) but uuid isn't part
-        of any folder index, leaving the database to either sort the whole folder or walk the global uuid index
-        filtering by folder. The response always carries a `count` so the list UI can show a total: a search
-        count via SearchCountMixin, otherwise the folder/label's cheap pre-calculated count (see
+        Folders are paged by `-uuid`, which is what the folder index (`msgs_by_folder`, see Msg.Meta.indexes) is
+        keyed on and time ordered as message uuids are v7, so a page is an index-ordered read rather than a sort.
+        Labels are paged by `-created_on, -id`. The response always carries a `count` so the list UI can show a
+        total: a search count via SearchCountMixin, otherwise the folder/label's cheap pre-calculated count (see
         `get_total_count`) — never a COUNT(*) on the messages table.
         """
 
@@ -114,9 +111,7 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         max_page_size = 500
 
         def get_ordering(self, request, queryset, view=None):
-            if request.query_params.get("folder", "").lower() == "sent":
-                return SentOnCursorPagination.ordering
-            return self.ordering
+            return UUIDCursorPagination.ordering if view.folder else self.ordering
 
         def paginate_queryset(self, queryset, request, view=None):
             page = super().paginate_queryset(queryset, request, view)
@@ -156,6 +151,16 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
             return None
         return self.request.org.msgs_labels.filter(uuid=label_uuid).first()
 
+    @cached_property
+    def folder(self):
+        """
+        The folder selected by the `folder` param (defaulting to inbox), or None if a label is selected instead or
+        the folder isn't valid.
+        """
+        if self.request.query_params.get("label"):
+            return None
+        return self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
+
     def get_total_count(self) -> int:
         # Cheap pre-calculated total for the active folder/label (squashed count tables) — used as the list's total
         # when there's no search, avoiding a COUNT(*) on the messages table.
@@ -163,10 +168,7 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         if self.request.query_params.get("label"):
             return self.label.get_visible_count() if self.label else 0
 
-        folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
-        if not folder:
-            return 0
-        return MsgFolder.get_counts(org).get(folder, 0)
+        return MsgFolder.get_counts(org).get(self.folder, 0) if self.folder else 0
 
     def derive_queryset(self):
         # `label` takes precedence — the filter view passes a label UUID rather than a folder name, and the visible
@@ -183,22 +185,29 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
                 .prefetch_related("labels")
             )
 
-        folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
-        if not folder:
+        if not self.folder:
             return Msg.objects.none()
 
+        # a search's window is passed to the folder as a uuid bound so that it's a condition on the folder index
+        # rather than something checked on every row the search then has to scan - filter_queryset makes it exact
         return (
-            folder.get_queryset(self.request.org)
+            self.folder.get_queryset(self.request.org, after=self.search_since)
             .select_related("contact", "channel", "flow", "org")
             .prefetch_related("labels")
         )
+
+    @cached_property
+    def search_since(self):
+        """
+        The start of the search window if this request is a search, or None if it isn't
+        """
+        return timezone.now() - self.SEARCH_WINDOW if self.request.query_params.get("search") else None
 
     def filter_queryset(self, queryset):
         search = self.request.query_params.get("search")
         if search:
             queryset = queryset.filter(
-                Q(created_on__gte=timezone.now() - self.SEARCH_WINDOW)
-                & (Q(text__icontains=search) | Q(contact__name__icontains=search))
+                Q(created_on__gte=self.search_since) & (Q(text__icontains=search) | Q(contact__name__icontains=search))
             )
 
         return queryset

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1047,19 +1047,19 @@ class MsgFolder(Enum):
         """
         Returns the messages in this folder, newest first, optionally bounded by created_on (inclusive at both ends).
         The bounds are applied to uuid rather than created_on - message uuids are v7 and so time ordered - so that
-        they're conditions on the folder index rather than a filter over everything it yields. Because a message's
-        uuid is allocated before its created_on is set, the before bound is exact to the millisecond, but a uuid can
-        predate its created_on by more than that (e.g. one allocated before an external call, with created_on set
-        after it), so the after bound is padded to cover that - the padded rows only cost anything when a walk of the
-        folder reaches its low end. The bounds are therefore a superset of the messages created in the range, and
-        callers which need created_on itself honored filter on it as well.
+        they're conditions on the folder index rather than a filter over everything it yields. A message's uuid can
+        be a few milliseconds either side of its created_on - the writers read the clock separately for each, and a
+        v7 generator which exhausts its sequence within a millisecond spills into the next - so both bounds are
+        padded to cover that, at the cost of a few milliseconds of rows read and discarded at each end of a walk of
+        the folder. The bounds are therefore a superset of the messages created in the range, and callers which need
+        created_on itself honored filter on it as well.
         """
         # we don't use org.msgs here because it causes problems when the API is using different db connections
         qs = Msg.objects.filter(org=org, folder=self.code)
         if after:
-            qs = qs.filter(uuid__gte=uuid7_range(after - self.AFTER_PADDING)[0])
+            qs = qs.filter(uuid__gte=uuid7_range(after - self.UUID_PADDING)[0])
         if before:
-            qs = qs.filter(uuid__lte=uuid7_range(before)[1])
+            qs = qs.filter(uuid__lte=uuid7_range(before + self.UUID_PADDING)[1])
 
         return qs.order_by("-uuid")
 
@@ -1088,9 +1088,9 @@ class MsgFolder(Enum):
         return f"<MsgFolder.{self.name} code={self.code}>"
 
 
-# how far the after bound of a folder's uuid range is widened - see MsgFolder.get_queryset. Set outside the class as
-# an attribute defined inside it would become a member.
-MsgFolder.AFTER_PADDING = timedelta(minutes=1)
+# how far the bounds of a folder's uuid range are widened - see MsgFolder.get_queryset. Set outside the class as an
+# attribute defined inside it would become a member.
+MsgFolder.UUID_PADDING = timedelta(milliseconds=10)
 
 
 class Label(TembaModel, DependencyMixin):

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -5,6 +5,7 @@ import os
 import re
 from array import array
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 from fnmatch import fnmatch
 from urllib.parse import unquote, urlparse
@@ -1046,16 +1047,17 @@ class MsgFolder(Enum):
         """
         Returns the messages in this folder, newest first, optionally bounded by created_on (inclusive at both ends).
         The bounds are applied to uuid rather than created_on - message uuids are v7 and so time ordered - so that
-        they're conditions on the folder index rather than a filter over everything it yields. They're only accurate
-        to the millisecond of a message's uuid, which is usually but not necessarily the millisecond of its
-        created_on (e.g. a message whose uuid was allocated before an external call and created_on set after it) -
-        a trade accepted for the sake of the index. Callers which need created_on itself honored within those bounds
-        filter on it as well.
+        they're conditions on the folder index rather than a filter over everything it yields. Because a message's
+        uuid is allocated before its created_on is set, the before bound is exact to the millisecond, but a uuid can
+        predate its created_on by more than that (e.g. one allocated before an external call, with created_on set
+        after it), so the after bound is padded to cover that - the padded rows only cost anything when a walk of the
+        folder reaches its low end. The bounds are therefore a superset of the messages created in the range, and
+        callers which need created_on itself honored filter on it as well.
         """
         # we don't use org.msgs here because it causes problems when the API is using different db connections
         qs = Msg.objects.filter(org=org, folder=self.code)
         if after:
-            qs = qs.filter(uuid__gte=uuid7_range(after)[0])
+            qs = qs.filter(uuid__gte=uuid7_range(after - self.AFTER_PADDING)[0])
         if before:
             qs = qs.filter(uuid__lte=uuid7_range(before)[1])
 
@@ -1084,6 +1086,11 @@ class MsgFolder(Enum):
 
     def __repr__(self):  # pragma: no cover
         return f"<MsgFolder.{self.name} code={self.code}>"
+
+
+# how far the after bound of a folder's uuid range is widened - see MsgFolder.get_queryset. Set outside the class as
+# an attribute defined inside it would become a member.
+MsgFolder.AFTER_PADDING = timedelta(minutes=1)
 
 
 class Label(TembaModel, DependencyMixin):
@@ -1320,7 +1327,7 @@ class MessageExport(ExportType):
 
         if folder:
             # the uuid bounds put the date range on the folder index, and ordering by uuid walks it rather than
-            # sorting - the created_on filter below makes the range exact
+            # sorting - they're a superset of the range, which the created_on filter below then makes exact
             messages = folder.get_queryset(export.org, after=start_date, before=end_date)
             order_by = "uuid"
         elif label:

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -31,7 +31,7 @@ from temba.utils.export.models import MultiSheetExporter
 from temba.utils.models import LegacyIDMixin, TembaModel
 from temba.utils.models.counts import BaseSquashableCount
 from temba.utils.s3 import public_file_storage
-from temba.utils.uuid import uuid4
+from temba.utils.uuid import uuid4, uuid7_range
 
 logger = logging.getLogger(__name__)
 
@@ -745,10 +745,10 @@ class Msg(models.Model):
 
     def derive_folder(self) -> str:
         """
-        Derives the folder code for this message. Nothing reads this yet - it exists to pin down the contract that
-        mailroom and courier implement, in particular the precedence, which matters for states that fall outside the
-        user facing folders entirely: a message can be archived or deleted while still pending, and such messages
-        must not appear in the Archived folder.
+        Derives the folder code for this message. Folder is written by mailroom and courier - this exists to pin down
+        the contract they implement (and to set it on messages created in tests), in particular the precedence, which
+        matters for states that fall outside the user facing folders entirely: a message can be archived or deleted
+        while still pending, and such messages must not appear in the Archived folder.
         """
 
         if self.visibility in (self.VISIBILITY_DELETED_BY_USER, self.VISIBILITY_DELETED_BY_SENDER):
@@ -867,39 +867,36 @@ class Msg(models.Model):
                 fields=["created_on"],
                 condition=Q(direction="O", is_android=True, status__in=("I", "Q", "E")),
             ),
-            # used for Inbox view and API folder
+            # the five indexes below are no longer used now that the folder views and API folders read from
+            # msgs_by_folder - they're dropped in a follow-up once that has been released
             models.Index(
                 name="msgs_inbox",
                 fields=["org", "-created_on", "-id"],
                 condition=Q(direction="I", visibility="V", status="H", flow__isnull=True),
             ),
-            # used for Flows view and API folder
             models.Index(
                 name="msgs_flows",
                 fields=["org", "-created_on", "-id"],
                 condition=Q(direction="I", visibility="V", status="H", flow__isnull=False),
             ),
-            # used for Archived view and API folder
             models.Index(
                 name="msgs_archived",
                 fields=["org", "-created_on", "-id"],
                 condition=Q(direction="I", visibility="A", status="H"),
             ),
-            # used for Outbox and Failed views and API folders
             models.Index(
                 name="msgs_outbox_and_failed",
                 fields=["org", "status", "-created_on", "-id"],
                 condition=Q(direction="O", visibility="V", status__in=("I", "Q", "E", "F")),
             ),
-            # used for Sent view / API folder (distinct because of the ordering)
             models.Index(
                 name="msgs_sent",
                 fields=["org", "-sent_on", "-id"],
                 condition=Q(direction="O", visibility="V", status__in=("W", "S", "D", "R")),
             ),
-            # will replace the five folder indexes above once the folder views and API folders read from folder and
-            # order by uuid (which is time ordered as message uuids are v7). Partial on the user facing folders so it
-            # doesn't also index every pending and deleted message.
+            # used by the folder views and API folders, which filter by folder and page by uuid (time ordered as
+            # message uuids are v7) - see MsgFolder.get_queryset. Partial on the user facing folders so it doesn't
+            # also index every pending and deleted message.
             models.Index(
                 name="msgs_by_folder",
                 fields=["org", "folder", "-uuid"],
@@ -1045,9 +1042,24 @@ class MsgFolder(Enum):
 
         return None
 
-    def get_queryset(self, org):
+    def get_queryset(self, org, *, after=None, before=None):
+        """
+        Returns the messages in this folder, newest first, optionally bounded by created_on (inclusive at both ends).
+        The bounds are applied to uuid rather than created_on - message uuids are v7 and so time ordered - so that
+        they're conditions on the folder index rather than a filter over everything it yields. They're only accurate
+        to the millisecond of a message's uuid, which is usually but not necessarily the millisecond of its
+        created_on (e.g. a message whose uuid was allocated before an external call and created_on set after it) -
+        a trade accepted for the sake of the index. Callers which need created_on itself honored within those bounds
+        filter on it as well.
+        """
         # we don't use org.msgs here because it causes problems when the API is using different db connections
-        return Msg.objects.filter(org=org, **self.query)
+        qs = Msg.objects.filter(org=org, folder=self.code)
+        if after:
+            qs = qs.filter(uuid__gte=uuid7_range(after)[0])
+        if before:
+            qs = qs.filter(uuid__lte=uuid7_range(before)[1])
+
+        return qs.order_by("-uuid")
 
     def get_archive_query(self) -> dict:
         return self.archive_query.copy()
@@ -1304,8 +1316,13 @@ class MessageExport(ExportType):
                 matching.append(record)
             yield matching
 
+        order_by = "created_on"
+
         if folder:
-            messages = folder.get_queryset(export.org)
+            # the uuid bounds put the date range on the folder index, and ordering by uuid walks it rather than
+            # sorting - the created_on filter below makes the range exact
+            messages = folder.get_queryset(export.org, after=start_date, before=end_date)
+            order_by = "uuid"
         elif label:
             messages = label.get_messages()
         else:
@@ -1313,7 +1330,7 @@ class MessageExport(ExportType):
 
         messages = messages.filter(created_on__gte=start_date, created_on__lte=end_date)
 
-        messages = messages.order_by("created_on").using("readonly")
+        messages = messages.order_by(order_by).using("readonly")
         if last_created_on:
             messages = messages.filter(created_on__gt=last_created_on)
 

--- a/temba/msgs/tests/test_export.py
+++ b/temba/msgs/tests/test_export.py
@@ -106,6 +106,7 @@ class MessageExportTest(TembaTest):
 
         # archive last message
         msg3.visibility = Msg.VISIBILITY_ARCHIVED
+        msg3.folder = Msg.FOLDER_ARCHIVED
         msg3.save()
 
         expected_headers = [
@@ -559,6 +560,7 @@ class MessageExportTest(TembaTest):
 
         # archive last message
         msg3.visibility = Msg.VISIBILITY_ARCHIVED
+        msg3.folder = Msg.FOLDER_ARCHIVED
         msg3.save()
 
         # archive 6 msgs

--- a/temba/msgs/tests/test_msg_folder.py
+++ b/temba/msgs/tests/test_msg_folder.py
@@ -41,8 +41,9 @@ class MsgFolderTest(TembaTest):
         self.create_channel("A", "Org2Channel", "123456", country="RW", org=self.org2)
         t0 = (timezone.now() - timedelta(days=1)).replace(microsecond=0)
 
-        # a millisecond apart so that their uuids are strictly ordered, with the last in the same millisecond as
-        # the third so that the bounds are seen to be millisecond granular
+        # one well before the others, then some a millisecond apart so that their uuids are strictly ordered, with
+        # the last in the same millisecond as the one before it so that the bounds are seen to be millisecond granular
+        msg0 = self.create_incoming_msg(contact, "Msg 0", created_on=t0 - timedelta(minutes=2))
         msg1 = self.create_incoming_msg(contact, "Msg 1", created_on=t0)
         msg2 = self.create_incoming_msg(contact, "Msg 2", created_on=t0 + timedelta(milliseconds=1))
         msg3 = self.create_incoming_msg(contact, "Msg 3", created_on=t0 + timedelta(milliseconds=2))
@@ -52,25 +53,30 @@ class MsgFolderTest(TembaTest):
 
         # newest first, filtered by folder rather than the columns it's derived from
         qs = MsgFolder.INBOX.get_queryset(self.org)
-        self.assertEqual([msg4, msg3, msg2, msg1], list(qs))
+        self.assertEqual([msg4, msg3, msg2, msg1, msg0], list(qs))
         self.assertRegex(
             str(qs.query),
             r'WHERE \("msgs_msg"\."folder" = I AND "msgs_msg"\."org_id" = \d+\) ORDER BY "msgs_msg"\."uuid" DESC$',
         )
 
-        # bounds are inclusive and applied to uuid, so span the whole millisecond of the given time
-        self.assertEqual([msg4, msg3, msg2], list(MsgFolder.INBOX.get_queryset(self.org, after=msg2.created_on)))
-        self.assertEqual([msg2, msg1], list(MsgFolder.INBOX.get_queryset(self.org, before=msg2.created_on)))
-        self.assertEqual(
-            [msg4, msg3], list(MsgFolder.INBOX.get_queryset(self.org, before=msg3.created_on, after=msg3.created_on))
-        )
-        self.assertEqual(
-            [msg2], list(MsgFolder.INBOX.get_queryset(self.org, after=msg2.created_on, before=msg2.created_on))
-        )
-        self.assertEqual(
-            [], list(MsgFolder.INBOX.get_queryset(self.org, after=msg4.created_on + timedelta(milliseconds=1)))
-        )
-        self.assertEqual([], list(MsgFolder.INBOX.get_queryset(self.org, before=t0 - timedelta(milliseconds=1))))
+        def assert_range(expected, **bounds):
+            self.assertEqual(expected, list(MsgFolder.INBOX.get_queryset(self.org, **bounds)), bounds)
+
+        # the before bound is inclusive and spans the whole millisecond of the given time
+        assert_range([msg2, msg1, msg0], before=msg2.created_on)
+        assert_range([msg4, msg3, msg2, msg1, msg0], before=msg3.created_on)
+        assert_range([msg0], before=t0 - timedelta(milliseconds=1))
+        assert_range([], before=t0 - timedelta(minutes=3))
+
+        # the after bound is inclusive but padded to a minute earlier
+        assert_range([msg4, msg3, msg2, msg1], after=msg2.created_on)
+        assert_range([msg4, msg3, msg2, msg1, msg0], after=t0 - timedelta(minutes=1))
+        assert_range([msg4, msg3, msg2, msg1], after=t0 - timedelta(minutes=1, milliseconds=-1))
+        assert_range([], after=msg4.created_on + timedelta(minutes=1, milliseconds=1))
+
+        # and both together
+        assert_range([msg4, msg3, msg2, msg1], before=msg3.created_on, after=msg3.created_on)
+        assert_range([msg0], before=msg0.created_on, after=msg0.created_on)
 
     def test_get_archive_query(self):
         tcs = (

--- a/temba/msgs/tests/test_msg_folder.py
+++ b/temba/msgs/tests/test_msg_folder.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.utils import timezone
 
 from temba.flows.models import Flow, FlowRun, FlowSession
@@ -32,6 +34,43 @@ class MsgFolderTest(TembaTest):
         # messages which aren't in a user facing folder
         assert_folder(self.create_incoming_msg(contact, "Hi", status=Msg.STATUS_PENDING), None)
         assert_folder(self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_DELETED_BY_USER), None)
+
+    def test_get_queryset(self):
+        contact = self.create_contact("Bob", phone="0783835001")
+        other_contact = self.create_contact("Jim", phone="0783835002", org=self.org2)
+        self.create_channel("A", "Org2Channel", "123456", country="RW", org=self.org2)
+        t0 = (timezone.now() - timedelta(days=1)).replace(microsecond=0)
+
+        # a millisecond apart so that their uuids are strictly ordered, with the last in the same millisecond as
+        # the third so that the bounds are seen to be millisecond granular
+        msg1 = self.create_incoming_msg(contact, "Msg 1", created_on=t0)
+        msg2 = self.create_incoming_msg(contact, "Msg 2", created_on=t0 + timedelta(milliseconds=1))
+        msg3 = self.create_incoming_msg(contact, "Msg 3", created_on=t0 + timedelta(milliseconds=2))
+        msg4 = self.create_incoming_msg(contact, "Msg 4", created_on=t0 + timedelta(milliseconds=2, microseconds=500))
+        self.create_incoming_msg(contact, "Archived", created_on=t0, visibility=Msg.VISIBILITY_ARCHIVED)
+        self.create_incoming_msg(other_contact, "Other org", created_on=t0)
+
+        # newest first, filtered by folder rather than the columns it's derived from
+        qs = MsgFolder.INBOX.get_queryset(self.org)
+        self.assertEqual([msg4, msg3, msg2, msg1], list(qs))
+        self.assertRegex(
+            str(qs.query),
+            r'WHERE \("msgs_msg"\."folder" = I AND "msgs_msg"\."org_id" = \d+\) ORDER BY "msgs_msg"\."uuid" DESC$',
+        )
+
+        # bounds are inclusive and applied to uuid, so span the whole millisecond of the given time
+        self.assertEqual([msg4, msg3, msg2], list(MsgFolder.INBOX.get_queryset(self.org, after=msg2.created_on)))
+        self.assertEqual([msg2, msg1], list(MsgFolder.INBOX.get_queryset(self.org, before=msg2.created_on)))
+        self.assertEqual(
+            [msg4, msg3], list(MsgFolder.INBOX.get_queryset(self.org, before=msg3.created_on, after=msg3.created_on))
+        )
+        self.assertEqual(
+            [msg2], list(MsgFolder.INBOX.get_queryset(self.org, after=msg2.created_on, before=msg2.created_on))
+        )
+        self.assertEqual(
+            [], list(MsgFolder.INBOX.get_queryset(self.org, after=msg4.created_on + timedelta(milliseconds=1)))
+        )
+        self.assertEqual([], list(MsgFolder.INBOX.get_queryset(self.org, before=t0 - timedelta(milliseconds=1))))
 
     def test_get_archive_query(self):
         tcs = (

--- a/temba/msgs/tests/test_msg_folder.py
+++ b/temba/msgs/tests/test_msg_folder.py
@@ -41,19 +41,21 @@ class MsgFolderTest(TembaTest):
         self.create_channel("A", "Org2Channel", "123456", country="RW", org=self.org2)
         t0 = (timezone.now() - timedelta(days=1)).replace(microsecond=0)
 
-        # one well before the others, then some a millisecond apart so that their uuids are strictly ordered, with
-        # the last in the same millisecond as the one before it so that the bounds are seen to be millisecond granular
-        msg0 = self.create_incoming_msg(contact, "Msg 0", created_on=t0 - timedelta(minutes=2))
+        # one a second before the others and one 20ms after, with the others a millisecond apart so that their uuids
+        # are strictly ordered, and the last in the same millisecond as the one before it so that the bounds are seen
+        # to be millisecond granular
+        msg0 = self.create_incoming_msg(contact, "Msg 0", created_on=t0 - timedelta(seconds=1))
         msg1 = self.create_incoming_msg(contact, "Msg 1", created_on=t0)
         msg2 = self.create_incoming_msg(contact, "Msg 2", created_on=t0 + timedelta(milliseconds=1))
         msg3 = self.create_incoming_msg(contact, "Msg 3", created_on=t0 + timedelta(milliseconds=2))
         msg4 = self.create_incoming_msg(contact, "Msg 4", created_on=t0 + timedelta(milliseconds=2, microseconds=500))
+        msg5 = self.create_incoming_msg(contact, "Msg 5", created_on=t0 + timedelta(milliseconds=20))
         self.create_incoming_msg(contact, "Archived", created_on=t0, visibility=Msg.VISIBILITY_ARCHIVED)
         self.create_incoming_msg(other_contact, "Other org", created_on=t0)
 
         # newest first, filtered by folder rather than the columns it's derived from
         qs = MsgFolder.INBOX.get_queryset(self.org)
-        self.assertEqual([msg4, msg3, msg2, msg1, msg0], list(qs))
+        self.assertEqual([msg5, msg4, msg3, msg2, msg1, msg0], list(qs))
         self.assertRegex(
             str(qs.query),
             r'WHERE \("msgs_msg"\."folder" = I AND "msgs_msg"\."org_id" = \d+\) ORDER BY "msgs_msg"\."uuid" DESC$',
@@ -62,19 +64,19 @@ class MsgFolderTest(TembaTest):
         def assert_range(expected, **bounds):
             self.assertEqual(expected, list(MsgFolder.INBOX.get_queryset(self.org, **bounds)), bounds)
 
-        # the before bound is inclusive and spans the whole millisecond of the given time
-        assert_range([msg2, msg1, msg0], before=msg2.created_on)
-        assert_range([msg4, msg3, msg2, msg1, msg0], before=msg3.created_on)
-        assert_range([msg0], before=t0 - timedelta(milliseconds=1))
-        assert_range([], before=t0 - timedelta(minutes=3))
+        # bounds are inclusive, millisecond granular, and padded by 10ms at each end
+        assert_range([msg4, msg3, msg2, msg1, msg0], before=msg2.created_on)
+        assert_range([msg4, msg3, msg2, msg1, msg0], before=t0 + timedelta(milliseconds=9))
+        assert_range([msg5, msg4, msg3, msg2, msg1, msg0], before=t0 + timedelta(milliseconds=10))
+        assert_range([msg0], before=t0 - timedelta(seconds=1, milliseconds=10))
+        assert_range([], before=t0 - timedelta(seconds=1, milliseconds=11))
 
-        # the after bound is inclusive but padded to a minute earlier
-        assert_range([msg4, msg3, msg2, msg1], after=msg2.created_on)
-        assert_range([msg4, msg3, msg2, msg1, msg0], after=t0 - timedelta(minutes=1))
-        assert_range([msg4, msg3, msg2, msg1], after=t0 - timedelta(minutes=1, milliseconds=-1))
-        assert_range([], after=msg4.created_on + timedelta(minutes=1, milliseconds=1))
+        assert_range([msg5, msg4, msg3, msg2, msg1], after=msg2.created_on)
+        assert_range([msg5, msg4, msg3, msg2, msg1], after=t0 - timedelta(seconds=1) + timedelta(milliseconds=11))
+        assert_range([msg5, msg4, msg3, msg2, msg1, msg0], after=t0 - timedelta(seconds=1) + timedelta(milliseconds=10))
+        assert_range([msg5], after=msg5.created_on + timedelta(milliseconds=10))
+        assert_range([], after=msg5.created_on + timedelta(milliseconds=11))
 
-        # and both together
         assert_range([msg4, msg3, msg2, msg1], before=msg3.created_on, after=msg3.created_on)
         assert_range([msg0], before=msg0.created_on, after=msg0.created_on)
 

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -265,7 +265,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # create broadcast and fail the only message
         broadcast = self.create_broadcast(self.admin, {"eng": {"text": "message number 2"}}, contacts=[contact1])
-        broadcast.get_messages().update(status="F")
+        broadcast.get_messages().update(status="F", folder=Msg.FOLDER_FAILED)
         msg2 = broadcast.get_messages()[0]
 
         # message without a broadcast

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -724,7 +724,6 @@ class MsgCRUDL(SmartCRUDL):
         folder = MsgFolder.SENT
         bulk_actions = ()
         allow_export = True
-        default_order = ("-sent_on", "-id")
 
     class Failed(MsgListView):
         title = _("Failed")

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -390,6 +390,7 @@ class TembaTest(SmartminTest):
         assert not channel or channel.org == contact.org, "channel belong to different org than contact"
 
         org = contact.org
+        created_on = created_on or timezone.now()  # uuid is derived from it, so read the clock once
 
         if failed_reason == Msg.FAILED_NO_DESTINATION:
             channel = None
@@ -400,7 +401,7 @@ class TembaTest(SmartminTest):
             assert channel and contact_urn, "messages require a channel and contact URN, except for failed_reason=D"
 
         msg = Msg(
-            uuid=uuid7(created_on or timezone.now()),
+            uuid=uuid7(created_on),
             org=org,
             direction=direction,
             contact=contact,
@@ -416,7 +417,7 @@ class TembaTest(SmartminTest):
             is_android=bool(channel and channel.is_android),
             external_identifier=external_identifier,
             high_priority=high_priority,
-            created_on=created_on or timezone.now(),
+            created_on=created_on,
             created_by=created_by,
             modified_on=timezone.now(),
             sent_on=sent_on,

--- a/temba/utils/tests/test_uuids.py
+++ b/temba/utils/tests/test_uuids.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone as tzone
+
 from temba.tests import TembaTest
 from temba.utils import uuid
 
@@ -17,3 +19,36 @@ class TestUUIDs(TembaTest):
         g = uuid.seeded_generator(456)
         self.assertEqual(uuid.UUID("8c338abf-94e2-4c73-9944-72f7a6ff5877", version=4), g())
         self.assertEqual(uuid.UUID("c8e0696f-b3f6-4e63-a03a-57cb95bdb6e3", version=4), g())
+
+    def test_uuid7_range(self):
+        when = datetime(2026, 9, 1, 12, 30, 45, 123456, tzinfo=tzone.utc)
+        lowest, highest = uuid.uuid7_range(when)
+
+        self.assertEqual(7, lowest.version)
+        self.assertEqual(7, highest.version)
+        self.assertEqual("01a05cf3-5183-7000-8000-000000000000", str(lowest))
+        self.assertEqual("01a05cf3-5183-7fff-bfff-ffffffffffff", str(highest))
+
+        # bounds cover any uuid generated in that millisecond regardless of the sub-millisecond part of the time
+        for offset in (timedelta(), timedelta(microseconds=-456), timedelta(microseconds=543)):
+            generated = uuid.uuid7(when + offset)
+            self.assertTrue(lowest <= generated <= highest, offset)
+
+        # but not the neighboring milliseconds
+        self.assertLess(uuid.uuid7(when - timedelta(milliseconds=1)), lowest)
+        self.assertGreater(uuid.uuid7(when + timedelta(milliseconds=1)), highest)
+
+    def test_uuid7(self):
+        when = datetime(2026, 9, 1, 12, 30, 45, 123456, tzinfo=tzone.utc)
+
+        # uuids generated for the same millisecond are ordered as generated, as are ones generated for now
+        for_when = [uuid.uuid7(when) for _ in range(5)]
+        for_now = [uuid.uuid7() for _ in range(5)]
+        self.assertEqual(sorted(for_when), for_when)
+        self.assertEqual(sorted(for_now), for_now)
+        self.assertEqual(5, len(set(for_when)))
+        self.assertTrue(all(u.version == 7 for u in for_when + for_now))
+
+        # and are within the bounds for that millisecond
+        lowest, highest = uuid.uuid7_range(when)
+        self.assertTrue(all(lowest <= u <= highest for u in for_when))

--- a/temba/utils/uuid/__init__.py
+++ b/temba/utils/uuid/__init__.py
@@ -65,6 +65,10 @@ _last_counter_v7 = 0  # 42-bit counter
 _RFC_4122_VERSION_7_FLAGS = (7 << 76) | (0x8000 << 48)
 
 
+def _uuid7_timestamp_ms(when) -> int:
+    return int(when.timestamp()) * 1000 + when.microsecond // 1000
+
+
 def _uuid7_get_counter_and_tail():
     rand = int.from_bytes(os.urandom(10))
     # 42-bit counter with MSB set to 0
@@ -96,8 +100,14 @@ def uuid7(when=None) -> UUID:
     global _last_counter_v7
 
     if when:
-        timestamp_ms = int(when.timestamp() * 1000)
-        counter, tail = _uuid7_get_counter_and_tail()
+        timestamp_ms = _uuid7_timestamp_ms(when)
+
+        # keep UUIDs generated for the same millisecond ordered as generated, as the clock based branch below does
+        if timestamp_ms == _last_timestamp_v7 and _last_counter_v7 < 0x3FF_FFFF_FFFF:
+            counter = _last_counter_v7 + 1
+            tail = int.from_bytes(os.urandom(4))
+        else:
+            counter, tail = _uuid7_get_counter_and_tail()
     else:
         nanoseconds = time.time_ns()
         timestamp_ms = nanoseconds // 1_000_000
@@ -141,3 +151,14 @@ def uuid7(when=None) -> UUID:
 
     hex = "%032x" % int_uuid_7
     return UUID(f"{hex[:8]}-{hex[8:12]}-{hex[12:16]}-{hex[16:20]}-{hex[20:]}")
+
+
+def uuid7_range(when) -> tuple[UUID, UUID]:
+    """
+    Returns the lowest and highest possible v7 UUIDs for the millisecond containing the given time, i.e. bounds on the
+    UUIDs of anything created in that millisecond.
+    """
+    lowest = ((_uuid7_timestamp_ms(when) & 0xFFFF_FFFF_FFFF) << 80) | _RFC_4122_VERSION_7_FLAGS
+    highest = lowest | 0x0FFF_3FFF_FFFF_FFFF_FFFF  # every counter and random bit set
+
+    return UUID(int=lowest), UUID(int=highest)


### PR DESCRIPTION
## Summary

Switches every read of a message folder — the folder views, the internal messages endpoint the list components fetch from, the API v2 `folder` param and message exports — from the multi-column `direction/visibility/status/flow` predicates to the denormalized `Msg.folder` column, paged by `uuid` rather than `(created_on, id)`. That's what the `msgs_by_folder` index added in #6918 is keyed on (message uuids are v7 and so time ordered), so a folder page is a single index-ordered read. It's also a step towards message reads not depending on `id`.

`before`/`after` on the API and the export's date range stay filters on `created_on`, but are additionally applied as uuid bounds so that they're conditions on the folder index rather than a check on every row the index yields. A message's uuid can sit a few milliseconds either side of its `created_on` — the writers read the clock separately for each, and a v7 generator that exhausts its sequence within a millisecond spills into the next — so both bounds are padded by 10 ms (`MsgFolder.UUID_PADDING`). The uuid range is therefore a superset of the `created_on` range, and the `created_on` filters make it exact; the padding costs a few milliseconds of rows read and discarded at each end of a walk.

## Changes

- **`MsgFolder.get_queryset(org, *, after=None, before=None)`** filters on `folder = <code>`, orders by `-uuid`, and applies the optional bounds as `uuid >= min_uuid7(after − 10ms)` / `uuid <= max_uuid7(before + 10ms)`. The per-folder column predicates remain on the enum for `from_msg` / `derive_folder`, which is what mailroom, courier and the test factory write from.
- **API v2 messages** (`temba/api/v2/views.py`): folder requests page by `-uuid` (a new `UUIDCursorPagination` in `api/support.py` replaces `SentOnCursorPagination`), pass parsed `before`/`after` into the folder as bounds, and still apply `filter_before_after` on `created_on` for exactness. Non-folder requests (contact, label, everything) are unchanged and still page by `created_on` on their own indexes. `ListAPIMixin.get_before_after()` is factored out of `filter_before_after` so both share the parsing.
- **Internal messages endpoint** (`temba/msgs/api.py`): folder requests page by `-uuid`; a search's 90-day window is passed to the folder as a uuid bound so it's an index condition rather than a per-row check. Label requests are unchanged.
- **Sent folder** now orders by creation like every other folder rather than `sent_on` — in both endpoints and the view.
- **Message exports**: a folder export applies its date range as uuid bounds and walks the folder index in `uuid` order rather than sorting; the `created_on` filters remain so the range is exact.
- **`uuid7_range(when)`** in `temba/utils/uuid` returns the lowest and highest v7 uuid for the millisecond containing `when`. `uuid7(when)` now computes the millisecond exactly rather than via float multiplication, and keeps uuids generated for the same explicit millisecond ordered as generated (the clock-based path already did), so fixtures created in the same millisecond page deterministically.
- **Test factory** reads the clock once for a message's uuid and `created_on` so they can't straddle a millisecond; two fixtures that changed `status`/`visibility` directly now set `folder` too, as the writers they stand in for do.
- Comments on the five superseded folder indexes note they're now unused and dropped in a follow-up.

## Behavior

| Request | Before | After |
|---|---|---|
| `GET /api/v2/messages.json?folder=inbox` | `WHERE direction='I' AND visibility='V' AND status='H' AND flow_id IS NULL ORDER BY created_on DESC, id DESC` on `msgs_inbox` | `WHERE folder='I' ORDER BY uuid DESC` on `msgs_by_folder` |
| `...?folder=sent` | ordered by `sent_on` | ordered by creation (uuid), like the other folders |
| `...?folder=flows&after=T` | `created_on >= T` filtered per row | `uuid >= min_uuid7(T − 10ms) AND created_on >= T` — the uuid bound is an index condition, the `created_on` filter keeps it exact |
| `...?contact=<uuid>&after=T` | unchanged | unchanged |

## Review notes

The review job flagged that the export comment claimed the `created_on` filter made the range exact when the uuid bounds could exclude boundary messages first. Addressed by padding the bounds in `get_queryset` — one place rather than the export — so the uuid range is always a superset: initially a minute on `after` for a uuid-allocated-before-an-external-call case, then revised to 10 ms on both sides once it was established that path (`NewBaseEventWithUUID`) is only used for airtime events, never messages, and that the real skews are sub-millisecond clock reads and forward sequence spill.

## Test plan

- [x] `MsgFolderTest.test_get_queryset` — filters by `folder` alone (asserted on the SQL), newest first, both bounds inclusive, millisecond granular and padded by exactly 10 ms, other orgs excluded
- [x] `MessagesEndpointTest` — folder + `before`/`after` combinations, malformed `before` within a folder returns nothing
- [x] Internal endpoint test updated to assert the sent folder now orders by creation, not `sent_on`
- [x] `test_uuid7_range` and `test_uuid7` — bounds cover the millisecond and nothing beyond it; same-millisecond uuids are ordered as generated
- [x] `temba.api`, `temba.msgs` and uuid test suites pass locally; `code_check.py` clean