### PR TITLE
Stop reading Msg.visibility to tell whether a message is archived

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -413,9 +413,7 @@ class MessageField(TembaModelField):
     require_exists = False
 
     def get_queryset(self):
-        return self.model.objects.filter(
-            org=self.context["org"], visibility__in=(Msg.VISIBILITY_VISIBLE, Msg.VISIBILITY_ARCHIVED)
-        )
+        return self.model.objects.filter(org=self.context["org"]).exclude(folder=Msg.FOLDER_DELETED)
 
 
 class TicketField(TembaModelField):

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -1350,11 +1350,6 @@ class MsgReadSerializer(ReadSerializer):
         Msg.STATUS_ERRORED: "errored",
         Msg.STATUS_FAILED: "failed",
     }
-    VISIBILITIES = {  # deleted messages should never be exposed over API
-        Msg.VISIBILITY_VISIBLE: "visible",
-        Msg.VISIBILITY_ARCHIVED: "archived",
-    }
-
     broadcast = serializers.SerializerMethodField()
     contact = fields.ContactField()
     urn = fields.URNField(source="contact_urn")
@@ -1395,10 +1390,11 @@ class MsgReadSerializer(ReadSerializer):
         return obj.attachments[0] if obj.attachments else None
 
     def get_archived(self, obj):
-        return obj.visibility == Msg.VISIBILITY_ARCHIVED
+        return obj.folder == Msg.FOLDER_ARCHIVED
 
     def get_visibility(self, obj):
-        return self.VISIBILITIES.get(obj.visibility)
+        # deleted messages are never exposed over the API so everything is either visible or archived
+        return "archived" if obj.folder == Msg.FOLDER_ARCHIVED else "visible"
 
     def get_labels(self, obj):
         # to optimize the POST case that creates an outgoing message, don't even try to look for labels

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2328,9 +2328,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
 
             return self.folder.get_queryset(org, after=after, before=before)
         else:
-            return self.model.objects.filter(
-                org=org, visibility__in=(Msg.VISIBILITY_VISIBLE, Msg.VISIBILITY_ARCHIVED)
-            ).exclude(status=Msg.STATUS_PENDING)
+            return self.model.objects.filter(org=org).exclude(folder__in=(Msg.FOLDER_PENDING, Msg.FOLDER_DELETED))
 
     def filter_queryset(self, queryset):
         params = self.request.query_params

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -180,7 +180,8 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
             if not label:
                 return Msg.objects.none()
             return (
-                Msg.objects.filter(org=self.request.org, labels=label, visibility=Msg.VISIBILITY_VISIBLE)
+                Msg.objects.filter(org=self.request.org, labels=label)
+                .exclude(folder__in=(Msg.FOLDER_ARCHIVED, Msg.FOLDER_DELETED))
                 .select_related("contact", "channel", "flow", "org")
                 .prefetch_related("labels")
             )

--- a/temba/msgs/migrations/0310_backfill_msg_folder.py
+++ b/temba/msgs/migrations/0310_backfill_msg_folder.py
@@ -11,7 +11,7 @@ from django.db.models import Max, Min
 #
 # So this works by comparison rather than by absence: recompute the folder every message should have and write it
 # wherever it disagrees with what's stored, which covers the never-written and the stale cases in one pass without
-# needing to know which messages fall into which. The CASE mirrors Msg.derive_folder, including its precedence: being
+# needing to know which messages fall into which. The CASE mirrors the folder derivation mailroom and courier implement, including its precedence: being
 # deleted, and then being unhandled, both come before the user facing folders, so that a message which is archived or
 # deleted whilst still pending doesn't land in Archived.
 #

