### PR TITLE
Remove mention of deprecated contact filter from runs endpoint docs

### DIFF
--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2795,8 +2795,6 @@ class RunsEndpoint(ListAPIMixin, BaseEndpoint):
      * **exited_on** - the datetime when this run exited or null if it is still active (datetime).
      * **exit_type** - how the run ended, one of `interrupted`, `completed`, `expired`.
 
-    Note that you cannot filter by `flow` and `contact` at the same time.
-
     Example:
 
         GET /api/v2/runs.json?flow=f5901b62-ba76-4003-9c62-72fdacc1b7b7


### PR DESCRIPTION
## Summary

The runs API endpoint docs still noted that `flow` and `contact` can't be combined, even though filtering by `contact` is deprecated and no longer documented. This removes that note.

An audit of every filter and endpoint recorded as deprecated (broadcast `id`, channel events, definitions, message `id`/`broadcast`/`label`, run `id`/`contact`) found no other references in the endpoint docs or the API explorer.

## Changes

- `temba/api/v2/views.py`: drop the sentence about `flow` and `contact` from the runs endpoint docstring.

## Test plan

- [x] `temba.api.v2.tests.test_runs` passes
- [x] `code_check.py` passes