### PR TITLE
Only show channel logs menu items to users with permission to view them

### DIFF
--- a/temba/channels/tests/test_channelcrudl.py
+++ b/temba/channels/tests/test_channelcrudl.py
@@ -233,6 +233,13 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
             ["Configuration", "Edit", "Delete"],
         )
 
+        # and not for users without permission to view logs
+        self.assertContentMenu(
+            reverse("channels.channel_read", args=[self.ex_channel.uuid]),
+            self.editor,
+            ["Configuration", "Edit", "Delete"],
+        )
+
     def test_logs_list(self):
         channel = self.create_channel("T", "My Channel", "+250785551212")
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -479,10 +479,10 @@ class ChannelCRUDL(SmartCRUDL):
             if obj.type.config_ui:
                 menu.add_link(_("Configuration"), reverse("channels.channel_configuration", args=[obj.uuid]))
 
-            if obj.type.has_logs:
+            if obj.type.has_logs and self.has_org_perm("channels.channel_logs"):
                 menu.add_link(_("Logs"), reverse("channels.channel_logs_list", args=[obj.uuid]))
 
-            if obj.type.template_type:
+            if obj.type.template_type and self.has_org_perm("request_logs.httplog_list"):
                 menu.add_link(_("Template Logs"), reverse("request_logs.httplog_channel", args=[obj.uuid]))
 
             if self.has_org_perm("channels.channel_update"):


### PR DESCRIPTION
The channel read page showed the **Logs** and **Template Logs** menu items to every user, but only users with the corresponding permissions can open those views. Users without them were redirected to the login page, which redirected an already-authenticated user straight back, ending in a browser redirect loop error.

This hides those two menu items from users who lack the `channels.channel_logs` / `request_logs.httplog_list` permissions, and adds a test covering the editor role.

The underlying redirect loop for authenticated users without permission is addressed separately.