### PR TITLE
Update Django to 6.1.1 and remove prefetch routing workarounds

### DIFF
--- a/temba/api/v2/tests/test_runs.py
+++ b/temba/api/v2/tests/test_runs.py
@@ -1,40 +1,14 @@
 import iso8601
-from rest_framework.request import Request
-from rest_framework.test import APIRequestFactory
 
-from django.db.models import Prefetch
 from django.urls import reverse
 
 from temba.api.v2.serializers import format_datetime
-from temba.api.v2.views import RunsEndpoint
 from temba.tests.engine import MockSessionWriter
 
 from . import APITest
 
 
 class RunsEndpointTest(APITest):
-    def test_readonly_routing(self):
-        # GET requests should route both the main queryset and any custom Prefetch querysets to the readonly
-        # database - Django 6.1 stopped routing custom prefetches by the parent queryset's database, which broke
-        # bulk_urn_cache_initialize by mixing contacts from default with URNs from readonly
-        request = Request(APIRequestFactory().get("/api/v2/runs.json"))
-        request._request.org = self.org
-
-        view = RunsEndpoint()
-        view.request = request
-        view.kwargs = {}
-
-        queryset = view.filter_queryset(view.get_queryset())
-        view.paginate_queryset(queryset)
-
-        self.assertEqual("readonly", queryset.db)
-
-        prefetches = {p.prefetch_through: p for p in queryset._prefetch_related_lookups if isinstance(p, Prefetch)}
-        self.assertEqual({"flow", "contact", "contact__org", "start"}, set(prefetches))
-        for lookup, prefetch in prefetches.items():
-            if prefetch.queryset is not None:
-                self.assertEqual("readonly", prefetch.queryset.db, f"prefetch of {lookup} not routed to readonly")
-
     def test_endpoint(self):
         endpoint_url = reverse("api.v2.runs") + ".json"
 

--- a/temba/api/v2/tests/test_runs.py
+++ b/temba/api/v2/tests/test_runs.py
@@ -3,12 +3,24 @@ import iso8601
 from django.urls import reverse
 
 from temba.api.v2.serializers import format_datetime
+from temba.contacts.models import Contact
+from temba.flows.models import FlowRun
 from temba.tests.engine import MockSessionWriter
 
 from . import APITest
 
 
 class RunsEndpointTest(APITest):
+    def test_readonly_routing(self):
+        # custom Prefetch querysets should be routed to the same database as the instances they're prefetched for
+        # (regressed in Django 6.1) as otherwise bulk_urn_cache_initialize mixes contacts and URNs from different dbs
+        run = FlowRun()
+        run._state.db = "readonly"
+
+        queryset = FlowRun.contact.get_prefetch_querysets([run], [Contact.objects.only("uuid", "name")])[0]
+
+        self.assertEqual("readonly", queryset.db)
+
     def test_endpoint(self):
         endpoint_url = reverse("api.v2.runs") + ".json"
 

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -7,7 +7,6 @@ from rest_framework.response import Response
 from smartmin.views import SmartCRUDL
 
 from django.db import transaction
-from django.db.models import Prefetch
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -172,15 +171,6 @@ class ListAPIMixin(mixins.ListModelMixin):
         return queryset
 
     def paginate_queryset(self, queryset):
-        # Django 6.1 no longer routes custom Prefetch querysets on forward FK/O2O fields to the same database as
-        # the parent queryset (regression from django/django@821619aa87) so route them explicitly
-        queryset._prefetch_related_lookups = tuple(
-            Prefetch(lookup.prefetch_through, queryset=lookup.queryset.using(queryset.db), to_attr=lookup.to_attr)
-            if isinstance(lookup, Prefetch) and lookup.queryset is not None and lookup.queryset._db is None
-            else lookup
-            for lookup in queryset._prefetch_related_lookups
-        )
-
         page = super().paginate_queryset(queryset)
 
         # give views a chance to prepare objects for serialization

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1558,14 +1558,12 @@ class ResultsExport(ExportType):
         )
 
         for id_batch in itertools.batched(run_ids, 1000):