--- a/temba/msgs/migrations/0315_update_triggers.py
+++ b/temba/msgs/migrations/0315_update_triggers.py
@@ -1,0 +1,238 @@
+from django.db import migrations
+
+# the label counts (which are split by whether the message is archived or deleted) and the guard against archiving
+# outgoing messages are keyed on the folder rather than visibility, like the folder counts already are. That's the last
+# thing in the database that read visibility to tell whether a message is archived, so archived can stop being a
+# visibility - and when the visibility of messages archived before then is updated, no counts move.
+SQL = """
+----------------------------------------------------------------------
+-- Handles DELETE statements on msgs_msg_labels table
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_labels_on_delete() RETURNS TRIGGER AS $$
+BEGIN
+    -- add negative label count for all deleted rows
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT o.label_id, m.folder IN ('A', 'D'), -count(*), FALSE FROM oldtab o
+    INNER JOIN msgs_msg m ON m.id = o.msg_id
+    GROUP BY o.label_id, m.folder IN ('A', 'D');
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Handles INSERT statements on msgs_msg_labels table
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_labels_on_insert() RETURNS TRIGGER AS $$
+BEGIN
+    -- add label count for all new rows
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT n.label_id, m.folder IN ('A', 'D'), count(*), FALSE FROM newtab n
+    INNER JOIN msgs_msg m ON m.id = n.msg_id
+    GROUP BY n.label_id, m.folder IN ('A', 'D');
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Trigger procedure to update user and system labels on column changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_on_change() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    -- prevent illegal message states
+    IF NEW.direction = 'I' AND NEW.status NOT IN ('P', 'H') THEN
+      RAISE EXCEPTION 'Incoming messages can only be PENDING or HANDLED';
+    END IF;
+    IF NEW.direction = 'O' AND NEW.folder = 'A' THEN
+      RAISE EXCEPTION 'Outgoing messages cannot be archived';
+    END IF;
+  END IF;
+
+  -- existing message updated
+  IF TG_OP = 'UPDATE' THEN
+    -- restrict changes
+    IF NEW.direction <> OLD.direction THEN RAISE EXCEPTION 'Cannot change direction on messages'; END IF;
+    IF NEW.created_on <> OLD.created_on THEN RAISE EXCEPTION 'Cannot change created_on on messages'; END IF;
+    IF NEW.msg_type <> OLD.msg_type THEN RAISE EXCEPTION 'Cannot change msg_type on messages'; END IF;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Handles UPDATE statements on msg table
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_on_update() RETURNS TRIGGER AS $$
+BEGIN
+    -- add negative item counts for all rows that belonged to a folder they no longer belong to
+    INSERT INTO orgs_itemcount("org_id", "scope", "count", "is_squashed")
+    SELECT o.org_id, temba_msg_countscope(o), -count(*), FALSE FROM oldtab o
+    INNER JOIN newtab n ON n.id = o.id
+    WHERE temba_msg_countscope(o) IS DISTINCT FROM temba_msg_countscope(n) AND temba_msg_countscope(o) IS NOT NULL
+    GROUP BY 1, 2;
+
+    -- add positive item counts for all rows that now belong to a folder they didn't belong to
+    INSERT INTO orgs_itemcount("org_id", "scope", "count", "is_squashed")
+    SELECT n.org_id, temba_msg_countscope(n), count(*), FALSE FROM newtab n
+    INNER JOIN oldtab o ON o.id = n.id
+    WHERE temba_msg_countscope(o) IS DISTINCT FROM temba_msg_countscope(n) AND temba_msg_countscope(n) IS NOT NULL
+    GROUP BY 1, 2;
+
+    -- add negative old-state label counts for all messages being archived/restored
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT ml.label_id, o.folder IN ('A', 'D'), -count(*), FALSE FROM oldtab o
+    INNER JOIN newtab n ON n.id = o.id
+    INNER JOIN msgs_msg_labels ml ON ml.msg_id = o.id
+    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
+    GROUP BY 1, 2;
+
+    -- add new-state label counts for all messages being archived/restored
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT ml.label_id, n.folder IN ('A', 'D'), count(*), FALSE FROM newtab n
+    INNER JOIN oldtab o ON o.id = n.id
+    INNER JOIN msgs_msg_labels ml ON ml.msg_id = n.id
+    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
+    GROUP BY 1, 2;
+
+    -- add new flow activity counts for incoming messages now marked as handled by a flow
+    INSERT INTO flows_flowactivitycount("flow_id", "scope", "count", "is_squashed")
+    SELECT s.flow_id, unnest(ARRAY[
+            format('msgsin:hour:%s', extract(hour FROM NOW())),
+            format('msgsin:dow:%s', extract(isodow FROM NOW())),
+            format('msgsin:date:%s', NOW()::date)
+        ]), s.msgs, FALSE
+    FROM (
+        SELECT n.flow_id, count(*) AS msgs FROM newtab n INNER JOIN oldtab o ON o.id = n.id
+        WHERE n.direction = 'I' AND o.flow_id IS NULL AND n.flow_id IS NOT NULL
+        GROUP BY 1
+    ) s;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+# the previous definitions, keyed on visibility, so that this can be unapplied
+REVERSE_SQL = """
+----------------------------------------------------------------------
+-- Handles DELETE statements on msgs_msg_labels table
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_labels_on_delete() RETURNS TRIGGER AS $$
+BEGIN
+    -- add negative label count for all deleted rows
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT o.label_id, m.visibility != 'V', -count(*), FALSE FROM oldtab o
+    INNER JOIN msgs_msg m ON m.id = o.msg_id
+    GROUP BY o.label_id, m.visibility != 'V';
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Handles INSERT statements on msgs_msg_labels table
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_labels_on_insert() RETURNS TRIGGER AS $$
+BEGIN
+    -- add label count for all new rows
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT n.label_id, m.visibility != 'V', count(*), FALSE FROM newtab n
+    INNER JOIN msgs_msg m ON m.id = n.msg_id
+    GROUP BY n.label_id, m.visibility != 'V';
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Trigger procedure to update user and system labels on column changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_on_change() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    -- prevent illegal message states
+    IF NEW.direction = 'I' AND NEW.status NOT IN ('P', 'H') THEN
+      RAISE EXCEPTION 'Incoming messages can only be PENDING or HANDLED';
+    END IF;
+    IF NEW.direction = 'O' AND NEW.visibility = 'A' THEN
+      RAISE EXCEPTION 'Outgoing messages cannot be archived';
+    END IF;
+  END IF;
+
+  -- existing message updated
+  IF TG_OP = 'UPDATE' THEN
+    -- restrict changes
+    IF NEW.direction <> OLD.direction THEN RAISE EXCEPTION 'Cannot change direction on messages'; END IF;
+    IF NEW.created_on <> OLD.created_on THEN RAISE EXCEPTION 'Cannot change created_on on messages'; END IF;
+    IF NEW.msg_type <> OLD.msg_type THEN RAISE EXCEPTION 'Cannot change msg_type on messages'; END IF;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Handles UPDATE statements on msg table
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_on_update() RETURNS TRIGGER AS $$
+BEGIN
+    -- add negative item counts for all rows that belonged to a folder they no longer belong to
+    INSERT INTO orgs_itemcount("org_id", "scope", "count", "is_squashed")
+    SELECT o.org_id, temba_msg_countscope(o), -count(*), FALSE FROM oldtab o
+    INNER JOIN newtab n ON n.id = o.id
+    WHERE temba_msg_countscope(o) IS DISTINCT FROM temba_msg_countscope(n) AND temba_msg_countscope(o) IS NOT NULL
+    GROUP BY 1, 2;
+
+    -- add positive item counts for all rows that now belong to a folder they didn't belong to
+    INSERT INTO orgs_itemcount("org_id", "scope", "count", "is_squashed")
+    SELECT n.org_id, temba_msg_countscope(n), count(*), FALSE FROM newtab n
+    INNER JOIN oldtab o ON o.id = n.id
+    WHERE temba_msg_countscope(o) IS DISTINCT FROM temba_msg_countscope(n) AND temba_msg_countscope(n) IS NOT NULL
+    GROUP BY 1, 2;
+
+    -- add negative old-state label counts for all messages being archived/restored
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT ml.label_id, o.visibility != 'V', -count(*), FALSE FROM oldtab o
+    INNER JOIN newtab n ON n.id = o.id
+    INNER JOIN msgs_msg_labels ml ON ml.msg_id = o.id
+    WHERE (o.visibility = 'V' AND n.visibility != 'V') or (o.visibility != 'V' AND n.visibility = 'V')
+    GROUP BY 1, 2;
+
+    -- add new-state label counts for all messages being archived/restored
+    INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
+    SELECT ml.label_id, n.visibility != 'V', count(*), FALSE FROM newtab n
+    INNER JOIN oldtab o ON o.id = n.id
+    INNER JOIN msgs_msg_labels ml ON ml.msg_id = n.id
+    WHERE (o.visibility = 'V' AND n.visibility != 'V') or (o.visibility != 'V' AND n.visibility = 'V')
+    GROUP BY 1, 2;
+
+    -- add new flow activity counts for incoming messages now marked as handled by a flow
+    INSERT INTO flows_flowactivitycount("flow_id", "scope", "count", "is_squashed")
+    SELECT s.flow_id, unnest(ARRAY[
+            format('msgsin:hour:%s', extract(hour FROM NOW())),
+            format('msgsin:dow:%s', extract(isodow FROM NOW())),
+            format('msgsin:date:%s', NOW()::date)
+        ]), s.msgs, FALSE
+    FROM (
+        SELECT n.flow_id, count(*) AS msgs FROM newtab n INNER JOIN oldtab o ON o.id = n.id
+        WHERE n.direction = 'I' AND o.flow_id IS NULL AND n.flow_id IS NOT NULL
+        GROUP BY 1
+    ) s;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msgs", "0314_update_triggers"),
+    ]
+
+    operations = [
+        migrations.RunSQL(SQL, REVERSE_SQL),
+    ]

