### PR TITLE
Remove the unsent messages warning from the channel read page

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 21:13+0000\n"
+"POT-Creation-Date: 2026-09-01 23:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -4400,11 +4400,6 @@ msgstr ""
 
 msgid "Not synced yet"
 msgstr ""
-
-msgid "unsent message"
-msgid_plural "unsent messages"
-msgstr[0] ""
-msgstr[1] ""
 
 #, python-format
 msgid "Activated on %(date)s"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 21:13+0000\n"
+"POT-Creation-Date: 2026-09-01 23:32+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -4433,12 +4433,6 @@ msgstr "%(last_sync)s hace"
 
 msgid "Not synced yet"
 msgstr "Aún no sincronizado"
-
-msgid "unsent message"
-msgid_plural "unsent messages"
-msgstr[0] "mensaje no enviado"
-msgstr[1] "mensajes no enviados"
-msgstr[2] "mensajes no enviados"
 
 #, python-format
 msgid "Activated on %(date)s"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 21:13+0000\n"
+"POT-Creation-Date: 2026-09-01 23:32+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -4433,12 +4433,6 @@ msgstr "depuis %(last_sync)s "
 
 msgid "Not synced yet"
 msgstr "Pas encore synchronisé"
-
-msgid "unsent message"
-msgid_plural "unsent messages"
-msgstr[0] "message non envoyé"
-msgstr[1] "messages non envoyés"
-msgstr[2] "messages non envoyés"
 
 #, python-format
 msgid "Activated on %(date)s"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 21:13+0000\n"
+"POT-Creation-Date: 2026-09-01 23:32+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -4437,12 +4437,6 @@ msgstr "%(last_sync)s atrás"
 
 msgid "Not synced yet"
 msgstr "Não está sincronizado ainda"
-
-msgid "unsent message"
-msgid_plural "unsent messages"
-msgstr[0] "mensagem não enviada"
-msgstr[1] "mensagens não enviadas"
-msgstr[2] "mensagens não enviadas"
 
 #, python-format
 msgid "Activated on %(date)s"

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -594,51 +594,12 @@ class Channel(LegacyIDMixin, TembaModel, DependencyMixin):
 
         return self.address
 
-    def get_last_sent_message(self):
-        from temba.msgs.models import Msg
-
-        # find last successfully sent message
-        return (
-            self.msgs.filter(status__in=[Msg.STATUS_SENT, Msg.STATUS_DELIVERED], direction=Msg.DIRECTION_OUT)
-            .exclude(sent_on=None)
-            .order_by("-sent_on")
-            .first()
-        )
-
-    def get_delayed_outgoing_messages(self):
-        from temba.msgs.models import Msg
-
-        one_hour_ago = timezone.now() - timedelta(hours=1)
-        latest_sent_message = self.get_last_sent_message()
-
-        # if the last sent message was in the last hour, assume this channel is ok
-        if latest_sent_message and latest_sent_message.sent_on > one_hour_ago:  # pragma: no cover
-            return Msg.objects.none()
-
-        messages = self.get_unsent_messages()
-
-        # channels have an hour to send messages before we call them delays, so ignore all messages created in last hour
-        messages = messages.filter(created_on__lt=one_hour_ago)
-
-        # if we have a successfully sent message, we're only interested a new failures since then. Note that we use id
-        # here instead of created_on because we won't hit the outbox index if we use a range condition on created_on.
-        if latest_sent_message:  # pragma: needs cover
-            messages = messages.filter(id__gt=latest_sent_message.id)
-
-        return messages
-
     @cached_property
     def last_sync(self):
         """
         Gets the last sync event for this channel (only applies to Android channels)
         """
         return self.sync_events.order_by("id").last()
-
-    def get_unsent_messages(self):
-        # use our optimized index for our org outbox
-        from temba.msgs.models import Msg
-
-        return Msg.objects.filter(org=self.org.id, status__in=["P", "Q"], direction="O", visibility="V", channel=self)
 
     def is_new(self):
         # is this channel newer than an hour

--- a/temba/channels/tests/test_channel.py
+++ b/temba/channels/tests/test_channel.py
@@ -337,16 +337,14 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
             sync.created_on = two_hours_ago
             sync.save()
 
+        # an outgoing message from a couple of hours ago, which counts in this month's chart below
         bob = self.create_contact("Bob", phone="+250785551212")
-
-        # add a message, just sent so shouldn't be delayed
         with patch("django.utils.timezone.now", return_value=two_hours_ago):
