### PR TITLE
Give the chart and range picker boxes on the dashboard and ticket analytics pages the standard card elevation

### DIFF
--- a/templates/channels/channel_read.html
+++ b/templates/channels/channel_read.html
@@ -52,7 +52,7 @@
       </div>
     {% endif %}
   </div>
-  <div class="surface flex px-4 rounded-lg mb-6 bg-white">
+  <div class="shadow flex px-4 rounded-lg mb-6 bg-white">
     <div class="flex-grow"></div>
     <temba-range-picker min="{{ object.created_on|date:"Y-m-d" }}">
     </temba-range-picker>
@@ -103,7 +103,7 @@
         </div>
       {% endif %}
     {% endif %}
-    <temba-chart class="mb-6"
+    <temba-chart class="shadow mb-6"
                  url="{% url 'channels.channel_chart' object.uuid %}"
                  dataname="Messages"
                  legend
@@ -238,12 +238,6 @@
 
     table.list th.text-right {
       text-align: right;
-    }
-
-    /* same elevation as table.list so every box on the page sits at one level */
-    .surface,
-    temba-chart {
-      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
     }
 
     temba-chart {

--- a/templates/dashboard/home.html
+++ b/templates/dashboard/home.html
@@ -10,12 +10,12 @@
   </style>
 {% endblock extra-style %}
 {% block content %}
-  <div class="flex px-4 rounded-lg mb-6 bg-white">
+  <div class="shadow flex px-4 rounded-lg mb-6 bg-white">
     <div class="flex-grow"></div>
     <temba-range-picker min="{{ request.org.created_on|date:"Y-m-d" }}">
     </temba-range-picker>
   </div>
-  <div class="p-8 bg-white rounded-lg">
+  <div class="shadow p-8 bg-white rounded-lg">
     <temba-chart header="{% trans "Message History" %}"
                  url="{% url 'dashboard.dashboard_message_history' %}"
                  dataname="Messages"

--- a/templates/tickets/ticket_analytics.html
+++ b/templates/tickets/ticket_analytics.html
@@ -65,12 +65,13 @@
   </style>
 {% endblock extra-style %}
 {% block content %}
-  <div class="flex px-4 rounded-lg mb-6 bg-white">
+  <div class="shadow flex px-4 rounded-lg mb-6 bg-white">
     <div class="flex-grow"></div>
     <temba-range-picker min="{{ request.org.created_on|date:"Y-m-d" }}">
     </temba-range-picker>
   </div>
-  <temba-chart header="{% trans "Tickets Opened" %}"
+  <temba-chart class="shadow"
+               header="{% trans "Tickets Opened" %}"
                url="{% url 'tickets.ticket_chart' 'opened' %}"
                dataname="Topics"
                xtype="time"
@@ -78,7 +79,7 @@
                requireWindow
                legend>
   </temba-chart>
-  <temba-chart class="mt-6"
+  <temba-chart class="shadow mt-6"
                header="{% trans "Response Time" %}"
                url="{% url 'tickets.ticket_chart' 'resptime' %}"
                dataname="Average Response"
@@ -89,7 +90,7 @@
                requireWindow>
   </temba-chart>
   {% if has_teams %}
-    <temba-chart class="mt-6"
+    <temba-chart class="shadow mt-6"
                  header="{% trans "Response Count" %}"
                  url="{% url 'tickets.ticket_chart' 'replies' %}"
                  dataname="Teams"
@@ -100,7 +101,7 @@
                  legend>
     </temba-chart>
   {% else %}
-    <temba-chart class="mt-6"
+    <temba-chart class="shadow mt-6"
                  header="{% trans "Response Count" %}"
                  url="{% url 'tickets.ticket_chart' 'replies' %}"
                  dataname="Responses"
@@ -110,7 +111,7 @@
                  requireWindow>
     </temba-chart>
   {% endif %}
-  <div class="leaderboard mt-6" id="leaderboard">
+  <div class="leaderboard shadow mt-6" id="leaderboard">
     <h3 style="margin: 0 0 1em 0; font-size: 1.1em; font-weight: 600;">{% trans "Top Responders" %}</h3>
     <table>
       <thead>


### PR DESCRIPTION
## Summary

The chart boxes, range picker bars and leaderboard on the analytics pages sat flat on the page background while every other box in the app (cards, list tables) carries a drop shadow. This applies the existing shared elevation to them so the pages read as one system.

## Changes

- **`templates/tickets/ticket_analytics.html`** — adds the shared `shadow` utility to the range picker bar, all three charts and the Top Responders leaderboard.
- **`templates/dashboard/home.html`** — adds it to the range picker bar and the chart container.
- **`templates/channels/channel_read.html`** — drops the hand-written `box-shadow` declaration added when this page's charts were styled, and uses the same shared utility instead. No visual change here, just the same result expressed once rather than duplicated per page.

No new CSS: `shadow` is the Tailwind utility that `.card` and `table.list` already apply, so these boxes now inherit the same elevation from the same place. Using the class rather than a global `temba-chart` selector keeps it opt-in, since the flow results page deliberately renders its charts flat on a grey background inside tabs.

## Behavior examples

| Page | Before | After |
|---|---|---|
| Ticket analytics | Range picker, 3 charts, leaderboard flat on the page | All five carry the standard card shadow |
| Dashboard | Range picker and chart container flat | Both carry the standard card shadow |
| Channel read | Shadow from a page-local `box-shadow` rule | Same shadow, from the shared `shadow` utility |

## Test plan

- `code_check.py` clean (djlint, ruff, migrations, locale files)
- Channel read, dashboard and ticket analytics view tests pass
- Ticket analytics and dashboard pages loaded in a dev stack and confirmed rendering the shadows on every box