--- a/temba/msgs/migrations/0315_update_triggers.py
+++ b/temba/msgs/migrations/0315_update_triggers.py
@@ -1,9 +1,17 @@
 from django.db import migrations
 
-# the label counts (which are split by whether the message is archived or deleted) and the guard against archiving
-# outgoing messages are keyed on the folder rather than visibility, like the folder counts already are. That's the last
-# thing in the database that read visibility to tell whether a message is archived, so archived can stop being a
-# visibility - and when the visibility of messages archived before then is updated, no counts move.
+# the label counts (which are split by whether the message is archived or deleted) are keyed on the folder rather than
+# visibility, like the folder counts already are. That's the last thing in the database that read visibility to tell
+# whether a message is archived, so archived can stop being a visibility - and when the visibility of messages archived
+# before then is updated, no counts move.
+#
+# The guard against archiving outgoing messages checks both columns, because until mailroom stops writing visibility an
+# outgoing message can be archived by either - and a folder-only check would never fire, since the folder outgoing
+# messages derive is never Archived. The visibility half comes out when the value does.
+#
+# The archived/restored WHERE clauses keep the old shape of two ANDed comparisons ORed together rather than comparing
+# the two IN expressions with <>. The planner has no selectivity estimate for the latter and falls back to a default
+# that badly over-estimates the join, which matters because these run per statement on the message write path.
 SQL = """
 ----------------------------------------------------------------------
 -- Handles DELETE statements on msgs_msg_labels table
@@ -45,7 +53,7 @@ BEGIN
     IF NEW.direction = 'I' AND NEW.status NOT IN ('P', 'H') THEN
       RAISE EXCEPTION 'Incoming messages can only be PENDING or HANDLED';
     END IF;
-    IF NEW.direction = 'O' AND NEW.folder = 'A' THEN
+    IF NEW.direction = 'O' AND (NEW.visibility = 'A' OR NEW.folder = 'A') THEN
       RAISE EXCEPTION 'Outgoing messages cannot be archived';
     END IF;
   END IF;
@@ -86,7 +94,8 @@ BEGIN
     SELECT ml.label_id, o.folder IN ('A', 'D'), -count(*), FALSE FROM oldtab o
     INNER JOIN newtab n ON n.id = o.id
     INNER JOIN msgs_msg_labels ml ON ml.msg_id = o.id
-    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
+    WHERE (o.folder NOT IN ('A', 'D') AND n.folder IN ('A', 'D'))
+       OR (o.folder IN ('A', 'D') AND n.folder NOT IN ('A', 'D'))
     GROUP BY 1, 2;
 
     -- add new-state label counts for all messages being archived/restored
@@ -94,7 +103,8 @@ BEGIN
     SELECT ml.label_id, n.folder IN ('A', 'D'), count(*), FALSE FROM newtab n
     INNER JOIN oldtab o ON o.id = n.id
     INNER JOIN msgs_msg_labels ml ON ml.msg_id = n.id
-    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
+    WHERE (o.folder NOT IN ('A', 'D') AND n.folder IN ('A', 'D'))
+       OR (o.folder IN ('A', 'D') AND n.folder NOT IN ('A', 'D'))
     GROUP BY 1, 2;
 
     -- add new flow activity counts for incoming messages now marked as handled by a flow

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -643,8 +643,9 @@ class Msg(models.Model):
     direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES)
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=STATUS_PENDING)
     visibility = models.CharField(max_length=1, choices=VISIBILITY_CHOICES, default=VISIBILITY_VISIBLE)
-    # denormalized folder, derived from direction/visibility/status/flow (see derive_folder) and maintained by mailroom
-    # and courier - every message is in one, including those not in a user facing folder
+    # the folder this message is in, derived from direction/visibility/status/flow and maintained by mailroom and
+    # courier - every message is in one, including those not in a user facing folder. This is what's read to tell
+    # which folder a message is in, including whether it's archived, rather than the state it's derived from.
     folder = models.CharField(max_length=1, choices=FOLDER_CHOICES)
 
     is_android = models.BooleanField()
@@ -743,25 +744,6 @@ class Msg(models.Model):
         """
 
         mailroom.get_client().msg_handle(self.org, [self])
