### PR TITLE
Let agent users see ticket analytics scoped to their team

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -609,6 +609,7 @@ GROUP_PERMISSIONS = {
         "orgs.org_languages",
         "orgs.org_menu",
         "orgs.org_switch",
+        "tickets.ticket_analytics",
         "tickets.ticket_assign",
         "tickets.ticket_list",
         "tickets.ticket_menu",

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -183,13 +183,17 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_analytics(self):
         analytics_url = reverse("tickets.ticket_analytics")
 
-        self.assertRequestDisallowed(analytics_url, [None, self.agent])
+        self.assertRequestDisallowed(analytics_url, [None])
 
         # should be able to fetch analytics
         response = self.assertReadFetch(analytics_url, [self.editor, self.admin])
         self.assertEqual(200, response.status_code)
         self.assertContains(response, "Analytics")
         self.assertContains(response, "Tickets Opened")
+        self.assertContains(response, "Response Time")
+        self.assertContains(response, "/ticket/all/?assignee=")
+        self.assertIsNone(response.context["team"])
+        self.assertContentMenu(analytics_url, self.admin, ["Export Raw"])
 
         # the search button is part of the tickets section menu so search has to be mounted here too
         self.assertContains(response, "<temba-ticket-search")
@@ -198,12 +202,27 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(response.context["has_teams"])
         self.assertNotContains(response, 'dataname="Teams"')
 
+        # agents see analytics scoped to their team, so no response time chart (not tracked per team), no raw export
+        # and no links from the leaderboard to other agents' tickets
+        response = self.assertReadFetch(analytics_url, [self.agent])
+        self.assertEqual(self.org.default_team, response.context["team"])
+        self.assertContains(response, "Tickets Opened")
+        self.assertNotContains(response, "Response Time")
+        self.assertNotContains(response, "/ticket/all/?assignee=")
+        self.assertContentMenu(analytics_url, self.agent, [])
+
         self.org.features = [Org.FEATURE_TEAMS]
         self.org.save(update_fields=("features",))
 
         response = self.assertReadFetch(analytics_url, [self.admin])
         self.assertTrue(response.context["has_teams"])
         self.assertContains(response, 'dataname="Teams"')
+
+        # agents only see their own team so response count chart is never split by team
+        response = self.assertReadFetch(analytics_url, [self.agent2])
+        self.assertEqual(self.sales_only, response.context["team"])
+        self.assertFalse(response.context["has_teams"])
+        self.assertNotContains(response, 'dataname="Teams"')
 
         # should not be able to post to it
         response = self.client.post(analytics_url)
@@ -263,16 +282,21 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
                 "Unassigned (1)",
                 "All (4)",
                 ("Topics", ["General (2)", "Sales (2)", "Support (0)"]),
+                "Analytics",
                 "Search",
             ],
         )
         self.assertPageMenu(
-            menu_url, self.agent2, ["My Tickets (0)", "Unassigned (0)", "All (2)", ("Topics", ["Sales (2)"])]
+            menu_url,
+            self.agent2,
+            ["My Tickets (0)", "Unassigned (0)", "All (2)", ("Topics", ["Sales (2)"]), "Analytics"],
         )
 
         # agent3's assigned ticket isn't counted because it's not in a topic they can access
         self.assertPageMenu(
-            menu_url, self.agent3, ["My Tickets (0)", "Unassigned (0)", "All (0)", ("Topics", ["Support (0)"])]
+            menu_url,
+            self.agent3,
+            ["My Tickets (0)", "Unassigned (0)", "All (0)", ("Topics", ["Support (0)"]), "Analytics"],
         )
 
     def test_folder(self):
@@ -873,8 +897,37 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
             response.json(),
         )
 
+        # agent on a team with all topics sees the same as admins
+        self.login(self.agent)
+
+        response = self.client.get(opened_url + "?since=2024-03-01&until=2024-05-01")
+        self.assertEqual(
+            [
+                {"label": "<Unknown>", "data": [1, 0]},
+                {"label": "Cats", "data": [3, 5]},
+                {"label": "Dogs", "data": [2, 4]},
+            ],
+            response.json()["data"]["datasets"],
+        )
+
+        # agent on a topic-limited team only sees openings in their team's topics
+        self.sales_only.topics.add(cats)
+        self.login(self.agent2)
+
+        response = self.client.get(opened_url + "?since=2024-03-01&until=2024-05-01")
+        self.assertEqual(
+            {
+                "period": ["2024-03-01", "2024-05-01"],
+                "data": {"labels": ["2024-04-25", "2024-04-26"], "datasets": [{"label": "Cats", "data": [3, 5]}]},
+            },
+            response.json(),
+        )
+
     def test_resptime_chart(self):
         opened_url = reverse("tickets.ticket_chart", args=["resptime"])
