### PR TITLE
Make Msg.folder non-null

### DIFF
--- a/temba/msgs/migrations/0313_alter_msg_folder.py
+++ b/temba/msgs/migrations/0313_alter_msg_folder.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+# On a large table this is better done ahead of the deploy, as a CHECK (folder IS NOT NULL) constraint added NOT VALID,
+# validated (which scans without blocking writes), then SET NOT NULL - which Postgres satisfies from the validated
+# constraint without another scan, and which this migration then finds already in place and skips.
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msgs", "0312_remove_msg_msgs_inbox_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="msg",
+            name="folder",
+            field=models.CharField(
+                choices=[
+                    ("I", "Inbox"),
+                    ("W", "Handled"),
+                    ("A", "Archived"),
+                    ("O", "Outbox"),
+                    ("S", "Sent"),
+                    ("X", "Failed"),
+                    ("P", "Pending"),
+                    ("D", "Deleted"),
+                ],
+                max_length=1,
+            ),
+        ),
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -643,9 +643,9 @@ class Msg(models.Model):
     direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES)
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=STATUS_PENDING)
     visibility = models.CharField(max_length=1, choices=VISIBILITY_CHOICES, default=VISIBILITY_VISIBLE)
-    # denormalized folder, derived from direction/visibility/status/flow, maintained by mailroom and courier. null
-    # means not yet written, not "in no folder" - see derive_folder.
-    folder = models.CharField(max_length=1, null=True, choices=FOLDER_CHOICES)
+    # denormalized folder, derived from direction/visibility/status/flow (see derive_folder) and maintained by mailroom
+    # and courier - every message is in one, including those not in a user facing folder
+    folder = models.CharField(max_length=1, choices=FOLDER_CHOICES)
 
     is_android = models.BooleanField()
     labels = models.ManyToManyField("Label", related_name="msgs")


### PR DESCRIPTION
## Summary

`Msg.folder` becomes non-null. It's written by mailroom and courier for every message, was backfilled for everything that predates that (and the backfill re-run after the writers caught up found nothing left to change), and is now what the folder views, API folders and folder counts all read — so a null no longer has a meaning worth allowing.

## Changes

- `Msg.folder`: `null=True` removed; the field comment no longer describes null as "not yet written".
- Migration `0313_alter_msg_folder`: the plain `AlterField`. Its `SET NOT NULL` would scan the whole table under `ACCESS EXCLUSIVE`, so on a large installation it's better done ahead of the deploy the non-blocking way — a `CHECK (folder IS NOT NULL)` constraint added `NOT VALID`, validated (the scan, without blocking writes), then `SET NOT NULL`, which Postgres satisfies from the validated constraint — after which the migration finds the column already `NOT NULL` and skips the scan. The migration's comment says so; the validation is also what proves no row was left null.

## Test plan

- [x] `temba.msgs` suite passes, including the migration tests which roll back through 0313 and forward again
- [x] `makemigrations --check` reports no changes; `code_check.py` clean
- [x] The one non-test place constructing `Msg` directly (`MsgWriteSerializer` building the API response from mailroom's result) never saves it