### PR TITLE
Add ADMIN_GROUPS setting for the groups staff can attach to workspaces

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -400,6 +400,10 @@ PERMISSIONS = {
 }
 
 
+# names of the auth groups which staff can attach to workspaces as admin groups, making their members administrators of
+# those workspaces. Each also gets a filter in the staff user list.
+ADMIN_GROUPS = ()
+
 # assigns the permissions that each group should have
 GROUP_PERMISSIONS = {
     "Administrators": (

--- a/temba/staff/tests.py
+++ b/temba/staff/tests.py
@@ -308,29 +308,10 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.requestView(list_url + "?filter=staff", self.customer_support)
         self.assertEqual({self.customer_support}, set(response.context["object_list"]))
 
-        # deployments can configure admin groups, each of which gets a filter by membership
-        self.create_admin_group("Global Admins", users=[self.editor])
-        self.create_admin_group("Regional Admins", users=[self.agent])
+        self.assertEqual("/staff/users/staff", response.headers[TEMBA_MENU_SELECTION])
 
-        with override_settings(ADMIN_GROUPS=("Global Admins", "Regional Admins")):
-            response = self.requestView(list_url + "?filter=global_admins", self.customer_support)
-            self.assertEqual({self.editor}, set(response.context["object_list"]))
-            self.assertEqual("/staff/users/global_admins", response.headers[TEMBA_MENU_SELECTION])
-            self.assertEqual(
-                [
-                    ("all", "All"),
-                    ("staff", "Staff"),
-                    ("global_admins", "Global Admins"),
-                    ("regional_admins", "Regional Admins"),
-                ],
-                [(f[0], str(f[1])) for f in response.context["filters"]],
-            )
-
-            response = self.requestView(list_url + "?filter=regional_admins", self.customer_support)
-            self.assertEqual({self.agent}, set(response.context["object_list"]))
-
-        # filters for groups which aren't configured as admin groups are ignored
-        response = self.requestView(list_url + "?filter=global_admins", self.customer_support)
+        # unknown filters are ignored
+        response = self.requestView(list_url + "?filter=xxxx", self.customer_support)
         self.assertEqual(8, len(response.context["object_list"]))
 
         response = self.requestView(list_url + "?search=admin@textit.com", self.customer_support)

--- a/temba/staff/tests.py
+++ b/temba/staff/tests.py
@@ -1,6 +1,7 @@
 from allauth.mfa.models import Authenticator
 
 from django.contrib.auth.models import Group
+from django.test import override_settings
 from django.urls import reverse
 
 from temba.contacts.models import Contact
@@ -133,6 +134,30 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # limits left blank aren't recorded on the org
         self.assertEqual({"channels": 20, "contacts": 100_000, "fields": 300, "groups": 400}, self.org.limits)
+
+        # admin groups are limited to those configured for the deployment
+        global_admins = self.create_admin_group("Global Admins")
+        other_admins = self.create_admin_group("Other Admins")
+
+        with override_settings(ADMIN_GROUPS=("Global Admins",)):
+            response = self.client.get(update_url)
+            self.assertEqual([global_admins], list(response.context["form"].fields["admin_groups"].queryset))
+
+            response = self.client.post(
+                update_url, {"name": "Temba II", "is_anon": False, "admin_groups": [other_admins.id]}
+            )
+            self.assertFormError(
+                response.context["form"],
+                "admin_groups",
+                f"Select a valid choice. {other_admins.id} is not one of the available choices.",
+            )
+
+            response = self.client.post(
+                update_url, {"name": "Temba II", "is_anon": False, "admin_groups": [global_admins.id]}
+            )
+            self.assertEqual(302, response.status_code)
+
+        self.assertEqual([global_admins], list(self.org.admin_groups.all()))
 
         # and clearing a limit removes it, so it falls back to the default
         response = self.client.post(
@@ -282,6 +307,31 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
 
         response = self.requestView(list_url + "?filter=staff", self.customer_support)
         self.assertEqual({self.customer_support}, set(response.context["object_list"]))
+
+        # deployments can configure admin groups, each of which gets a filter by membership
+        self.create_admin_group("Global Admins", users=[self.editor])
+        self.create_admin_group("Regional Admins", users=[self.agent])
+
+        with override_settings(ADMIN_GROUPS=("Global Admins", "Regional Admins")):
+            response = self.requestView(list_url + "?filter=global_admins", self.customer_support)
+            self.assertEqual({self.editor}, set(response.context["object_list"]))
+            self.assertEqual("/staff/users/global_admins", response.headers[TEMBA_MENU_SELECTION])
+            self.assertEqual(
+                [
+                    ("all", "All"),
+                    ("staff", "Staff"),
+                    ("global_admins", "Global Admins"),
+                    ("regional_admins", "Regional Admins"),
+                ],
+                [(f[0], str(f[1])) for f in response.context["filters"]],
+            )
+
+            response = self.requestView(list_url + "?filter=regional_admins", self.customer_support)
+            self.assertEqual({self.agent}, set(response.context["object_list"]))
+
+        # filters for groups which aren't configured as admin groups are ignored
+        response = self.requestView(list_url + "?filter=global_admins", self.customer_support)
+        self.assertEqual(8, len(response.context["object_list"]))
 
         response = self.requestView(list_url + "?search=admin@textit.com", self.customer_support)
         self.assertEqual({self.admin}, set(response.context["object_list"]))

--- a/temba/staff/views.py
+++ b/temba/staff/views.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import Group
 from django.db.models import Prefetch
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
+from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
@@ -156,7 +157,7 @@ class OrgCRUDL(SmartCRUDL):
                 required=False,
             )
             admin_groups = forms.ModelMultipleChoiceField(
-                queryset=Group.objects.exclude(name__in=[r.group_name for r in OrgRole]).order_by("name"),
+                queryset=Group.objects.none(),
                 widget=SelectMultipleWidget(
                     attrs={"placeholder": _("Optional: Select groups whose members administer this workspace.")}
                 ),
@@ -165,6 +166,10 @@ class OrgCRUDL(SmartCRUDL):
 
             def __init__(self, org, *args, **kwargs):
                 super().__init__(*args, **kwargs)
+
+                self.fields["admin_groups"].queryset = Group.objects.filter(name__in=settings.ADMIN_GROUPS).order_by(
+                    "name"
+                )
 
                 self.limits_rows = []
                 self.add_limits_fields(org)
@@ -385,6 +390,13 @@ class UserCRUDL(SmartCRUDL):
         search_fields = ("email__icontains", "first_name__icontains", "last_name__icontains")
         filters = (("all", _("All")), ("staff", _("Staff")))
 
+        @staticmethod
+        def get_admin_group_filters() -> dict[str, str]:
+            """
+            The filters for the configured admin groups, as filter slug -> group name
+            """
+            return {slugify(name).replace("-", "_"): name for name in settings.ADMIN_GROUPS}
+
         def derive_menu_path(self):
             return f"/staff/users/{self.request.GET.get('filter', 'all')}"
 
@@ -398,8 +410,11 @@ class UserCRUDL(SmartCRUDL):
             qs = super().derive_queryset(**kwargs).filter(is_active=True)
 
             obj_filter = self.request.GET.get("filter")
+            admin_group_filters = self.get_admin_group_filters()
             if obj_filter == "staff":
                 qs = qs.filter(is_staff=True)
+            elif obj_filter in admin_group_filters:
+                qs = qs.filter(groups__name=admin_group_filters[obj_filter])
 
             return qs.prefetch_related(
                 Prefetch("emailaddress_set", queryset=verified_email_qs, to_attr="email_verified"),
@@ -409,7 +424,7 @@ class UserCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
             context["filter"] = self.request.GET.get("filter", "all")
-            context["filters"] = self.filters
+            context["filters"] = self.filters + tuple(self.get_admin_group_filters().items())
             return context
 
         def get_2fa(self, obj):

--- a/temba/staff/views.py
+++ b/temba/staff/views.py
@@ -11,7 +11,6 @@ from django.contrib.auth.models import Group
 from django.db.models import Prefetch
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
-from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
@@ -388,14 +387,16 @@ class UserCRUDL(SmartCRUDL):
         fields = ("email", "name", "date_joined", "2fa", "verified")
         ordering = ("-date_joined",)
         search_fields = ("email__icontains", "first_name__icontains", "last_name__icontains")
-        filters = (("all", _("All")), ("staff", _("Staff")))
+        filters = (
+            ("all", _("All"), dict()),
+            ("staff", _("Staff"), dict(is_staff=True)),
+        )
 
-        @staticmethod
-        def get_admin_group_filters() -> dict[str, str]:
-            """
-            The filters for the configured admin groups, as filter slug -> group name
-            """
-            return {slugify(name).replace("-", "_"): name for name in settings.ADMIN_GROUPS}
+        def get_filter(self):
+            obj_filter = self.request.GET.get("filter", "all")
+            for filter in self.filters:
+                if filter[0] == obj_filter:
+                    return filter
 
         def derive_menu_path(self):
             return f"/staff/users/{self.request.GET.get('filter', 'all')}"
@@ -409,12 +410,10 @@ class UserCRUDL(SmartCRUDL):
 
             qs = super().derive_queryset(**kwargs).filter(is_active=True)
 
-            obj_filter = self.request.GET.get("filter")
-            admin_group_filters = self.get_admin_group_filters()
-            if obj_filter == "staff":
-                qs = qs.filter(is_staff=True)
-            elif obj_filter in admin_group_filters:
-                qs = qs.filter(groups__name=admin_group_filters[obj_filter])
+            filter = self.get_filter()
+            if filter:
+                _, _, filter_kwargs = filter
+                qs = qs.filter(**filter_kwargs)
 
             return qs.prefetch_related(
                 Prefetch("emailaddress_set", queryset=verified_email_qs, to_attr="email_verified"),
@@ -424,7 +423,7 @@ class UserCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
             context["filter"] = self.request.GET.get("filter", "all")
-            context["filters"] = self.filters + tuple(self.get_admin_group_filters().items())
+            context["filters"] = self.filters
             return context
 
         def get_2fa(self, obj):


### PR DESCRIPTION
## Summary

Adds an `ADMIN_GROUPS` setting naming the auth groups which staff can attach to workspaces as admin groups, and limits the staff workspace update form to those groups. Also makes the staff user list's filters an overridable table, like the org list's, so a deployment can register extra filters such as one per admin group.

## Changes

- `settings_common.py`: new `ADMIN_GROUPS = ()` setting, defined alongside `GROUP_PERMISSIONS`.
- `staff/views.py`:
  - `OrgCRUDL.Update` limits the `admin_groups` field to the groups named in `ADMIN_GROUPS`, resolved per request rather than at import time. Previously it offered every non-role group.
  - `UserCRUDL.List.filters` becomes a table of `(id, label, queryset kwargs)` applied by `derive_queryset` via a `get_filter()` helper, replacing the hard-coded `staff` check. Vanilla keeps just the `all` and `staff` filters. Unknown filters are ignored as before.
- `staff/tests.py`: covers the restricted form field, rejection of an unconfigured group, and the list filters including the menu path and unknown filters.

## Behavior examples

With `ADMIN_GROUPS = ("Global Admins",)` and a `Regional Admins` group also present:

| Staff org update form, admin groups | Before | After |
|---|---|---|
| Options offered | Global Admins, Regional Admins | Global Admins |
| Posting Regional Admins | Saved | Rejected as an invalid choice |

A deployment can register a user list filter by extending the table, for example `UserCRUDL.List.filters += (("global_admins", "Global Admins", dict(groups__name="Global Admins")),)`, after which `?filter=global_admins` lists that group's members and the menu path becomes `/staff/users/global_admins`.

## Test plan

- [x] `temba.staff` tests pass in the devcontainer
- [x] `code_check.py` passes