+
+        # response times aren't tracked per team so agents can't fetch them
+        self.assertRequestDisallowed(opened_url, [None, self.agent])
 
         self.login(self.admin)
 
@@ -955,10 +1008,34 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
             response.json(),
         )
 
+        # agents only see replies from their own team
+        self.login(self.agent2)
+
+        response = self.client.get(replies_url + "?since=2024-03-01&until=2024-05-01")
+        self.assertEqual(
+            {
+                "period": ["2024-03-01", "2024-05-01"],
+                "data": {"labels": ["2024-04-25", "2024-04-26"], "datasets": [{"label": "Sales", "data": [3, 7]}]},
+            },
+            response.json(),
+        )
+
+        # including no replies at all
+        self.login(self.agent)
+
+        response = self.client.get(replies_url + "?since=2024-03-01&until=2024-05-01")
+        self.assertEqual(
+            {
+                "period": ["2024-03-01", "2024-05-01"],
+                "data": {"labels": [], "datasets": [{"label": "All Topics", "data": []}]},
+            },
+            response.json(),
+        )
+
     def test_leaderboard(self):
         leaderboard_url = reverse("tickets.ticket_leaderboard")
 
-        self.assertRequestDisallowed(leaderboard_url, [None, self.agent])
+        self.assertRequestDisallowed(leaderboard_url, [None])
 
         self.login(self.admin)
 
@@ -994,8 +1071,25 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(str(self.editor.uuid), data["results"][2]["uuid"])
         self.assertEqual(2, data["results"][2]["replies"])
 
+        # agents only see responders from their own team
+        self.login(self.agent2)
+
+        response = self.client.get(leaderboard_url + "?since=2024-03-01&until=2024-05-01")
+        self.assertEqual(
+            {"results": [{"name": "agent2@textit.com", "uuid": str(self.agent2.uuid), "replies": 10}]},
+            response.json(),
+        )
+
+        self.login(self.agent)
+
+        response = self.client.get(leaderboard_url + "?since=2024-03-01&until=2024-05-01")
+        self.assertEqual({"results": []}, response.json())
+
     def test_analytics_export(self):
         export_url = reverse("tickets.ticket_analytics_export")
+
+        # raw stats are workspace-wide so agents can't export them
+        self.assertRequestDisallowed(export_url, [None, self.agent])
 
         self.login(self.admin)
 

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -211,6 +211,17 @@ class TeamCRUDL(SmartCRUDL):
             return context
 
 