-            self.create_outgoing_msg(bob, "delayed message", status=Msg.STATUS_QUEUED, channel=self.tel_channel)
+            self.create_outgoing_msg(bob, "hello", status=Msg.STATUS_QUEUED, channel=self.tel_channel)
 
         with patch("django.utils.timezone.now", return_value=test_date):
             response = self.requestView(tel_channel_read_url, self.admin)
             self.assertIn("delayed_sync_event", response.context_data.keys())
-            self.assertIn("unsent_msgs_count", response.context_data.keys())
 
             # now that we can access the channel, which messages do we display in the chart?
             joe = self.create_contact("Joe", phone="+2501234567890")

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -518,12 +518,6 @@ class ChannelCRUDL(SmartCRUDL):
                 if channel.last_sync and (timezone.now() - channel.last_sync.created_on).total_seconds() > 3600:
                     context["delayed_sync_event"] = True
 
-                # unsent messages
-                unsent_msgs = channel.get_delayed_outgoing_messages()
-
-                if unsent_msgs:
-                    context["unsent_msgs_count"] = unsent_msgs.count()
-
             context["monthly_counts"] = self.get_monthly_counts()
             return context
 

--- a/templates/channels/channel_read.html
+++ b/templates/channels/channel_read.html
@@ -15,7 +15,7 @@
     {% if object.country %}({{ object.get_country_display }}){% endif %}
   </div>
   <div class="mb-4 text-base">
-    {% if delayed_sync_event or unsent_msgs_count %}
+    {% if delayed_sync_event %}
       <div class="flex items-center text-error">
         <div class="mr-1">
           <div class="icon-warning text-error text-lg mt-1"></div>
@@ -31,18 +31,6 @@
               {% else %}
                 {% trans "Not synced yet" %}
               {% endif %}
-            </div>
-          {% endif %}
-          {% if unsent_msgs_count %}
-            <div onclick="goto(event)"
-                 href="{% url 'msgs.msg_failed' %}"
-                 class="text-error text-base inline-block ml-2">
-              {{ unsent_msgs_count|intcomma }}
-              {% blocktrans trimmed count unsent_msgs_count=unsent_msgs_count %}
-                unsent message
-              {% plural %}
-                unsent messages
-              {% endblocktrans %}
             </div>
           {% endif %}
         </div>

--- a/templates/channels/channel_read.html
+++ b/templates/channels/channel_read.html
@@ -20,18 +20,14 @@
         <div class="mr-1">
           <div class="icon-warning text-error text-lg mt-1"></div>
         </div>
-        <div class="message">
-          {% if delayed_sync_event %}
-            <div class="inline-block ml-2">
-              {% if last_sync %}
-                {% trans "Last synced" %}
-                {% blocktrans trimmed with last_sync.created_on|timesince as last_sync %}
-                  {{ last_sync }} ago
-                {% endblocktrans %}
-              {% else %}
-                {% trans "Not synced yet" %}
-              {% endif %}
-            </div>
+        <div class="inline-block ml-2">
+          {% if last_sync %}
+            {% trans "Last synced" %}
+            {% blocktrans trimmed with last_sync.created_on|timesince as last_sync %}
+              {{ last_sync }} ago
+            {% endblocktrans %}
+          {% else %}
+            {% trans "Not synced yet" %}
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Removes the "N unsent messages" warning from the channel read page, along with the model methods behind it: `Channel.get_last_sent_message`, `get_delayed_outgoing_messages` and `get_unsent_messages`.

It counted a channel's queued outgoing messages that were older than an hour and newer than the channel's last successful send, as a "this channel looks stuck" hint. That's a heuristic from the Android relayer era, and it aged badly: it ran an unindexed query on every channel page view (its comment claimed "our optimized index for our org outbox", but its `status IN ('P', 'Q')` never matched that index's predicate), and via `if unsent_msgs:` loaded the channel's whole backlog into memory before counting it — worst exactly when a channel was stuck and someone opened the page to look. The "last synced N ago" warning next to it, which is the genuinely relayer-specific check, stays.

Split out of #6922 (which drops the superseded folder indexes and has to wait on a mailroom deploy) so this can land independently.

## Changes

- `temba/channels/models.py`: the three methods removed.
- `temba/channels/views.py`: the read view no longer computes `unsent_msgs_count`.
- `templates/channels/channel_read.html`: the warning's block removed; the alert now shows only for a delayed sync. Locale files regenerated for the two removed strings.
- `test_read` keeps its `delayed_sync_event` assertion; the outgoing message the old fixture created also feeds the monthly-counts chart assertion further down, so it's kept with that as its stated purpose.

## Test plan

- [x] `temba.channels.tests.test_channel` passes
- [x] `code_check.py` clean, locale files regenerated