-
-    def derive_folder(self) -> str:
-        """
-        Derives the folder code for this message. Folder is written by mailroom and courier - this exists to pin down
-        the contract they implement (and to set it on messages created in tests), in particular the precedence, which
-        matters for states that fall outside the user facing folders entirely: a message can be archived or deleted
-        while still pending, and such messages must not appear in the Archived folder.
-        """
-
-        if self.visibility in (self.VISIBILITY_DELETED_BY_USER, self.VISIBILITY_DELETED_BY_SENDER):
-            return self.FOLDER_DELETED
-        if self.direction == self.DIRECTION_IN and self.status == self.STATUS_PENDING:
-            return self.FOLDER_PENDING
-
-        folder = MsgFolder.from_msg(self)
-
-        assert folder is not None, f"unable to derive folder for msg #{self.id}"
-
-        return folder.code
 
     @classmethod
     def apply_action_label(cls, user, msgs, label):
@@ -928,93 +910,40 @@ class MsgFolder(Enum):
     A folder of messages owned by an org.
     """
 
+    # each folder's code (the Msg.folder value) and the S3 Select query which selects its messages from archived
+    # message records - which have no folder field, so describe messages by state
     INBOX = (
         Msg.FOLDER_INBOX,
-        dict(
-            direction=Msg.DIRECTION_IN,
-            visibility=Msg.VISIBILITY_VISIBLE,
-            status=Msg.STATUS_HANDLED,
-            flow__isnull=True,
-        ),
         dict(direction="in", visibility="visible", status="handled", flow__isnull=True),
     )
     HANDLED = (
         Msg.FOLDER_HANDLED,
-        dict(
-            direction=Msg.DIRECTION_IN,
-            visibility=Msg.VISIBILITY_VISIBLE,
-            status=Msg.STATUS_HANDLED,
-            flow__isnull=False,
-        ),
         dict(direction="in", visibility="visible", status="handled", flow__isnull=False),
     )
     ARCHIVED = (
         Msg.FOLDER_ARCHIVED,
-        dict(
-            direction=Msg.DIRECTION_IN,
-            visibility=Msg.VISIBILITY_ARCHIVED,
-            status=Msg.STATUS_HANDLED,
-        ),
         dict(direction="in", visibility="archived", status="handled"),
     )
     OUTBOX = (
         Msg.FOLDER_OUTBOX,
-        dict(
-            direction=Msg.DIRECTION_OUT,
-            visibility=Msg.VISIBILITY_VISIBLE,
-            status__in=(Msg.STATUS_INITIALIZING, Msg.STATUS_QUEUED, Msg.STATUS_ERRORED),
-        ),
         dict(direction="out", visibility="visible", status__in=("initializing", "queued", "errored")),
     )
     SENT = (
         Msg.FOLDER_SENT,
-        dict(
-            direction=Msg.DIRECTION_OUT,
-            visibility=Msg.VISIBILITY_VISIBLE,
-            status__in=(Msg.STATUS_WIRED, Msg.STATUS_SENT, Msg.STATUS_DELIVERED, Msg.STATUS_READ),
-        ),
         dict(direction="out", visibility="visible", status__in=("wired", "sent", "delivered", "read")),
     )
     FAILED = (
         Msg.FOLDER_FAILED,
-        dict(direction=Msg.DIRECTION_OUT, visibility=Msg.VISIBILITY_VISIBLE, status=Msg.STATUS_FAILED),
         dict(direction="out", visibility="visible", status="failed"),
     )
 
-    def __init__(self, code, query: dict, archive_query: dict = None):
+    def __init__(self, code, records_query: dict):
         self.code = code
-        self.query = query
-        self.archive_query = archive_query
+        self.records_query = records_query
 
     @classmethod
     def from_code(cls, code):
         return next(f for f in cls if f.code == code)
-
-    @classmethod
-    def from_msg(cls, msg):
-        """
-        Derives the folder that the given message belongs to, or None if it isn't in one (e.g. an unhandled incoming
-        message, or one deleted by its sender).
-        """
-
-        def matches(lookup: str, expected) -> bool:
-            field, _, op = lookup.partition("__")
-            actual = getattr(msg, Msg._meta.get_field(field).attname)
-
-            if op == "in":
-                return actual in expected
-            elif op == "isnull":
-                return (actual is None) == expected
-
-            assert op == "", f"unsupported lookup: {lookup}"
-
-            return actual == expected
-
-        for folder in cls:
-            if all(matches(lookup, expected) for lookup, expected in folder.query.items()):
-                return folder
-
-        return None
 
     def get_queryset(self, org, *, after=None, before=None):
         """
