### PR TITLE
Add handling for mailroom contact limit errors

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 16:34+0000\n"
+"POT-Creation-Date: 2026-09-09 15:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -2918,6 +2918,10 @@ msgid "Can't query on URNs in an anonymous workspace."
 msgstr ""
 
 msgid "This query is too complex. Please simplify it and try again."
+msgstr ""
+
+#, python-format
+msgid "This workspace has reached its limit of %(limit)s contacts."
 msgstr ""
 
 msgid "Using a message template may incur additional fees from your channel provider."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 16:34+0000\n"
+"POT-Creation-Date: 2026-09-09 15:15+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -2945,6 +2945,10 @@ msgstr "No se pueden consultar URN en un workspace anónimo."
 
 msgid "This query is too complex. Please simplify it and try again."
 msgstr "Esta consulta es demasiado compleja. Simplifíquela y vuelva a intentarlo."
+
+#, python-format
+msgid "This workspace has reached its limit of %(limit)s contacts."
+msgstr "Este workspace ha alcanzado su límite de %(limit)s contactos."
 
 msgid "Using a message template may incur additional fees from your channel provider."
 msgstr "El uso de una plantilla de mensaje puede generar cargos adicionales de su proveedor de canal."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 16:34+0000\n"
+"POT-Creation-Date: 2026-09-09 15:15+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -2945,6 +2945,10 @@ msgstr "Impossible d'effectuer une requête sur les URN dans un espace de travai
 
 msgid "This query is too complex. Please simplify it and try again."
 msgstr "Cette requête est trop complexe. Veuillez la simplifier et réessayer."
+
+#, python-format
+msgid "This workspace has reached its limit of %(limit)s contacts."
+msgstr "Cet espace de travail a atteint sa limite de %(limit)s contacts."
 
 msgid "Using a message template may incur additional fees from your channel provider."
 msgstr "L'utilisation d'un modèle de message peut entraîner des frais supplémentaires de la part de votre fournisseur de canal."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 16:34+0000\n"
+"POT-Creation-Date: 2026-09-09 15:15+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -2949,6 +2949,10 @@ msgstr "Não é possível consultar URNs em uma área de trabalho anônima."
 
 msgid "This query is too complex. Please simplify it and try again."
 msgstr "Esta consulta é complexa demais. Por favor simplifique-a e tente novamente."
+
+#, python-format
+msgid "This workspace has reached its limit of %(limit)s contacts."
+msgstr "Esta área de trabalho atingiu seu limite de %(limit)s contatos."
 
 msgid "Using a message template may incur additional fees from your channel provider."
 msgstr "Usar um template de mensagem pode gerar taxas adicionais do seu provedor de canal."

--- a/temba/api/v2/tests/test_contacts.py
+++ b/temba/api/v2/tests/test_contacts.py
@@ -460,7 +460,9 @@ class ContactsEndpointTest(APITest):
         )
 
         # try to create a contact when the workspace has reached its contact limit
-        self.mr_mocks.exception(mailroom.ContactLimitReached("workspace has reached its limit of 100 contacts", 100))
+        self.mr_mocks.exception(
+            mailroom.ContactLimitReachedException("workspace has reached its limit of 100 contacts", 100)
+        )
 
         self.assertPost(
             endpoint_url,

--- a/temba/api/v2/tests/test_contacts.py
+++ b/temba/api/v2/tests/test_contacts.py
@@ -4,6 +4,7 @@ from urllib.parse import quote_plus
 from django.urls import reverse
 from django.utils import timezone
 
+from temba import mailroom
 from temba.api.v2.serializers import format_datetime
 from temba.contacts.models import Contact, ContactField, ContactGroup
 
@@ -456,6 +457,17 @@ class ContactsEndpointTest(APITest):
             self.editor,
             {"name": "Robert", "urns": ["tel:+250-78-5555555"]},
             errors={("urns", "0"): "URN is in use by another contact."},
+        )
+
+        # try to create a contact when the workspace has reached its contact limit
+        self.mr_mocks.exception(mailroom.ContactLimitReached("workspace has reached its limit of 100 contacts", 100))
+
+        self.assertPost(
+            endpoint_url,
+            self.editor,
+            {"name": "Robert", "urns": ["tel:+250-78-6666666"]},
+            errors={None: "This workspace has reached its limit of 100 contacts."},
+            status=409,
         )
 
         # try to update a contact with non-existent UUID

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -232,7 +232,7 @@ class WriteAPIMixin:
                     output = serializer.save()
                 except mailroom.URNValidationException as e:
                     return Response(serializer.urn_exception(e), status=status.HTTP_400_BAD_REQUEST)
