### PR TITLE
Remove Dashboard auth group

### DIFF
--- a/temba/orgs/migrations/0189_delete_dashboard_group.py
+++ b/temba/orgs/migrations/0189_delete_dashboard_group.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def delete_dashboard_group(apps, schema_editor):  # pragma: no cover
+    Group = apps.get_model("auth", "Group")
+
+    Group.objects.filter(name="Dashboard").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("orgs", "0188_reset_dropped_languages"),
+    ]
+
+    operations = [migrations.RunPython(delete_dashboard_group, migrations.RunPython.noop)]

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -402,7 +402,6 @@ PERMISSIONS = {
 
 # assigns the permissions that each group should have
 GROUP_PERMISSIONS = {
-    "Dashboard": ("orgs.org_dashboard",),
     "Granters": ("orgs.org_grant",),
     "Administrators": (
         "ai.llm.*",

--- a/temba/staff/tests.py
+++ b/temba/staff/tests.py
@@ -275,7 +275,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(200, response.status_code)
 
         granters = Group.objects.get(name="Granters")
-        dashboard = Group.objects.get(name="Dashboard")
+        editors = Group.objects.get(name="Editors")
 
         response = self.requestView(
             update_url,
@@ -284,7 +284,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
                 "email": "eddy@textit.com",
                 "first_name": "Edward",
                 "last_name": "",
-                "groups": [granters.id, dashboard.id],
+                "groups": [granters.id, editors.id],
             },
         )
         self.assertEqual(302, response.status_code)
@@ -293,7 +293,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual("eddy@textit.com", self.editor.email)
         self.assertEqual("Edward", self.editor.first_name)
         self.assertEqual("", self.editor.last_name)
-        self.assertEqual({granters, dashboard}, set(self.editor.groups.all()))
+        self.assertEqual({granters, editors}, set(self.editor.groups.all()))
 
         # submit with one less group
         response = self.requestView(


### PR DESCRIPTION
## Summary

Removes the `Dashboard` auth group. It granted only `orgs.org_dashboard`, which the Administrators role already carries, so membership in the group never changed what an administrator could see. The group predates the current dashboard, which is reached from the Workspaces menu of an org with the child orgs feature and already gated on administrator-only permissions.

## Changes

- `temba/settings_common.py`: drop the `Dashboard` entry from `GROUP_PERMISSIONS`.
- `temba/orgs/migrations/0189_delete_dashboard_group.py`: data migration that deletes the `Dashboard` group. Reverse is a no-op.
- `temba/staff/tests.py`: the staff user update test used the `Dashboard` group as its second permissions group, so it now uses `Editors` instead.

## Behavior

| User | Before | After |
|---|---|---|
| Administrator of an org with child orgs | Dashboard in Workspaces menu | Unchanged |
| Administrator of any org | Could open the dashboard URL directly | Unchanged (via role) |
| Non-administrator in the `Dashboard` group | Could open the dashboard URL directly for that org | No access |

## Test plan

- [x] `manage.py test temba.dashboard temba.orgs temba.users temba.staff`
- [x] `manage.py makemigrations --check`
- [x] `code_check.py`
- [x] CI green