@@ -1037,7 +966,7 @@ class MsgFolder(Enum):
         return qs.order_by("-uuid")
 
     def get_archive_query(self) -> dict:
-        return self.archive_query.copy()
+        return self.records_query.copy()
 
     @property
     def _count_scope(self) -> str:
@@ -1306,7 +1235,7 @@ class MessageExport(ExportType):
         elif label:
             messages = label.get_messages()
         else:
-            messages = export.org.msgs.filter(visibility=Msg.VISIBILITY_VISIBLE)
+            messages = export.org.msgs.exclude(folder__in=(Msg.FOLDER_ARCHIVED, Msg.FOLDER_DELETED))
 
         messages = messages.filter(created_on__gte=start_date, created_on__lte=end_date)
 

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -31,9 +31,15 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         assert_folder(self.create_incoming_msg(self.joe, "Hi"), Msg.FOLDER_INBOX)
         assert_folder(self.create_incoming_msg(self.joe, "Hi", flow=flow), Msg.FOLDER_HANDLED)
         assert_folder(self.create_incoming_msg(self.joe, "Hi", visibility=Msg.VISIBILITY_ARCHIVED), Msg.FOLDER_ARCHIVED)
-        assert_folder(self.create_outgoing_msg(self.joe, "Hi", status=Msg.STATUS_QUEUED), Msg.FOLDER_OUTBOX)
-        assert_folder(self.create_outgoing_msg(self.joe, "Hi", status=Msg.STATUS_SENT), Msg.FOLDER_SENT)
         assert_folder(self.create_outgoing_msg(self.joe, "Hi", status=Msg.STATUS_FAILED), Msg.FOLDER_FAILED)
+
+        # the outbox and sent folders each fold in several statuses
+        for status in (Msg.STATUS_INITIALIZING, Msg.STATUS_QUEUED, Msg.STATUS_ERRORED):
+            assert_folder(self.create_outgoing_msg(self.joe, "Hi", status=status), Msg.FOLDER_OUTBOX)
+
+        for status in (Msg.STATUS_WIRED, Msg.STATUS_SENT, Msg.STATUS_DELIVERED, Msg.STATUS_READ):
+            msg = self.create_outgoing_msg(self.joe, "Hi", status=status, sent_on=timezone.now())
+            assert_folder(msg, Msg.FOLDER_SENT)
 
         # incoming messages which haven't been handled yet are pending, whatever their visibility
         assert_folder(self.create_incoming_msg(self.joe, "Hi", status=Msg.STATUS_PENDING), Msg.FOLDER_PENDING)

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from temba.flows.models import Flow
 from temba.msgs.models import Msg, MsgFolder
 from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