-                except mailroom.ContactLimitReached as e:
+                except mailroom.ContactLimitReachedException as e:
                     return Response({"detail": str(e)}, status=status.HTTP_409_CONFLICT)
 
                 self.post_save(output)

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -232,6 +232,8 @@ class WriteAPIMixin:
                     output = serializer.save()
                 except mailroom.URNValidationException as e:
                     return Response(serializer.urn_exception(e), status=status.HTTP_400_BAD_REQUEST)
+                except mailroom.ContactLimitReached as e:
+                    return Response({"detail": str(e)}, status=status.HTTP_409_CONFLICT)
 
                 self.post_save(output)
                 return self.render_write_response(output, context)

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -124,6 +124,19 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             form_errors={"phone": "Invalid phone number."},
         )
 
+        # simulate creation failing because workspace has reached its contact limit
+        with patch("temba.contacts.models.Contact.create") as mock_create:
+            mock_create.side_effect = mailroom.ContactLimitReached(
+                "workspace has reached its limit of 100 contacts", 100
+            )
+
+            self.assertCreateSubmit(
+                create_url,
+                self.admin,
+                {"name": "Joe", "phone": "+250782222222"},
+                form_errors={"__all__": "This workspace has reached its limit of 100 contacts."},
+            )
+
         # try valid number
         self.assertCreateSubmit(
             create_url,

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -126,7 +126,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
         # simulate creation failing because workspace has reached its contact limit
         with patch("temba.contacts.models.Contact.create") as mock_create:
-            mock_create.side_effect = mailroom.ContactLimitReached(
+            mock_create.side_effect = mailroom.ContactLimitReachedException(
                 "workspace has reached its limit of 100 contacts", 100
             )
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -656,7 +656,7 @@ class ContactCRUDL(SmartCRUDL):
                 error = _("In use by another contact.") if e.code == "taken" else _("Not a valid phone number.")
                 self.form.add_error("phone", error)
                 return self.form_invalid(form)
-            except mailroom.ContactLimitReached as e:
+            except mailroom.ContactLimitReachedException as e:
                 self.form.add_error(None, str(e))
                 return self.form_invalid(form)
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -656,6 +656,9 @@ class ContactCRUDL(SmartCRUDL):
                 error = _("In use by another contact.") if e.code == "taken" else _("Not a valid phone number.")
                 self.form.add_error("phone", error)
                 return self.form_invalid(form)
+            except mailroom.ContactLimitReached as e:
+                self.form.add_error(None, str(e))
+                return self.form_invalid(form)
 
             return self.render_modal_response(form)
 

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -11,6 +11,7 @@ from temba.utils import json
 from ..modifiers import Modifier
 from .exceptions import (
     AIServiceException,
+    ContactLimitReached,
     FlowValidationException,
     QueryValidationException,
     RequestException,
@@ -450,6 +451,8 @@ class MailroomClient:
                 raise QueryValidationException(error, code, extra)
             elif domain == "urn":
                 raise URNValidationException(error, code, extra["index"])
+            elif domain == "limit" and code == "contacts":
+                raise ContactLimitReached(error, extra["limit"])
             elif domain == "ai":
                 raise AIServiceException(error, code, extra["instructions"], extra["input"])
 

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -11,7 +11,7 @@ from temba.utils import json
 from ..modifiers import Modifier
 from .exceptions import (
     AIServiceException,
-    ContactLimitReached,
+    ContactLimitReachedException,
     FlowValidationException,
     QueryValidationException,
     RequestException,
@@ -452,9 +452,13 @@ class MailroomClient:
             elif domain == "urn":
                 raise URNValidationException(error, code, extra["index"])
             elif domain == "limit" and code == "contacts":
-                raise ContactLimitReached(error, extra["limit"])
+                raise ContactLimitReachedException(error, extra["limit"])
             elif domain == "ai":
                 raise AIServiceException(error, code, extra["instructions"], extra["input"])
+            else:
+                # an error domain we don't know about is still an error, so fail loudly rather than returning
+                # the error body to the caller as if it was a successful response
+                raise RequestException(endpoint, payload, response)
 
         elif 400 <= response.status_code < 600:
             raise RequestException(endpoint, payload, response)

--- a/temba/mailroom/client/exceptions.py
+++ b/temba/mailroom/client/exceptions.py
@@ -81,7 +81,7 @@ class URNValidationException(Exception):
         return self.error
 
 
-class ContactLimitReached(Exception):
+class ContactLimitReachedException(Exception):
     """
     Request that fails because the workspace has reached its limit on the number of contacts.
     """

--- a/temba/mailroom/client/exceptions.py
+++ b/temba/mailroom/client/exceptions.py
@@ -81,6 +81,19 @@ class URNValidationException(Exception):
         return self.error
 
 
+class ContactLimitReached(Exception):
+    """
+    Request that fails because the workspace has reached its limit on the number of contacts.
+    """
+
+    def __init__(self, error: str, limit: int):
+        self.error = error
+        self.limit = limit
+
+    def __str__(self):
+        return _("This workspace has reached its limit of %(limit)s contacts.") % {"limit": f"{self.limit:,}"}
+
+
 class AIServiceException(Exception):
     """
     Request that fails because an LLM service error

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -16,6 +16,7 @@ from .. import modifiers
 from .client import MailroomClient
 from .exceptions import (
     AIServiceException,
+    ContactLimitReached,
     FlowValidationException,
     QueryValidationException,
     RequestException,
@@ -1162,6 +1163,27 @@ class MailroomClientTest(TembaTest):
         self.assertEqual("taken", e.exception.code)
         self.assertEqual(1, e.exception.index)
         self.assertEqual("URN 1 is taken", str(e.exception))
+
+        mock_post.return_value = MockJsonResponse(
+            422,
+            {
+                "error": "workspace has reached its limit of 50000000 contacts",
+                "code": "limit:contacts",
+                "extra": {"limit": 50000000},
+            },
+        )
+
+        with self.assertRaises(ContactLimitReached) as e:
+            self.client.contact_create(
+                self.org,
+                self.admin,
+                ContactSpec(name="Bob", language="eng", status="active", urns=["tel:+123456789"], fields={}, groups=[]),
+                "ui",
+            )
+
+        self.assertEqual("workspace has reached its limit of 50000000 contacts", e.exception.error)
+        self.assertEqual(50000000, e.exception.limit)
+        self.assertEqual("This workspace has reached its limit of 50,000,000 contacts.", str(e.exception))
 
         mock_post.return_value = MockJsonResponse(500, {"error": "error loading fields"})
 

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -16,7 +16,7 @@ from .. import modifiers
 from .client import MailroomClient
 from .exceptions import (
     AIServiceException,
-    ContactLimitReached,
+    ContactLimitReachedException,
     FlowValidationException,
     QueryValidationException,
     RequestException,
@@ -1173,7 +1173,7 @@ class MailroomClientTest(TembaTest):
             },
         )
 
-        with self.assertRaises(ContactLimitReached) as e:
+        with self.assertRaises(ContactLimitReachedException) as e:
             self.client.contact_create(
                 self.org,
                 self.admin,
@@ -1184,6 +1184,19 @@ class MailroomClientTest(TembaTest):
         self.assertEqual("workspace has reached its limit of 50000000 contacts", e.exception.error)
         self.assertEqual(50000000, e.exception.limit)
         self.assertEqual("This workspace has reached its limit of 50,000,000 contacts.", str(e.exception))
+
+        # a 422 with an error domain we don't know about is still an error
+        mock_post.return_value = MockJsonResponse(422, {"error": "workspace limit reached", "code": "limit:groups"})
+
+        with self.assertRaises(RequestException) as e:
+            self.client.contact_create(
+                self.org,
+                self.admin,
+                ContactSpec(name="Bob", language="eng", status="active", urns=["tel:+123456789"], fields={}, groups=[]),
+                "ui",
+            )
+
+        self.assertEqual("workspace limit reached", e.exception.error)
 
         mock_post.return_value = MockJsonResponse(500, {"error": "error loading fields"})
 


### PR DESCRIPTION
## Summary

Mailroom now enforces a per-workspace ceiling on the number of contacts, rejecting contact creation with a `422` and a `limit:contacts` error code. Temba had no branch for the `limit` error domain, so that response fell through the 422 dispatch and surfaced as a generic failure. This adds a `ContactLimitReachedException` and turns it into a sensible message at the two places that create contacts. It also makes any *unhandled* 422 domain fail loudly instead of being returned to the caller as if it were a success.

## Changes

**`temba/mailroom/client/exceptions.py`** — new `ContactLimitReachedException`, holding the raw `error` plus the `limit` that was hit, with a translatable `__str__` matching the existing phrasing used for other workspace limits.

**`temba/mailroom/client/client.py`** — the 422 dispatch gains a branch for `limit:contacts` alongside the existing flow / query / urn / ai domains. It keys on the specific code rather than the whole `limit` domain: the message is contacts-specific, so a future limit type gets its own branch and wording rather than silently inheriting this one. The dispatch also gains an `else` that raises `RequestException`, so a 422 whose domain matches no branch now errors rather than falling through to `return resp_body` and being consumed as a successful response.

**`temba/contacts/views.py`** — the contact create modal catches it and adds a non-field form error, so hitting the ceiling re-renders the form with an explanation instead of raising.

**`temba/api/views.py`** — the write mixin catches it and returns `409 Conflict`, consistent with the workspace-limit check already in that method for other object types.

**`locale/*`** — regenerated PO files, with translations authored for the new string.

## Behavior examples

Mailroom rejects a create with:

```json
{"error": "workspace has reached its limit of 50000000 contacts", "code": "limit:contacts", "extra": {"limit": 50000000}}
```

| Caller | Before | After |
|---|---|---|
| Contact create modal | unhandled exception | form error: "This workspace has reached its limit of 50,000,000 contacts." |
| `POST /api/v2/contacts` | `500` | `409` with that message in `detail` |
| 422 with an unknown error domain | error body returned as a success | `RequestException` |

Contact imports are unaffected — the import endpoint only queues batches, and per-contact rejection happens as mailroom processes them.

## Test plan

- [x] Client test asserting the 422 body raises `ContactLimitReachedException` with the right `error`, `limit` and message
- [x] Client test asserting an unhandled 422 domain raises `RequestException`
- [x] Contact create view test asserting the form error
- [x] API v2 contacts test asserting the `409` and `detail`
- [x] `temba.mailroom`, `temba.api.v2.tests.test_contacts`, `temba.contacts.tests.test_contactcrudl`, `temba.contacts.tests.test_contact` all pass
- [x] `code_check.py` clean (locale files up to date, no missing migrations, ruff clean)