+class TeamScopedMixin:
+    """
+    Mixin for analytics views which agent users see scoped to their team. Other users see the whole workspace.
+    """
+
+    @cached_property
+    def team(self):
+        membership = self.request.org.get_membership(self.request.user)
+        return membership.team if membership else None  # only agent memberships have a team
+
+
 class TicketCRUDL(SmartCRUDL):
     model = Ticket
     actions = (
@@ -312,21 +323,23 @@ class TicketCRUDL(SmartCRUDL):
 
             return menu
 
-    class Analytics(SpaMixin, SearchMixin, ContextMenuMixin, OrgPermsMixin, SmartTemplateView):
+    class Analytics(TeamScopedMixin, SpaMixin, SearchMixin, ContextMenuMixin, OrgPermsMixin, SmartTemplateView):
         permission = "tickets.ticket_analytics"
         title = _("Analytics")
         menu_path = "/ticket/analytics"
 
         def build_context_menu(self, menu):
-            menu.add_link(_("Export Raw"), reverse("tickets.ticket_analytics_export"))
+            if self.has_org_perm("tickets.ticket_export"):
+                menu.add_link(_("Export Raw"), reverse("tickets.ticket_analytics_export"))
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
-            context["has_teams"] = Org.FEATURE_TEAMS in self.request.org.features
+            context["team"] = self.team
+            context["has_teams"] = Org.FEATURE_TEAMS in self.request.org.features and not self.team
             return context
 
     class AnalyticsExport(OrgPermsMixin, SmartTemplateView):
-        permission = "tickets.ticket_analytics"
+        permission = "tickets.ticket_export"  # raw stats are org-wide so agents can't export them
 
         def render_to_response(self, context, **response_kwargs):
             num_days = self.request.GET.get("days", 90)
@@ -739,7 +752,7 @@ class TicketCRUDL(SmartCRUDL):
             self.get_object().add_note(self.request.user, note=form.cleaned_data["note"])
             return self.render_modal_response(form)
 
-    class Chart(OrgPermsMixin, ChartViewMixin, SmartTemplateView):
+    class Chart(TeamScopedMixin, OrgPermsMixin, ChartViewMixin, SmartTemplateView):
         permission = "tickets.ticket_analytics"
         default_chart_period = (-timedelta(days=90), timedelta(days=1))
 
@@ -750,7 +763,13 @@ class TicketCRUDL(SmartCRUDL):
         def get_opened_chart(self, org, since, until) -> tuple:
             topics_by_id = {t.id: t.name for t in org.topics.filter(is_active=True)}
 
-            counts = org.daily_counts.period(since, until).prefix("tickets:opened:").day_totals(scoped=True)
+            counts = org.daily_counts.period(since, until).prefix("tickets:opened:")
+
+            # agents on a topic-limited team only see openings in their team's topics
+            if self.team and not self.team.all_topics:
+                counts = counts.filter(scope__in=[f"tickets:opened:{t.id}" for t in self.team.topics.all()])
+
+            counts = counts.day_totals(scoped=True)
 
             # collect all dates and values by topic
             dates_set = set()
@@ -773,6 +792,9 @@ class TicketCRUDL(SmartCRUDL):
             return [d.strftime("%Y-%m-%d") for d in labels], datasets
 
         def get_resptime_chart(self, org, since, until) -> tuple:
+            if self.team:  # response times are only tracked workspace-wide
+                raise Http404()
+
             counts = org.daily_counts.period(since, until).prefix("ticketresptime:").day_totals(scoped=True)
             totals_by_date, counts_by_date = {}, {}
             for (day, scope), count in counts.items():
@@ -796,6 +818,18 @@ class TicketCRUDL(SmartCRUDL):
             return [d.strftime("%Y-%m-%d") for d in labels], [{"label": _("Response Time"), "data": data}]
 
         def get_replies_chart(self, org, since, until) -> tuple:
+            # agents only see replies from their own team
+            if self.team:
+                counts = (
+                    org.daily_counts.period(since, until)
+                    .prefix(f"msgs:ticketreplies:{self.team.id}:")
+                    .day_totals(scoped=False)
+                )
+                labels = sorted(counts.keys())
+                return [d.strftime("%Y-%m-%d") for d in labels], [
+                    {"label": self.team.name, "data": [counts[d] for d in labels]}
+                ]
+
             teams_by_id = {t.id: t.name for t in org.teams.filter(is_active=True)}
             # Add default team (id=0) for users not assigned to specific teams
             teams_by_id[0] = _("No Team")
@@ -841,14 +875,16 @@ class TicketCRUDL(SmartCRUDL):
             elif chart == "replies":
                 return self.get_replies_chart(self.request.org, since, until)
 
-    class Leaderboard(OrgPermsMixin, ChartViewMixin, SmartTemplateView):
+    class Leaderboard(TeamScopedMixin, OrgPermsMixin, ChartViewMixin, SmartTemplateView):
         permission = "tickets.ticket_analytics"
 
         def render_to_response(self, context, **response_kwargs):
             org = self.request.org
             since, until = self.get_chart_period()
 
-            daily_counts = org.daily_counts.period(since, until).prefix("msgs:ticketreplies:")
+            # agents only see responders from their own team
+            prefix = f"msgs:ticketreplies:{self.team.id}:" if self.team else "msgs:ticketreplies:"
+            daily_counts = org.daily_counts.period(since, until).prefix(prefix)
 
             counts = (
                 daily_counts.annotate(

--- a/templates/tickets/ticket_analytics.html
+++ b/templates/tickets/ticket_analytics.html
@@ -79,16 +79,18 @@
                requireWindow
                legend>
   </temba-chart>
-  <temba-chart class="shadow mt-6"
-               header="{% trans "Response Time" %}"
-               url="{% url 'tickets.ticket_chart' 'resptime' %}"
-               dataname="Average Response"
-               colorIndex="2"
-               xtype="time"
-               ytype="duration"
-               single
-               requireWindow>
-  </temba-chart>
+  {% if not team %}
+    <temba-chart class="shadow mt-6"
+                 header="{% trans "Response Time" %}"
+                 url="{% url 'tickets.ticket_chart' 'resptime' %}"
+                 dataname="Average Response"
+                 colorIndex="2"
+                 xtype="time"
+                 ytype="duration"
+                 single
+                 requireWindow>
+    </temba-chart>
+  {% endif %}
   {% if has_teams %}
     <temba-chart class="shadow mt-6"
                  header="{% trans "Response Count" %}"
@@ -156,8 +158,12 @@
             return;
           }
           tbody.innerHTML = data.results.map(function(user) {
-            return '<tr><td><a href="/ticket/all/?assignee=' + user.uuid + '">' +
-              escapeHtml(user.name) + '</a></td><td>' + user.replies.toLocaleString() + '</td></tr>';
+            {% if team %}
+              var name = escapeHtml(user.name);
+            {% else %}
+              var name = '<a href="/ticket/all/?assignee=' + user.uuid + '">' + escapeHtml(user.name) + '</a>';
+            {% endif %}
+            return '<tr><td>' + name + '</td><td>' + user.replies.toLocaleString() + '</td></tr>';
           }).join("");
         })
         .catch(function() {


### PR DESCRIPTION
## Summary

Agent users can now open the ticket analytics page, seeing it scoped to their own team rather than the whole workspace. Administrators, editors and staff continue to see workspace-wide analytics unchanged.

## Changes

- **Permissions** — agents gain `tickets.ticket_analytics`, so the Analytics item appears in their ticket menu.
- **`TeamScopedMixin`** (`temba/tickets/views.py`) — resolves the requesting user's team from their org membership. Only agent memberships carry a team (asserted in `Org.add_user`), so every other role resolves to no team and keeps the org-wide view. Used by the analytics page, chart and leaderboard views.
- **Tickets Opened chart** — for an agent on a topic-limited team, only openings in that team's topics are included. Teams with access to all topics see every topic.
- **Response Count chart** — for an agent, only replies recorded against their team are counted, returned as a single series named after the team. The page never splits by team for agents even when the workspace has the teams feature.
- **Top Responders leaderboard** — for an agent, only responders in their team are listed, and names are rendered as plain text rather than linking to the all-tickets folder filtered by assignee.
- **Response Time chart** — hidden for agents, and the chart endpoint returns 404 for them, since response times are only tracked workspace-wide.
- **Raw export** — now requires `tickets.ticket_export`, which agents don't have. The Export Raw context menu item is hidden accordingly.

## Behavior examples

| Viewer | Tickets Opened | Response Time | Response Count | Top Responders | Export Raw |
|---|---|---|---|---|---|
| Admin / editor | all topics | shown | by team (if teams feature) | all users, linked | shown |
| Agent, team with all topics | all topics | hidden | own team only | own team only, unlinked | hidden |
| Agent, topic-limited team | team's topics only | hidden | own team only | own team only, unlinked | hidden |

In a workspace without the teams feature every agent is in the default team, so agents see the replies and leaderboard for all agents in the workspace. Replies by administrators and editors are recorded without a team and so aren't included in what agents see.

## Test plan

- [x] `temba.tickets`, `temba.orgs` and `temba.users` test suites pass
- [x] Analytics page tests cover agents on all-topic and topic-limited teams, including the hidden response time chart, hidden export and unlinked leaderboard
- [x] Chart tests cover topic filtering for opened tickets, team filtering for replies, and 404 on response time for agents
- [x] Leaderboard and raw export tests cover the agent cases
- [x] Ticket menu test covers the Analytics item for agents
- [x] `code_check.py` passes

## Review notes

The automated review suggested additionally gating the team lookup on the agent role. Declined: `Org.add_user` asserts that only agent memberships carry a team, and `Topic.get_restriction` already relies on the same invariant, so a role check would only duplicate it.