### PR TITLE
Serve static files with WhiteNoise so no web server is needed in front

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
           # check we can collect and compress all static files
           uv run python manage.py collectstatic --noinput --verbosity=0
           uv run python manage.py compress --extension=".html" --settings=temba.settings_compress
+          # collectstatic writes .gz/.br siblings for what it collects, but the compressor bundles are written
+          # after it, so they need their own pass - without it WhiteNoise serves them uncompressed
+          uv run python -m whitenoise.compress sitestatic
 
       - name: Run tests
         run: uv run coverage run manage.py test --keepdb --noinput --verbosity=2 --parallel 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ dependencies = [
     "pgvector>=0.4.2",
     "fido2>=2.0.0,<3.0.0",
     "elasticsearch>=9.0.0,<10.0.0",
-    "tzdata>=2025.2"
+    "tzdata>=2025.2",
+    "whitenoise[brotli]>=6.12.0,<7.0.0"
 ]
 
 [project.urls]

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -77,8 +77,9 @@ STORAGES = {
             "querystring_auth": False,
         },
     },
-    # standard Django static files storage
-    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+    # static files are served by the app itself (WhiteNoise) rather than a web server in front of it, so
+    # collectstatic also writes .gz/.br siblings for WhiteNoise to serve - it never compresses at request time
+    "staticfiles": {"BACKEND": "whitenoise.storage.CompressedStaticFilesStorage"},
 }
 
 # settings used by django-storages (defaults to localstack)
@@ -143,6 +144,13 @@ STATIC_URL = "/sitestatic/"
 COMPRESS_ROOT = os.path.join(PROJECT_DIR, "../sitestatic")
 MEDIA_ROOT = os.path.join(PROJECT_DIR, "../media")
 MEDIA_URL = "/media/"
+
+# WhiteNoise serves everything under STATIC_URL from STATIC_ROOT, so no web server needs to be configured to do it.
+# Two things to know about it: it only ever serves the .gz/.br siblings generated at collectstatic time, never
+# compressing a response on the fly, and it only marks a file immutable if the staticfiles storage is a manifest one
+# that can map the hashed name back - which ours isn't. So everything, hashed compressor bundle or not, gets this
+# max-age, chosen to match the far-future expiry a web server would have been configured to send for these.
+WHITENOISE_MAX_AGE = 315360000  # 10 years
 
 # -----------------------------------------------------------------------------------
 # Email
@@ -213,6 +221,7 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/temba/utils/http/tests.py
+++ b/temba/utils/http/tests.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import requests
+from requests.utils import DEFAULT_ACCEPT_ENCODING
 
 from django.utils import timezone
 