+from temba.tests.mailroom import derive_msg_folder
 from temba.utils.uuid import uuid7
 
 
@@ -19,14 +20,13 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         self.just_joe = self.create_group("Just Joe", [self.joe])
         self.joe_and_frank = self.create_group("Joe and Frank", [self.joe, self.frank])
 
-    def test_derive_folder(self):
+    def test_folder(self):
         flow = self.create_flow("Test")
 
         def assert_folder(msg, expected):
-            self.assertEqual(expected, msg.derive_folder(), f"folder mismatch for msg #{msg.id}")
-
             # test fixtures write the folder at creation like mailroom and courier do
             self.assertEqual(expected, msg.folder, f"folder mismatch for msg #{msg.id}")
+            self.assertEqual(expected, derive_msg_folder(msg), f"folder mismatch for msg #{msg.id}")
 
         assert_folder(self.create_incoming_msg(self.joe, "Hi"), Msg.FOLDER_INBOX)
         assert_folder(self.create_incoming_msg(self.joe, "Hi", flow=flow), Msg.FOLDER_HANDLED)
@@ -49,6 +49,10 @@ class MsgTest(TembaTest, CRUDLTestMixin):
                 self.create_incoming_msg(self.joe, "Hi", status=Msg.STATUS_PENDING, visibility=visibility),
                 Msg.FOLDER_DELETED,
             )
+
+        # an outgoing message that is pending belongs to no folder - unlikely, but the database permits it
+        with self.assertRaises(AssertionError):
+            derive_msg_folder(Msg(direction=Msg.DIRECTION_OUT, status=Msg.STATUS_PENDING))
 
     def test_as_archive_json(self):
         flow = self.create_flow("Color Flow")

--- a/temba/msgs/tests/test_msg_folder.py
+++ b/temba/msgs/tests/test_msg_folder.py
@@ -11,30 +11,6 @@ from temba.utils import s3
 
 
 class MsgFolderTest(TembaTest):
-    def test_from_msg(self):
-        contact = self.create_contact("Bob", phone="0783835001")
-        flow = self.create_flow("Test")
-
-        def assert_folder(msg, expected):
-            self.assertEqual(expected, MsgFolder.from_msg(msg), f"folder mismatch for {msg.id}")
-
-        assert_folder(self.create_incoming_msg(contact, "Hi"), MsgFolder.INBOX)
-        assert_folder(self.create_incoming_msg(contact, "Hi", flow=flow), MsgFolder.HANDLED)
-        assert_folder(self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_ARCHIVED), MsgFolder.ARCHIVED)
-
-        for status in (Msg.STATUS_INITIALIZING, Msg.STATUS_QUEUED, Msg.STATUS_ERRORED):
-            assert_folder(self.create_outgoing_msg(contact, "Hi", status=status), MsgFolder.OUTBOX)
-
-        for status in (Msg.STATUS_WIRED, Msg.STATUS_SENT, Msg.STATUS_DELIVERED, Msg.STATUS_READ):
-            msg = self.create_outgoing_msg(contact, "Hi", status=status, sent_on=timezone.now())
-            assert_folder(msg, MsgFolder.SENT)
-
-        assert_folder(self.create_outgoing_msg(contact, "Hi", status=Msg.STATUS_FAILED), MsgFolder.FAILED)
-
-        # messages which aren't in a user facing folder
-        assert_folder(self.create_incoming_msg(contact, "Hi", status=Msg.STATUS_PENDING), None)
-        assert_folder(self.create_incoming_msg(contact, "Hi", visibility=Msg.VISIBILITY_DELETED_BY_USER), None)
-
     def test_get_queryset(self):
         contact = self.create_contact("Bob", phone="0783835001")
         other_contact = self.create_contact("Jim", phone="0783835002", org=self.org2)

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -786,7 +786,8 @@ class MsgCRUDL(SmartCRUDL):
             return (
                 super()
                 .get_queryset(**kwargs)
-                .filter(labels=self.label, visibility=Msg.VISIBILITY_VISIBLE)
+                .filter(labels=self.label)
+                .exclude(folder__in=(Msg.FOLDER_ARCHIVED, Msg.FOLDER_DELETED))
                 .prefetch_related("labels")
             )
 

--- a/temba/sql/current_functions.sql
+++ b/temba/sql/current_functions.sql
@@ -359,7 +359,7 @@ BEGIN
     IF NEW.direction = 'I' AND NEW.status NOT IN ('P', 'H') THEN
       RAISE EXCEPTION 'Incoming messages can only be PENDING or HANDLED';
     END IF;
