### PR TITLE
Drop the per-folder message indexes superseded by msgs_by_folder

### DIFF
--- a/temba/msgs/migrations/0312_remove_msg_msgs_inbox_and_more.py
+++ b/temba/msgs/migrations/0312_remove_msg_msgs_inbox_and_more.py
@@ -1,0 +1,32 @@
+from django.contrib.postgres.operations import RemoveIndexConcurrently
+from django.db import migrations
+from django.db.migrations.operations.models import RemoveIndex
+
+
+class RemoveIndexConcurrentlyPlainReverse(RemoveIndexConcurrently):
+    """
+    Removes the index concurrently but reverses with a plain create, so that migration tests - which roll the graph
+    backwards inside a transaction - can unapply it.
+    """
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        RemoveIndex.database_backwards(self, app_label, schema_editor, from_state, to_state)
+
+
+class Migration(migrations.Migration):
+    # the per-folder partial indexes, superseded by msgs_by_folder now that everything reading a folder filters by
+    # folder and pages by uuid. Dropped concurrently as a plain drop would hold ACCESS EXCLUSIVE on the messages table
+    # while waiting on every in-flight query against it.
+    atomic = False
+
+    dependencies = [
+        ("msgs", "0311_msg_msgs_by_folder"),
+    ]
+
+    operations = [
+        RemoveIndexConcurrentlyPlainReverse(model_name="msg", name="msgs_inbox"),
+        RemoveIndexConcurrentlyPlainReverse(model_name="msg", name="msgs_flows"),
+        RemoveIndexConcurrentlyPlainReverse(model_name="msg", name="msgs_archived"),
+        RemoveIndexConcurrentlyPlainReverse(model_name="msg", name="msgs_outbox_and_failed"),
+        RemoveIndexConcurrentlyPlainReverse(model_name="msg", name="msgs_sent"),
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -868,33 +868,6 @@ class Msg(models.Model):
                 fields=["created_on"],
                 condition=Q(direction="O", is_android=True, status__in=("I", "Q", "E")),
             ),
-            # the five indexes below are no longer used now that the folder views and API folders read from
-            # msgs_by_folder - they're dropped in a follow-up once that has been released
-            models.Index(
-                name="msgs_inbox",
-                fields=["org", "-created_on", "-id"],
-                condition=Q(direction="I", visibility="V", status="H", flow__isnull=True),
-            ),
-            models.Index(
-                name="msgs_flows",
-                fields=["org", "-created_on", "-id"],
-                condition=Q(direction="I", visibility="V", status="H", flow__isnull=False),
-            ),
-            models.Index(
-                name="msgs_archived",
-                fields=["org", "-created_on", "-id"],
-                condition=Q(direction="I", visibility="A", status="H"),
-            ),
-            models.Index(
-                name="msgs_outbox_and_failed",
-                fields=["org", "status", "-created_on", "-id"],
-                condition=Q(direction="O", visibility="V", status__in=("I", "Q", "E", "F")),
-            ),
-            models.Index(
-                name="msgs_sent",
-                fields=["org", "-sent_on", "-id"],
-                condition=Q(direction="O", visibility="V", status__in=("W", "S", "D", "R")),
-            ),
             # used by the folder views and API folders, which filter by folder and page by uuid (time ordered as
             # message uuids are v7) - see MsgFolder.get_queryset. Partial on the user facing folders so it doesn't
             # also index every pending and deleted message.


### PR DESCRIPTION
> **Merge after nyaruka/mailroom#1242 is deployed.** Mailroom's `FailChannelMessages` query is served by `msgs_outbox_and_failed` until that change (merged, awaiting release) moves it onto `msgs_by_folder`; dropping the index first would leave it scanning everything a removed channel ever sent.

## Summary

Drops the five partial indexes that served the message folders before #6921 moved every folder read onto `msgs_by_folder` (`org_id, folder, uuid DESC`): `msgs_inbox`, `msgs_flows`, `msgs_archived`, `msgs_outbox_and_failed` and `msgs_sent`. This is the write-path payoff of the `Msg.folder` work — five conditional indexes off every message insert and status update on the largest table there is.

Before removing them I swept for anything else that could be using them, since an index with a `direction/visibility/status` predicate only serves a query carrying those same predicates alongside `org_id`:

- **mailroom** — one query, `FailChannelMessages` (`org_id AND direction='O' AND status IN ('I','Q','E') AND visibility='V' AND channel_id`), exactly the `msgs_outbox_and_failed` shape. nyaruka/mailroom#1242 switches it to `folder = 'O'`, which is equivalent and lands on `msgs_by_folder`. Everything else there is by uuid/id/channel, or on `msgs_outgoing_to_retry` / `msgs_outgoing_android_to_fail`, which stay.
- **courier** — by channel + external identifier only.
- **archiver** — `org_id` + `created_on` range, on `msgs_by_org`.
- **this codebase** — nothing. The one candidate, the channel read page's "unsent messages" warning, claimed to use "our optimized index for our org outbox" but filtered `status IN ('P','Q')`, which the predicate never covered; it's removed separately in #6924.

## Changes

- `Msg.Meta.indexes`: the five indexes removed.
- Migration `0312`: drops them with `DROP INDEX CONCURRENTLY` (non-atomic migration, reversing with a plain create so migration tests can roll it back), following the pattern of the earlier concurrent index migrations. A plain drop would hold `ACCESS EXCLUSIVE` on the messages table while waiting on every in-flight query against it.

## Test plan

- [x] `makemigrations --check` reports no changes; `code_check.py` clean
- [x] `temba.msgs` suite passes, including the migration tests which unapply and reapply 0312
- [x] mailroom's `TestFailMessages` passes against the folder-based query (nyaruka/mailroom#1242)

## Follow-up

Once this has landed, regenerate mailroom's test database dump so its schema stops carrying the dropped indexes.