@@ -58,7 +59,7 @@ class HttpLogTest(TembaTest):
         self.assertEqual(f"http://127.0.0.1:{self.server.server_port}/foo", log.url)
         self.assertEqual(200, log.status_code)
         self.assertEqual(
-            f"GET /foo HTTP/1.1\r\nHost: 127.0.0.1:{self.server.server_port}\r\nUser-Agent: python-requests/{requests.__version__}\r\nAccept-Encoding: gzip, deflate, zstd\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n",
+            f"GET /foo HTTP/1.1\r\nHost: 127.0.0.1:{self.server.server_port}\r\nUser-Agent: python-requests/{requests.__version__}\r\nAccept-Encoding: {DEFAULT_ACCEPT_ENCODING}\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n",
             log.request,
         )
         self.assertEqual(
@@ -82,7 +83,7 @@ class HttpLogTest(TembaTest):
         self.assertEqual("http://127.0.0.1:6666/", log.url)
         self.assertEqual(0, log.status_code)
         self.assertEqual(
-            f"GET / HTTP/1.1\r\nHost: 127.0.0.1:6666\r\nUser-Agent: python-requests/{requests.__version__}\r\nAccept-Encoding: gzip, deflate, zstd\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n",
+            f"GET / HTTP/1.1\r\nHost: 127.0.0.1:6666\r\nUser-Agent: python-requests/{requests.__version__}\r\nAccept-Encoding: {DEFAULT_ACCEPT_ENCODING}\r\nAccept: */*\r\nConnection: keep-alive\r\n\r\n",
             log.request,
         )
         self.assertEqual(

--- a/uv.lock
+++ b/uv.lock
@@ -200,6 +200,24 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
 name = "celery"
 version = "5.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1770,6 +1788,7 @@ dependencies = [
     { name = "twilio" },
     { name = "tzdata" },
     { name = "vonage" },
+    { name = "whitenoise", extra = ["brotli"] },
     { name = "xlsxlite" },
 ]
 
@@ -1825,6 +1844,7 @@ requires-dist = [
     { name = "twilio", specifier = ">=9.10.9,<10.0.0" },
     { name = "tzdata", specifier = ">=2025.2" },
     { name = "vonage", specifier = ">=4.8.2,<5.0.0" },
+    { name = "whitenoise", extras = ["brotli"], specifier = ">=6.12.0,<7.0.0" },
     { name = "xlsxlite", specifier = "~=1.1.1" },
 ]
 
@@ -2285,6 +2305,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
     { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
     { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
+]
+
+[package.optional-dependencies]
+brotli = [
+    { name = "brotli" },
 ]
 
 [[package]]


### PR DESCRIPTION
Static files under `/sitestatic/` have always been served off disk by a web server sitting in front
of the app. Anywhere the app is reached directly there is nothing serving that path at all, so this
moves the job into the app itself with [WhiteNoise](https://whitenoise.readthedocs.io/).

## What's here

* `whitenoise[brotli]` dependency
* `WhiteNoiseMiddleware` immediately after `SecurityMiddleware` — that ordering matters, because
  WhiteNoise short-circuits the request and only middleware *before* it gets to touch the response
* `STORAGES["staticfiles"]` → `whitenoise.storage.CompressedStaticFilesStorage`, so `collectstatic`
  writes `.gz`/`.br` siblings
* `WHITENOISE_MAX_AGE` set explicitly — the default is 60s, and these were previously being served
  with a far-future expiry
* a `python -m whitenoise.compress` pass in CI after the compress step

All of it in `settings_common`, since every variant already inherits `STATIC_ROOT`/`STATIC_URL`
from there. In development `STATIC_URL` is `/static/`, so WhiteNoise picks up that prefix instead
and the dev server behaves as before.

## Why the extra compress pass

WhiteNoise never compresses a response at request time — it only serves pre-generated `.gz`/`.br`
siblings. `collectstatic` generates those for what it collects, but django-compressor writes its
`CACHE/` bundles *afterwards*, so those get none. They're also the biggest files, so without the
extra pass the compression that matters most is exactly the part that silently goes missing:

| | raw | gz | br |
|---|---|---|---|
| `CACHE/js/output.<hash>.js` | 2130K | 558K | 441K |
| `CACHE/css/output.<hash>.css` | 595K | 62K | 40K |

## Verified

Ran a full `collectstatic` → `compress` → `whitenoise.compress` and served the result under gunicorn
with no web server in front:

* correct `Content-Type` across `.js` / `.css` / `.svg` / `.png` / `.woff`
* `Cache-Control: max-age=315360000, public` on both hashed bundles and loose assets, matching the
  far-future expiry these were served with before
* `gzip` and `br` negotiated correctly with `Vary: Accept-Encoding`, and absent on already-compressed
  types like `.woff`; decoded bodies byte-identical to the originals
* `Access-Control-Allow-Origin: *` (WhiteNoise's default), `304` on `If-None-Match`, `206` on `Range`
* a missing file falls through to Django's 404
* the compressor `CACHE/` bundles have their siblings

Full test suite green.

## Notes

Hashed compressor bundles are **not** detected as immutable. WhiteNoise's Django integration decides
that by asking the staticfiles storage to map the hashed name back to the un-hashed one, which plain
`CompressedStaticFilesStorage` can't do — only a manifest storage can. It makes no practical
difference here given the max-age, but it's the reason there's no `immutable` directive. Moving to
`CompressedManifestStaticFilesStorage` later would get that plus versioned filenames for loose
assets; it also rewrites `url()` references in CSS and fails `collectstatic` on unresolvable ones,
so it's worth doing separately.

Pulling in brotli changes the `Accept-Encoding` that `requests` advertises by default, which two
`HttpLog` tests were asserting on verbatim. They now take that header from `requests` itself rather
than hardcoding it.
