### PR TITLE
Cache per-request result of LimitAwareMixin.is_limit_reached

### DIFF
--- a/temba/ai/views.py
+++ b/temba/ai/views.py
@@ -228,7 +228,7 @@ class LLMCRUDL(SmartCRUDL):
             return super().derive_queryset(**kwargs).filter(is_system=False)
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("ai.llm_connect") and not self.is_limit_reached():
+            if self.has_org_perm("ai.llm_connect") and not self.is_limit_reached:
                 if any(t.is_available_to(self.request.org, self.request.user) for t in LLM.get_types()):
                     menu.add_modax(_("New Model"), "new-model", reverse("ai.llm_connect"), title=_("New Model"))
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1013,7 +1013,7 @@ class ContactFieldCRUDL(SmartCRUDL):
         template_name = "contacts/contactfield_list.html"
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("contacts.contactfield_create") and not self.is_limit_reached():
+            if self.has_org_perm("contacts.contactfield_create") and not self.is_limit_reached:
                 menu.add_modax(
                     _("New"),
                     "new-field",

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -4,7 +4,8 @@ from unittest.mock import call, patch
 
 from django_valkey import get_valkey_connection
 
-from django.test.utils import override_settings
+from django.db import connection
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
 
 from temba import mailroom
@@ -95,6 +96,13 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         flow1.release(self.admin)
 
         self.assertContentMenu(list_url, self.admin, ["New Flow", "New Label", "Import", "Export"])
+
+        # the limit check is only evaluated once per request even though both the menu and the context need it
+        with CaptureQueriesContext(connection) as captured:
+            self.client.get(list_url)
+
+        limit_queries = [q for q in captured.captured_queries if q["sql"].startswith('SELECT COUNT(*) AS "__count"')]
+        self.assertEqual(1, len(limit_queries))
 
     def test_create(self):
         create_url = reverse("flows.flow_create")

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -635,7 +635,7 @@ class FlowCRUDL(SmartCRUDL):
             return self.request.org.flow_labels.filter(is_active=True).order_by(Lower("name"))
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("flows.flow_create") and not self.is_limit_reached():
+            if self.has_org_perm("flows.flow_create") and not self.is_limit_reached:
                 menu.add_modax(
                     _("New Flow"),
                     "new-flow",

--- a/temba/globals/views.py
+++ b/temba/globals/views.py
@@ -95,7 +95,7 @@ class GlobalCRUDL(SmartCRUDL):
         menu_path = "/flow/globals"
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("globals.global_create") and not self.is_limit_reached():
+            if self.has_org_perm("globals.global_create") and not self.is_limit_reached:
                 menu.add_modax(
                     _("New"),
                     "new-global",

--- a/temba/orgs/views/base.py
+++ b/temba/orgs/views/base.py
@@ -16,7 +16,7 @@ from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.functional import Promise
+from django.utils.functional import Promise, cached_property
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
@@ -31,9 +31,10 @@ from .mixins import BulkActionMixin, DependencyMixin, OrgObjPermsMixin, OrgPerms
 class LimitAwareMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["limit_reached"] = self.is_limit_reached()
+        context["limit_reached"] = self.is_limit_reached
         return context
 
+    @cached_property
     def is_limit_reached(self) -> bool:
         """
         Returns whether we've reached the org limit for this model

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -196,7 +196,7 @@ class TeamCRUDL(SmartCRUDL):
             return super().derive_queryset(**kwargs).order_by(Lower("name"))
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("tickets.team_create") and not self.is_limit_reached():
+            if self.has_org_perm("tickets.team_create") and not self.is_limit_reached:
                 menu.add_modax(
                     _("New"), "new-team", reverse("tickets.team_create"), title=_("New Team"), as_button=True
                 )

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -438,7 +438,7 @@ class TriggerCRUDL(SmartCRUDL):
         }
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("triggers.trigger_create") and not self.is_limit_reached():
+            if self.has_org_perm("triggers.trigger_create") and not self.is_limit_reached:
                 menu.add_link(_("New Trigger"), reverse("triggers.trigger_create"), as_button=True)
 
         def derive_queryset(self, *args, **kwargs):


### PR DESCRIPTION
## Summary

List views that use `LimitAwareMixin` were issuing the per-workspace limit `COUNT(*)` query twice on every request. Making `is_limit_reached` a `cached_property` computes it once per request instead.

## Changes

- `temba/orgs/views/base.py` — `LimitAwareMixin.is_limit_reached` becomes a `@cached_property`. The mixin's `get_context_data` and any `build_context_menu` that consults it now share a single result for the life of the view instance (i.e. one request).
- `temba/ai/views.py`, `temba/contacts/views.py`, `temba/flows/views.py`, `temba/globals/views.py`, `temba/tickets/views.py`, `temba/triggers/views.py` — call sites updated to the property form (`not self.is_limit_reached`).
- `temba/flows/tests/test_flowcrudl.py` — `test_org_limit` gains a regression guard asserting the flow list issues exactly one limit `COUNT(*)`, so a future refactor can't silently reintroduce the double count.

The model-level `OrgLimitMixin.is_limit_reached(org)` classmethod is unchanged; only the view-side helper is affected.

## Behavior

No user-visible change — purely a query-count reduction.

Requesting the flow list as an administrator:

| | `COUNT(*) FROM flows_flow` queries |
|---|---|
| Before | 2 |
| After | 1 |

The same duplication applied to every list view whose context menu hides its "New …" action at the limit — globals, triggers, teams, contact fields and AI models — and is likewise halved.

## Test plan

- New assertion in `test_org_limit` verifies the single limit query; confirmed it fails (`1 != 2`) when the caching is reverted to a plain `property`, so the guard actually bites.
- Full test suite passes.
- `code_check.py` clean — no formatting, migration or locale drift.