### PR TITLE
Make Firebase Cloud Messaging channel type only available to staff for creating new channels

### DIFF
--- a/temba/channels/types/firebase/tests.py
+++ b/temba/channels/types/firebase/tests.py
@@ -27,10 +27,22 @@ class FirebaseCloudMessagingTypeTest(TembaTest):
     def test_claim(self, mock_get):
         url = reverse("channels.types.firebase.claim")
 
+        # not available to regular users
         self.login(self.admin)
 
-        # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))
+        self.assertNotContains(response, url)
+
+        response = self.client.get(reverse("channels.channel_claim_all"))
+        self.assertNotContains(response, url)
+
+        response = self.client.get(url)
+        self.assertEqual(404, response.status_code)
+
+        # but is available to staff
+        self.login(self.customer_support, choose_org=self.org)
+
+        response = self.client.get(reverse("channels.channel_claim_all"))
         self.assertContains(response, url)
 
         response = self.client.post(

--- a/temba/channels/types/firebase/type.py
+++ b/temba/channels/types/firebase/type.py
@@ -48,3 +48,8 @@ class FirebaseCloudMessagingType(ChannelType):
             ),
         ],
     )
+
+    def is_available_to(self, org, user):
+        available = user.is_staff  # no longer available to non-staff users for creating new channels
+
+        return available, available

--- a/temba/channels/types/firebase/views.py
+++ b/temba/channels/types/firebase/views.py
@@ -36,6 +36,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             return super().clean()
 
     form_class = Form
+    readonly_servicing = False  # staff can create these channels whilst servicing an org
 
     def form_valid(self, form):
         title = form.cleaned_data.get("title")


### PR DESCRIPTION
## Summary

Restricts creating new Firebase Cloud Messaging (FCM) channels to staff users. Regular users no longer see the type on the claim pages and can't reach its claim view. Existing FCM channels are unaffected and continue to send, receive and show their configuration page.

## Changes

- `temba/channels/types/firebase/type.py` — overrides `is_available_to` to return true only for staff users, the same gating the WebChat type uses. Both claim list pages and the claim view's own availability check already honour this.
- `temba/channels/types/firebase/views.py` — sets `readonly_servicing = False` on the claim view so that staff can create the channel while servicing a workspace they aren't a member of, rather than getting a 403 on submit.
- `temba/channels/types/firebase/tests.py` — checks that a regular admin doesn't see the type on either claim page and gets a 404 from the claim view, then runs the existing claim flow as a servicing staff user.

## Behavior examples

| | Regular user | Staff user |
|---|---|---|
| Claim page listing | Not listed | Listed on the "all" claim page |
| `/channels/types/firebase/claim/` | 404 | Claim form, submit allowed while servicing |
| Existing FCM channel configuration page | Works | Works |

## Test plan

- [x] `temba.channels.types.firebase` and `temba.channels.tests.test_channelcrudl` pass
- [x] `code_check.py` passes with no translatable string changes