-            # Django 6.1 no longer routes custom Prefetch querysets by the parent queryset's database so the
-            # prefetches need their own explicit .using(..)
             run_batch = (
                 FlowRun.objects.filter(id__in=id_batch)
                 .order_by("modified_on", "id")
                 .prefetch_related(
-                    Prefetch("contact", Contact.objects.only("uuid", "name").using("readonly")),
-                    Prefetch("flow", Flow.objects.only("uuid", "name").using("readonly")),
+                    Prefetch("contact", Contact.objects.only("uuid", "name")),
+                    Prefetch("flow", Flow.objects.only("uuid", "name")),
                 )
                 .using("readonly")
             )

--- a/temba/flows/tests/test_export.py
+++ b/temba/flows/tests/test_export.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from temba.archives.models import Archive
 from temba.contacts.models import Contact, ContactURN
-from temba.flows.models import Flow, FlowRun, ResultsExport
+from temba.flows.models import FlowRun, ResultsExport
 from temba.orgs.models import Export
 from temba.tests import TembaTest
 from temba.tests.engine import MockSessionWriter
@@ -42,7 +42,6 @@ class ResultsExportTest(TembaTest):
 
         readonly_models = {FlowRun}
         if has_results:
-            readonly_models.add(Flow)
             readonly_models.add(Contact)
             readonly_models.add(ContactURN)
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1316,16 +1316,14 @@ class MessageExport(ExportType):
 
         all_message_ids = array(str("l"), messages.values_list("id", flat=True))
 
-        # Django 6.1 no longer routes custom Prefetch querysets by the parent queryset's database so the
-        # prefetches need their own explicit .using(..)
         for msg_batch in MsgIterator(
             all_message_ids,
             order_by=("created_on",),
             select_related=("channel", "contact_urn"),
             prefetch_related=(
-                Prefetch("contact", queryset=Contact.objects.only("uuid", "name").using("readonly")),
-                Prefetch("flow", queryset=Flow.objects.only("uuid", "name").using("readonly")),
-                Prefetch("labels", queryset=Label.objects.only("uuid", "name").order_by("name").using("readonly")),
+                Prefetch("contact", queryset=Contact.objects.only("uuid", "name")),
+                Prefetch("flow", queryset=Flow.objects.only("uuid", "name")),
+                Prefetch("labels", queryset=Label.objects.only("uuid", "name").order_by("name")),
             ),
             using="readonly",
         ):

--- a/uv.lock
+++ b/uv.lock
@@ -516,16 +516,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.1"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/d4/8314b5bdef20832f0ac6ae3b3e4d4924e4759fa3b4af27609dd747e7a6be/django-6.1.1.tar.gz", hash = "sha256:7ab93536d8e677aa14554c56426290c69480bf2ee68d7513d4a22f57d6bfeb84", size = 11284905, upload-time = "2026-09-02T17:20:45.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ca/c1040a4fd15754ede7df15fd72fc2e123045b473b253ab5f5284e11c651e/django-6.1.1-py3-none-any.whl", hash = "sha256:585fb82bf15053c42cf52e67c2f1b54a032dca384759315fd6678ab1870d1d72", size = 8419512, upload-time = "2026-09-02T17:20:39.153Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Django 6.1.1 fixes the regression (django/django#37300) where custom `Prefetch` querysets on forward FK/O2O fields were no longer routed to the parent queryset's database. This updates Django to 6.1.1 and removes the workarounds from #6887 that are no longer needed.

## Changes

- Update Django from 6.1 to 6.1.1 in `uv.lock`
- `temba/api/views.py` — drop the explicit re-routing of custom `Prefetch` querysets in `ListAPIMixin.paginate_queryset`
- `temba/flows/models.py` / `temba/msgs/models.py` — drop the explicit `.using("readonly")` on the export prefetch querysets, which follow the parent batch queryset again. Routing the message export batches themselves to the readonly database is kept.
- `temba/flows/tests/test_export.py` — stop asserting an explicit readonly call for `Flow` since the prefetch no longer makes one
- `temba/api/v2/tests/test_runs.py` — remove the routing test that only verified the workaround
