### PR TITLE
Lower the default workspace contact limit to 10 million

### DIFF
--- a/temba/orgs/tests/test_org.py
+++ b/temba/orgs/tests/test_org.py
@@ -409,7 +409,7 @@ class OrgTest(TembaTest):
         self.assertEqual(self.org.get_limit(Org.LIMIT_FIELDS), 250)
         self.assertEqual(self.org.get_limit(Org.LIMIT_GROUPS), 250)
         self.assertEqual(self.org.get_limit(Org.LIMIT_GLOBALS), 250)
-        self.assertEqual(self.org.get_limit(Org.LIMIT_CONTACTS), 50_000_000)
+        self.assertEqual(self.org.get_limit(Org.LIMIT_CONTACTS), 10_000_000)
         self.assertEqual(self.org.get_limit(Org.LIMIT_FLOWS), 10_000)
 
         self.org.limits = dict(fields=500, groups=500, contacts=100_000)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -902,7 +902,7 @@ GLOBAL_VALUE_SIZE = 10_000  # max length of global values
 
 ORG_LIMIT_DEFAULTS = {
     "channels": 10,
-    "contacts": 50_000_000,
+    "contacts": 10_000_000,
     "fields": 250,
     "flows": 10_000,
     "globals": 250,

--- a/temba/staff/tests.py
+++ b/temba/staff/tests.py
@@ -98,7 +98,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         # every limit type shows its default as the placeholder
         form = response.context["form"]
         self.assertEqual("10", form.fields["channels_limit"].widget.attrs["placeholder"])
-        self.assertEqual("50000000", form.fields["contacts_limit"].widget.attrs["placeholder"])
+        self.assertEqual("10000000", form.fields["contacts_limit"].widget.attrs["placeholder"])
         self.assertEqual("10000", form.fields["flows_limit"].widget.attrs["placeholder"])
 
         # make some changes to our org
@@ -183,7 +183,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.org.refresh_from_db()
         self.assertEqual({"channels": 20, "fields": 300, "groups": 400}, self.org.limits)
-        self.assertEqual(self.org.get_limit(Org.LIMIT_CONTACTS), 50_000_000)
+        self.assertEqual(self.org.get_limit(Org.LIMIT_CONTACTS), 10_000_000)
 
         # flag org
         self.client.post(update_url, {"action": "flag"})


### PR DESCRIPTION
Lowers `ORG_LIMIT_DEFAULTS["contacts"]` from 50 million to 10 million, so that a workspace without an explicit contacts limit is capped at a number that's plausible for an operator to hit rather than one that never fires in practice.

Workspaces which legitimately need more than that should carry an explicit limit in their `limits` column, which takes precedence over this default. Enforcement lives in mailroom and courier, which read the column and fall back to their own equivalent config setting - both are being lowered to match.