### PR TITLE
Stop cards being squashed when they are direct children of the scrolling page container

### DIFF
--- a/static/css/frame.css
+++ b/static/css/frame.css
@@ -304,6 +304,13 @@ temba-menu.servicing {
   overflow-x: hidden;
 }
 
+/* cards have overflow:hidden which zeroes their flex-item min-height, so as
+   children of the scrolling flex column above they'd be squashed and clip
+   their own content once the page is taller than the viewport */
+.spa-content > .card {
+  flex-shrink: 0;
+}
+
 .input {
   border-radius: var(--curvature-widget);
   cursor: text;

--- a/static/css/frame.css
+++ b/static/css/frame.css
@@ -306,8 +306,10 @@ temba-menu.servicing {
 
 /* cards have overflow:hidden which zeroes their flex-item min-height, so as
    children of the scrolling flex column above they'd be squashed and clip
-   their own content once the page is taller than the viewport */
-.spa-content > .card {
+   their own content once the page is taller than the viewport. a card that
+   overrides that overflow to scroll itself is opting into being constrained,
+   so leave those alone */
+.spa-content > .card:not(.overflow-y-auto):not(.overflow-y-scroll) {
   flex-shrink: 0;
 }
 

--- a/templates/channels/channel_read.html
+++ b/templates/channels/channel_read.html
@@ -19,7 +19,7 @@
 {% block fields %}
 {% endblock fields %}
 {% block content %}
-  <div class="details card mt-0 mb-6 flex flex-wrap gap-4">
+  <div class="details card mt-0 mb-6 flex flex-shrink-0 flex-wrap gap-4">
     <div class="detail">
       <div class="label">{% trans "Type" %}</div>
       <div class="value">{{ object.type.name }}</div>


### PR DESCRIPTION
## Summary

A card placed directly in the page container can render collapsed to a sliver, with its labels clipped and its content invisible — most visibly on the channel read page, whose details card renders ~24px tall against 163px of content. The cause is generic to the container rather than specific to that page, so the fix is made there.

`.spa-content` is a flex column with `overflow-y: auto`, which makes every direct child a flex item. `.card` sets `overflow: hidden`, and an overflow other than `visible` makes a flex item's automatic `min-height` resolve to `0` instead of `auto` — so a card is the one child that *can* be shrunk, and once the page is taller than the viewport the container squashes it and it clips its own content.

## Changes

- `static/css/frame.css` — direct-child cards of `.spa-content` no longer shrink, with a comment explaining why. Cards that override the card overflow to scroll themselves (`overflow-y-auto` / `overflow-y-scroll`) are excluded: those are opting into being constrained, and forcing them to intrinsic height would spill their content into the page instead. `templates/channels/types/android/claim.html` has such a card.
- `templates/channels/channel_read.html` — added the matching `flex-shrink-0` utility to the details card, consistent with the cards in `channel_configuration.html` and `httplog_read.html` that already carry it. Redundant given the rule above, but it keeps the page readable on its own terms.

## Behavior

Details card on a channel read page whose content exceeds the viewport height:

| | Rendered height | Result |
|---|---|---|
| Before | 24px (content 163px) | labels clipped mid-glyph, values not visible |
| After | full content height | labels and values render in full |

A card that scrolls itself is unaffected in either version — still constrained, still scrolling internally.

## Test plan

- Reproduced the collapse in isolation against the repo's own `frame.css` and `tailwind.css`, measuring the card at 24px rendered vs 163px of content
- Confirmed the `frame.css` rule alone restores it — full height, all values present — with no template change needed
- Confirmed the exclusion works both ways in the same harness: a plain card resolves to `flex-shrink: 0` at full content height, a card with `overflow-y-scroll` keeps `flex-shrink: 1` and stays constrained with its own scrollbar
- `temba.channels` test suite passes (181 tests)
- `code_check.py` clean (migrations, locale, ruff)