### PR TITLE
Use a single design-system shadow token for cards, list tables and the shadow utility

### DIFF
--- a/static/css/frame.css
+++ b/static/css/frame.css
@@ -62,8 +62,10 @@ temba-menu > div {
   display: none;
 }
 
+/* templates use the bare shadow utility on card-like boxes so give it the same
+   shadow as .card and table.list rather than tailwind's default */
 .shadow {
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 40px 0 rgba(0, 0, 0, 0.09);
+  --tw-shadow: var(--shadow-2);
 }
 
 temba-modax,

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -1272,7 +1272,7 @@ table.list {
   background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
   border-radius: 0.5rem;
   overflow: hidden;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  --tw-shadow: var(--shadow-2);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   width: 100%;
 }
@@ -1631,7 +1631,7 @@ ul.steps {
   padding-bottom: 1.5rem;
   padding-left: 1.5rem;
   padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  --tw-shadow: var(--shadow-2);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -1709,7 +1709,7 @@ ul.steps {
     margin-bottom: 1rem;
     overflow: hidden;
     padding: 0;
-    --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+    --tw-shadow: var(--shadow-2);
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
 
@@ -10322,6 +10322,11 @@ ul.steps {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-card {
+  --tw-shadow: var(--shadow-2);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .shadow-md {
   --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -10377,6 +10382,11 @@ ul.steps {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.hover\:shadow-card:hover {
+  --tw-shadow: var(--shadow-2);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .hover\:shadow-md:hover {
   --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -10429,6 +10439,11 @@ ul.steps {
 
 .focus\:shadow:focus {
   --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus\:shadow-card:focus {
+  --tw-shadow: var(--shadow-2);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -23837,6 +23852,11 @@ ul.steps {
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
 
+  .md\:shadow-card {
+    --tw-shadow: var(--shadow-2);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  }
+
   .md\:shadow-md {
     --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -23892,6 +23912,11 @@ ul.steps {
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
 
+  .md\:hover\:shadow-card:hover {
+    --tw-shadow: var(--shadow-2);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  }
+
   .md\:hover\:shadow-md:hover {
     --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
@@ -23944,6 +23969,11 @@ ul.steps {
 
   .md\:focus\:shadow:focus {
     --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  }
+
+  .md\:focus\:shadow-card:focus {
+    --tw-shadow: var(--shadow-2);
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
 

--- a/static/scss/tailwind.scss
+++ b/static/scss/tailwind.scss
@@ -426,7 +426,7 @@ table.padded {
 }
 
 table.list {
-  @apply w-full shadow rounded-lg bg-white overflow-hidden;
+  @apply w-full shadow-card rounded-lg bg-white overflow-hidden;
 
   &.sticky {
     th {
@@ -744,7 +744,7 @@ ul.steps {
 }
 
 .card {
-  @apply rounded-lg py-6 px-6 shadow my-4 bg-white overflow-hidden transition duration-200;
+  @apply rounded-lg py-6 px-6 shadow-card my-4 bg-white overflow-hidden transition duration-200;
 
   .bleed-t {
     @apply -mt-6 mb-6;
@@ -806,7 +806,7 @@ ul.steps {
     margin-left: 0px;
     margin-right: 0px;
 
-    @apply border-0 rounded-lg shadow bg-white mb-4 p-0 overflow-hidden flex items-stretch;
+    @apply border-0 rounded-lg shadow-card bg-white mb-4 p-0 overflow-hidden flex items-stretch;
 
     &:hover {
       box-shadow: var(--widget-box-shadow-focused);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -271,6 +271,8 @@ module.exports = {
                 '0 3px 20px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.02)',
             DEFAULT:
                 '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+            // the one shadow for white card surfaces on the page background, from design-system.css
+            card: 'var(--shadow-2)',
             md:
                 '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
             lg:


### PR DESCRIPTION
## Summary

White boxes on the page background were getting three different drop shadows depending on which class happened to style them. This makes them all use the design system's `--shadow-2` token so cards, list tables and ad-hoc `shadow` boxes look the same — and line up with the web components (`temba-card` etc.) that already use that token.

## Changes

- **`tailwind.config.js`** — adds a `shadow-card` utility bound to `var(--shadow-2)` (defined on `:root` in `design-system.css`).
- **`static/scss/tailwind.scss`** — `.card`, `table.list` and `.formax-section` now `@apply shadow-card` instead of Tailwind's default `shadow`. `static/css/tailwind.css` is the rebuilt output; the only generated diff is the new utility plus those three rules.
- **`static/css/frame.css`** — the app's `.shadow` override, which templates use on card-like boxes (date range bars, charts, leaderboards), now also resolves to `--shadow-2` instead of its own 40px halo.

Tailwind's default `shadow` value is untouched, so buttons, pills and other components that `@apply shadow` are unaffected. The token is used without a literal fallback on purpose: every consumer loads `design-system.css`, and a fallback would be a second copy of the value that drifts.

## Behavior examples

| Surface | Before | After |
|---|---|---|
| `.card` (e.g. channel details) | `0 1px 3px .1, 0 1px 2px .06` | `var(--shadow-2)` |
| `table.list` | `0 1px 3px .1, 0 1px 2px .06` | `var(--shadow-2)` |
| `class="shadow"` boxes (range picker, charts, leaderboard) | `0 1px 3px .1, 0 1px 40px .09` | `var(--shadow-2)` |

## Test plan

- [x] `tailwind.css` rebuild is reproducible and the generated diff is limited to the intended rules
- [x] `code_check.py` clean, `temba.dashboard` tests pass
- [x] Computed `box-shadow` checked in the browser on the channel read page (details card, range bar, chart, monthly table) and the ticket analytics page (range bar, three charts, leaderboard) — every box resolves to the same `--shadow-2` value