-    IF NEW.direction = 'O' AND NEW.folder = 'A' THEN
+    IF NEW.direction = 'O' AND (NEW.visibility = 'A' OR NEW.folder = 'A') THEN
       RAISE EXCEPTION 'Outgoing messages cannot be archived';
     END IF;
   END IF;
@@ -439,7 +439,8 @@ BEGIN
     SELECT ml.label_id, o.folder IN ('A', 'D'), -count(*), FALSE FROM oldtab o
     INNER JOIN newtab n ON n.id = o.id
     INNER JOIN msgs_msg_labels ml ON ml.msg_id = o.id
-    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
+    WHERE (o.folder NOT IN ('A', 'D') AND n.folder IN ('A', 'D'))
+       OR (o.folder IN ('A', 'D') AND n.folder NOT IN ('A', 'D'))
     GROUP BY 1, 2;
 
     -- add new-state label counts for all messages being archived/restored
@@ -447,7 +448,8 @@ BEGIN
     SELECT ml.label_id, n.folder IN ('A', 'D'), count(*), FALSE FROM newtab n
     INNER JOIN oldtab o ON o.id = n.id
     INNER JOIN msgs_msg_labels ml ON ml.msg_id = n.id
-    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
+    WHERE (o.folder NOT IN ('A', 'D') AND n.folder IN ('A', 'D'))
+       OR (o.folder IN ('A', 'D') AND n.folder NOT IN ('A', 'D'))
     GROUP BY 1, 2;
 
     -- add new flow activity counts for incoming messages now marked as handled by a flow

--- a/temba/sql/current_functions.sql
+++ b/temba/sql/current_functions.sql
@@ -326,9 +326,9 @@ CREATE OR REPLACE FUNCTION temba_msg_labels_on_delete() RETURNS TRIGGER AS $$
 BEGIN
     -- add negative label count for all deleted rows
     INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
-    SELECT o.label_id, m.visibility != 'V', -count(*), FALSE FROM oldtab o
+    SELECT o.label_id, m.folder IN ('A', 'D'), -count(*), FALSE FROM oldtab o
     INNER JOIN msgs_msg m ON m.id = o.msg_id
-    GROUP BY o.label_id, m.visibility != 'V';
+    GROUP BY o.label_id, m.folder IN ('A', 'D');
 
     RETURN NULL;
 END;
@@ -341,9 +341,9 @@ CREATE OR REPLACE FUNCTION temba_msg_labels_on_insert() RETURNS TRIGGER AS $$
 BEGIN
     -- add label count for all new rows
     INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
-    SELECT n.label_id, m.visibility != 'V', count(*), FALSE FROM newtab n
+    SELECT n.label_id, m.folder IN ('A', 'D'), count(*), FALSE FROM newtab n
     INNER JOIN msgs_msg m ON m.id = n.msg_id
-    GROUP BY n.label_id, m.visibility != 'V';
+    GROUP BY n.label_id, m.folder IN ('A', 'D');
 
     RETURN NULL;
 END;
@@ -359,7 +359,7 @@ BEGIN
     IF NEW.direction = 'I' AND NEW.status NOT IN ('P', 'H') THEN
       RAISE EXCEPTION 'Incoming messages can only be PENDING or HANDLED';
     END IF;
-    IF NEW.direction = 'O' AND NEW.visibility = 'A' THEN
+    IF NEW.direction = 'O' AND NEW.folder = 'A' THEN
       RAISE EXCEPTION 'Outgoing messages cannot be archived';
     END IF;
   END IF;
@@ -436,18 +436,18 @@ BEGIN
 
     -- add negative old-state label counts for all messages being archived/restored
     INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
-    SELECT ml.label_id, o.visibility != 'V', -count(*), FALSE FROM oldtab o
+    SELECT ml.label_id, o.folder IN ('A', 'D'), -count(*), FALSE FROM oldtab o
     INNER JOIN newtab n ON n.id = o.id
     INNER JOIN msgs_msg_labels ml ON ml.msg_id = o.id
-    WHERE (o.visibility = 'V' AND n.visibility != 'V') or (o.visibility != 'V' AND n.visibility = 'V')
+    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
     GROUP BY 1, 2;
 
     -- add new-state label counts for all messages being archived/restored
     INSERT INTO msgs_labelcount("label_id", "is_archived", "count", "is_squashed")
-    SELECT ml.label_id, n.visibility != 'V', count(*), FALSE FROM newtab n
+    SELECT ml.label_id, n.folder IN ('A', 'D'), count(*), FALSE FROM newtab n
     INNER JOIN oldtab o ON o.id = n.id
     INNER JOIN msgs_msg_labels ml ON ml.msg_id = n.id
-    WHERE (o.visibility = 'V' AND n.visibility != 'V') or (o.visibility != 'V' AND n.visibility = 'V')
+    WHERE (o.folder IN ('A', 'D')) <> (n.folder IN ('A', 'D'))
     GROUP BY 1, 2;
 
     -- add new flow activity counts for incoming messages now marked as handled by a flow

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -44,6 +44,7 @@ from .mailroom import (
     create_broadcast,
     create_contact_locally,
     create_flowstart,
+    derive_msg_folder,
     resolve_destination,
     set_mocks,
     update_field_locally,
@@ -429,7 +430,7 @@ class TembaTest(SmartminTest):
         )
 
         # mailroom and courier write the folder when they write the message
