### PR TITLE
Record deprecated usage of label filter on messages endpoint

### DIFF
--- a/temba/api/v2/tests/test_messages.py
+++ b/temba/api/v2/tests/test_messages.py
@@ -127,12 +127,14 @@ class MessagesEndpointTest(APITest):
         # filter by invalid contact
         self.assertGet(endpoint_url + "?contact=invalid", [self.admin], results=[])
 
-        # filter by label UUID / name
+        # filter by label UUID / name (deprecated, so recorded)
         self.assertGet(endpoint_url + f"?label={label.uuid}", [self.admin], results=[frank_msg3, joe_msg3, frank_msg1])
         self.assertGet(endpoint_url + "?label=Spam", [self.admin], results=[frank_msg3, joe_msg3, frank_msg1])
+        self.assertDeprecatedRecorded("messages#filter:label", 2)
 
         # filter by invalid label
         self.assertGet(endpoint_url + "?label=invalid", [self.admin], results=[])
+        self.assertDeprecatedRecorded("messages#filter:label", 3)
 
         # filter by before (inclusive)
         self.assertGet(

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2356,8 +2356,9 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
             else:
                 queryset = queryset.none()
 
-        # filter by label name/uuid (optional)
+        # filter by label name/uuid (optional, deprecated)
         if label_ref := params.get("label"):
+            record_deprecated(org, "messages#filter:label")
             label_filter = Q(name=label_ref)
             if is_uuid(label_ref):
                 label_filter |= Q(uuid=label_ref)


### PR DESCRIPTION
## Summary

Filtering the messages API endpoint by `label` is being deprecated. This records each use of that filter as deprecated usage, the same way the `id` and `broadcast` filters on this endpoint already are, so operators can see which workspaces still rely on it before it is removed.

## Changes

- `temba/api/v2/views.py`: the `label` filter on the messages endpoint now calls `record_deprecated` with the feature key `messages#filter:label`. Filtering behavior is unchanged.
- `temba/api/v2/tests/test_messages.py`: assert the deprecated usage counter after label lookups by UUID, by name, and for an unknown label.

## Behavior examples

| Request | Before | After |
|---|---|---|
| `GET /api/v2/messages.json?label=Spam` | filtered results | same results, plus `messages#filter:label` usage recorded for the workspace |
| `GET /api/v2/messages.json?label=unknown` | empty results | same, usage still recorded |

## Test plan

- [x] `temba.api.v2.tests.test_messages` passes
- [x] `temba.api` app tests pass
- [x] `code_check.py` passes (migrations, locale, ruff)