### PR TITLE
Don't fail releasing an Android channel if it can't be synced

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -634,9 +634,13 @@ class Channel(LegacyIDMixin, TembaModel, DependencyMixin):
             # delay mailroom call for 5 seconds, so mailroom assets cache expires
             interrupt_channel_task.apply_async((self.id,), countdown=5)
 
-        # trigger the orphaned channel
-        if trigger_sync and self.is_android:
-            mailroom.get_client().android_sync(self)
+        # trigger a sync so the orphaned device learns it has been released - this needs the device's FCM registration
+        # id which older channels may not have, and is a best effort call which shouldn't block releasing the channel
+        if trigger_sync and self.is_android and self.config.get(Channel.CONFIG_FCM_ID):
+            try:
+                mailroom.get_client().android_sync(self)
+            except Exception as e:
+                logger.error(f"Unable to sync a released android channel: {str(e)}", exc_info=True)
 
         # any triggers associated with our channel get archived and released
         for trigger in self.triggers.filter(is_active=True):

--- a/temba/channels/tests/test_channel.py
+++ b/temba/channels/tests/test_channel.py
@@ -3,6 +3,7 @@ from unittest.mock import call, patch
 
 from django.urls import reverse
 
+from temba import mailroom
 from temba.contacts.models import URN, Contact
 from temba.msgs.models import Msg
 from temba.notifications.incidents.builtin import ChannelDisconnectedIncidentType
@@ -252,9 +253,11 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
             self.assertEqual(1, channel.triggers.filter(is_active=False).count())
             self.assertFalse(channel.is_active)
 
-    def test_release_android(self):
+    @mock_mailroom
+    def test_release_android(self, mr_mocks):
         android = self.claim_new_android()
         self.assertEqual("FCM111", android.config.get(Channel.CONFIG_FCM_ID))
+        mr_mocks.calls.clear()
 
         # release it
         android.release(self.admin)
@@ -263,6 +266,27 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(android.is_active)
         # and FCM ID now kept
         self.assertEqual("FCM111", android.config.get(Channel.CONFIG_FCM_ID))
+        self.assertEqual([call(android)], mr_mocks.calls["android_sync"])
+
+        # a sync failure shouldn't prevent the channel being released
+        android2 = self.claim_new_android(fcm_id="FCM222", number="0788123124")
+        mr_mocks.exception(mailroom.RequestException("android/sync", {}, MockResponse(500, '{"error": "sync failed"}')))
+        android2.release(self.admin, interrupt=False)
+        android2.refresh_from_db()
+
+        self.assertFalse(android2.is_active)
+
+        # a channel without a FCM ID (e.g. registered before FCM) can't be synced so we don't try
+        android3 = self.claim_new_android(fcm_id="FCM333", number="0788123125")
+        android3.config = {}
+        android3.save(update_fields=("config",))
+        mr_mocks.calls.clear()
+
+        android3.release(self.admin)
+        android3.refresh_from_db()
+
+        self.assertFalse(android3.is_active)
+        self.assertEqual([], mr_mocks.calls["android_sync"])
 
     def test_chart(self):
         chart_url = reverse("channels.channel_chart", args=[self.tel_channel.uuid])

--- a/temba/channels/tests/test_channel.py
+++ b/temba/channels/tests/test_channel.py
@@ -270,11 +270,13 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
 
         # a sync failure shouldn't prevent the channel being released
         android2 = self.claim_new_android(fcm_id="FCM222", number="0788123124")
+        mr_mocks.calls.clear()
         mr_mocks.exception(mailroom.RequestException("android/sync", {}, MockResponse(500, '{"error": "sync failed"}')))
         android2.release(self.admin, interrupt=False)
         android2.refresh_from_db()
 
         self.assertFalse(android2.is_active)
+        self.assertEqual([call(android2)], mr_mocks.calls["android_sync"])
 
         # a channel without a FCM ID (e.g. registered before FCM) can't be synced so we don't try
         android3 = self.claim_new_android(fcm_id="FCM333", number="0788123125")


### PR DESCRIPTION
## Summary

Releasing an Android channel triggers a mailroom sync so the orphaned device learns it has been released. Mailroom rejects that sync for channels with no FCM registration ID in their config, which made the whole release request fail with a 500 for such channels. The sync is best effort, so it should never block releasing the channel.

## Changes

- `temba/channels/models.py`: `Channel.release` now only requests the Android sync when the channel has an FCM ID, and logs any sync failure instead of raising.
- `temba/channels/tests/test_channel.py`: the Android release test now covers a normal release, a release where the sync request fails, and a release of a channel without an FCM ID (asserting no sync is attempted).

## Behavior examples

| Case | Before | After |
|---|---|---|
| Android channel with FCM ID, sync succeeds | Released, sync requested | Unchanged |
| Android channel without FCM ID | Release fails with `missing android channel registration id` | Released, no sync requested |
| Android channel with FCM ID, mailroom returns an error | Release fails | Released, error logged |

## Test plan

- [x] `temba.channels` test suite passes (181 tests)
- [x] ruff format and lint clean