### PR TITLE
Remove the Granters permission group

### DIFF
--- a/temba/orgs/tests/test_role.py
+++ b/temba/orgs/tests/test_role.py
@@ -11,7 +11,7 @@ class OrgRoleTest(TembaTest):
 
     def test_from_group(self):
         self.assertEqual(OrgRole.EDITOR, OrgRole.from_group(Group.objects.get(name="Editors")))
-        self.assertIsNone(OrgRole.from_group(Group.objects.get(name="Granters")))
+        self.assertIsNone(OrgRole.from_group(self.create_admin_group("Global Admins")))
 
     def test_group(self):
         self.assertEqual(Group.objects.get(name="Editors"), OrgRole.EDITOR.group)

--- a/temba/orgs/views/tests/test_orgcrudl.py
+++ b/temba/orgs/views/tests/test_orgcrudl.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Permission
 from django.core import mail
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -492,8 +492,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(grant_url)
         self.assertPermissionDenied(response)
 
-        granters = Group.objects.get(name="Granters")
-        user.groups.add(granters)
+        user.user_permissions.add(Permission.objects.get(content_type__app_label="orgs", codename="org_grant"))
 
         response = self.client.get(grant_url)
         self.assertEqual(200, response.status_code)
@@ -546,8 +545,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_org_grant_invalid_form(self):
         grant_url = reverse("orgs.org_grant")
 
-        granters = Group.objects.get(name="Granters")
-        self.admin.groups.add(granters)
+        self.admin.user_permissions.add(Permission.objects.get(content_type__app_label="orgs", codename="org_grant"))
 
         self.login(self.admin)
 
@@ -605,8 +603,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_org_grant_form_clean(self):
         grant_url = reverse("orgs.org_grant")
 
-        granters = Group.objects.get(name="Granters")
-        self.admin.groups.add(granters)
+        self.admin.user_permissions.add(Permission.objects.get(content_type__app_label="orgs", codename="org_grant"))
 
         self.login(self.admin)
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -402,7 +402,6 @@ PERMISSIONS = {
 
 # assigns the permissions that each group should have
 GROUP_PERMISSIONS = {
-    "Granters": ("orgs.org_grant",),
     "Administrators": (
         "ai.llm.*",
         "airtime.airtimetransfer_list",

--- a/temba/staff/tests.py
+++ b/temba/staff/tests.py
@@ -315,7 +315,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.requestView(update_url, self.customer_support)
         self.assertEqual(200, response.status_code)
 
-        granters = Group.objects.get(name="Granters")
+        global_admins = self.create_admin_group("Global Admins")
         editors = Group.objects.get(name="Editors")
 
         response = self.requestView(
@@ -325,7 +325,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
                 "email": "eddy@textit.com",
                 "first_name": "Edward",
                 "last_name": "",
-                "groups": [granters.id, editors.id],
+                "groups": [global_admins.id, editors.id],
             },
         )
         self.assertEqual(302, response.status_code)
@@ -334,7 +334,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual("eddy@textit.com", self.editor.email)
         self.assertEqual("Edward", self.editor.first_name)
         self.assertEqual("", self.editor.last_name)
-        self.assertEqual({granters, editors}, set(self.editor.groups.all()))
+        self.assertEqual({global_admins, editors}, set(self.editor.groups.all()))
 
         # submit with one less group
         response = self.requestView(
@@ -345,7 +345,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
                 "new_password": "Asdf1234",
                 "first_name": "Edward",
                 "last_name": "",
-                "groups": [granters.id],
+                "groups": [global_admins.id],
             },
         )
         self.assertEqual(302, response.status_code)
@@ -354,7 +354,7 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual("eddy@textit.com", self.editor.email)
         self.assertEqual("Edward", self.editor.first_name)
         self.assertEqual("", self.editor.last_name)
-        self.assertEqual({granters}, set(self.editor.groups.all()))
+        self.assertEqual({global_admins}, set(self.editor.groups.all()))
 
         # unverify user
         self.client.post(update_url, {"action": "unverify"})

--- a/temba/users/models.py
+++ b/temba/users/models.py
@@ -175,7 +175,7 @@ class User(LegacyIDMixin, TembaUUIDMixin, AbstractBaseUser, PermissionsMixin):
         Determines if a user has the given permission in the given org.
         """
 
-        # has it innately? e.g. Granter group
+        # has it innately? e.g. via a permission group configured by the install
         if self.has_perm(permission):
             return True
 

--- a/temba/users/tests/test_user.py
+++ b/temba/users/tests/test_user.py
@@ -1,6 +1,6 @@
 from allauth.mfa.models import Authenticator
 
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Permission
 
 from temba.api.models import APIToken
 from temba.orgs.models import Org, OrgRole
@@ -117,7 +117,8 @@ class UserTest(TembaTest):
         self.assertTrue(self.agent.is_mfa_enabled)
 
     def test_has_org_perm(self):
-        granter = self.create_user("jim@rapidpro.io", group_names=("Granters",))
+        granter = self.create_user("jim@rapidpro.io")
+        granter.user_permissions.add(Permission.objects.get(content_type__app_label="orgs", codename="org_grant"))
         group_admin = self.create_user("gad@rapidpro.io")
         self.create_admin_group("Global Admins", orgs=[self.org], users=[group_admin])
 
@@ -168,7 +169,7 @@ class UserTest(TembaTest):
 
     def test_release(self):
         token = APIToken.create(self.org, self.admin)
-        self.admin.groups.add(Group.objects.get(name="Granters"))
+        self.create_admin_group("Global Admins", users=[self.admin])
 
         # admin doesn't "own" any orgs
         self.assertEqual(0, len(self.admin.get_owned_orgs()))


### PR DESCRIPTION
## Summary

Removes the built-in `Granters` group from `GROUP_PERMISSIONS`. The workspace grant view is still gated by the `orgs.org_grant` permission, but which group (if any) holds it is now left to each install's own `GROUP_PERMISSIONS` configuration rather than being fixed upstream. Superusers can still reach the view as before.

## Changes

- **`temba/settings_common.py`** — drop the `Granters` entry from `GROUP_PERMISSIONS`. The `grant` entry in `PERMISSIONS` remains so the `orgs.org_grant` permission still exists for installs to assign.
- **`temba/users/models.py`** — update the comment on the innate-permission check in `has_org_perm` to no longer reference the removed group.
- **Tests** — the grant view tests and `test_has_org_perm` now give the user the `orgs.org_grant` permission directly via `user_permissions`. Tests that only needed some non-role auth group (`test_from_group`, staff user update, user release) use `create_admin_group` instead.

Note that smartmin only creates and updates groups listed in `GROUP_PERMISSIONS`; it never touches groups removed from it. On existing installs the `Granters` group row, its permission and any remaining members are left untouched by this change. Installs that want it gone should remove its members and delete the group by hand.

## Test plan

- [x] `temba.orgs`, `temba.users` and `temba.staff` test suites pass
- [x] `code_check.py` clean (no migration or locale changes)