-        msg.folder = msg.derive_folder()
+        msg.folder = derive_msg_folder(msg)
         msg.save()
 
         return msg

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -829,6 +829,33 @@ def create_contact_locally(
     return contact
 
 
+def derive_msg_folder(msg) -> str:
+    """
+    Derives the folder for a message from its state, as mailroom and courier do when they write it. In particular this
+    pins down the precedence, which matters for states that fall outside the user facing folders entirely: a message
+    can be archived or deleted while still pending, and such messages must not appear in the Archived folder.
+    """
+
+    if msg.visibility in (Msg.VISIBILITY_DELETED_BY_USER, Msg.VISIBILITY_DELETED_BY_SENDER):
+        return Msg.FOLDER_DELETED
+
+    if msg.direction == Msg.DIRECTION_IN:
+        if msg.status != Msg.STATUS_HANDLED:
+            return Msg.FOLDER_PENDING
+        if msg.visibility == Msg.VISIBILITY_ARCHIVED:
+            return Msg.FOLDER_ARCHIVED
+        return Msg.FOLDER_HANDLED if msg.flow_id else Msg.FOLDER_INBOX
+    elif msg.visibility == Msg.VISIBILITY_VISIBLE:
+        if msg.status in (Msg.STATUS_INITIALIZING, Msg.STATUS_QUEUED, Msg.STATUS_ERRORED):
+            return Msg.FOLDER_OUTBOX
+        elif msg.status in (Msg.STATUS_WIRED, Msg.STATUS_SENT, Msg.STATUS_DELIVERED, Msg.STATUS_READ):
+            return Msg.FOLDER_SENT
+        elif msg.status == Msg.STATUS_FAILED:
+            return Msg.FOLDER_FAILED
+
+    raise AssertionError(f"unable to derive folder for msg #{msg.id}")
+
+
 def delete_msgs(msgs):
     """
     Simulates mailroom soft deleting the given incoming messages - clearing their content and labels as well as
@@ -844,7 +871,7 @@ def delete_msgs(msgs):
             continue
 
         msg.visibility = Msg.VISIBILITY_DELETED_BY_USER
-        msg.folder = msg.derive_folder()
+        msg.folder = derive_msg_folder(msg)
         msg.text = ""
         msg.attachments = []
         msg.save(update_fields=("visibility", "folder", "text", "attachments"))
@@ -862,7 +889,7 @@ def update_msgs_visibility(msgs, from_visibility: str, to_visibility: str):
             continue
 
         msg.visibility = to_visibility
-        msg.folder = msg.derive_folder()
+        msg.folder = derive_msg_folder(msg)
         msg.modified_on = timezone.now()
         msg.save(update_fields=("visibility", "folder", "modified_on"))
 


### PR DESCRIPTION
## Summary

Every message is in exactly one folder, so whether it's archived is already recorded by `Msg.folder` and reading `visibility = 'A'` for it is redundant. This switches every read that distinguished archived or deleted messages by visibility to the folder instead. It's the read side only: mailroom still writes `visibility = 'A'` alongside `folder = 'A'`, and nothing here changes what gets written.

## Changes

**Reads switched to folder**
- The API's "not deleted" message filters exclude `folder = D` instead of matching on visibility.
- The message serializer's `archived` and `visibility` fields come from `folder`. The API contract is unchanged.
- Label list views, the label API and the all-messages export exclude the Archived and Deleted folders rather than matching `visibility = V`.

**Triggers** (migration `0315`, mirrored in `current_functions.sql`)
- Label counts split `is_archived` on `folder IN ('A', 'D')` instead of `visibility != 'V'`.
- The guard against archiving outgoing messages checks `folder = 'A'`.

With these, nothing in the database reads visibility to tell whether a message is archived, and a later update of visibility on already-archived messages moves no counts.

**`MsgFolder`**
- No longer carries the database state queries it used to derive a folder from, and `from_msg` is gone. Each folder keeps its code and `records_query`, the S3 Select query for its messages in archived records, which have no folder field and so still describe messages by state.

**`Msg.derive_folder`**
- Removed from the model. Nothing in the app called it, since mailroom and courier write the folder. Tests still need to derive a folder for the messages they create, so it lives with the other mailroom stand-ins in the test helpers as `derive_msg_folder`, unchanged in behaviour.

## Test plan

- [x] Full suite passes locally with the new migration applied (1157 tests)
- [x] Label counts verified moving between archived and not on archive and restore via the trigger tests
- [x] `code_check.py` and `makemigrations --check` clean

## Follow-ups

- mailroom: stop writing `visibility = 'A'` and move folders directly on archive, restore and handling of messages from blocked contacts
- Update visibility on messages archived before that, then remove the visibility value