### PR TITLE
Add dedicated permission for raw ticket analytics export

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -395,7 +395,7 @@ PERMISSIONS = {
     "request_logs.httplog": ("webhooks",),
     "knowledge.article": ("colors", "publish", "sort", "upload"),
     "knowledge.knowledge": ("menu", "upload"),
-    "tickets.ticket": ("assign", "menu", "note", "export", "analytics"),
+    "tickets.ticket": ("assign", "menu", "note", "export", "analytics", "analytics_export"),
     "triggers.trigger": ("archived", "type", "menu"),
 }
 

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -1091,6 +1091,11 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         # raw stats are workspace-wide so agents can't export them
         self.assertRequestDisallowed(export_url, [None, self.agent])
 
+        self.login(self.editor)
+
+        response = self.client.get(export_url)
+        self.assertEqual(200, response.status_code)
+
         self.login(self.admin)
 
         response = self.client.get(export_url)

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -329,7 +329,7 @@ class TicketCRUDL(SmartCRUDL):
         menu_path = "/ticket/analytics"
 
         def build_context_menu(self, menu):
-            if self.has_org_perm("tickets.ticket_export"):
+            if self.has_org_perm("tickets.ticket_analytics_export"):
                 menu.add_link(_("Export Raw"), reverse("tickets.ticket_analytics_export"))
 
         def get_context_data(self, **kwargs):
@@ -339,7 +339,7 @@ class TicketCRUDL(SmartCRUDL):
             return context
 
     class AnalyticsExport(OrgPermsMixin, SmartTemplateView):
-        permission = "tickets.ticket_export"  # raw stats are org-wide so agents can't export them
+        permission = "tickets.ticket_analytics_export"
 
         def render_to_response(self, context, **response_kwargs):
             num_days = self.request.GET.get("days", 90)


### PR DESCRIPTION
## Summary

Follow-up to #6950. The raw ticket analytics export was gated on `tickets.ticket_export` to keep it away from agents, but that conflates exporting tickets with exporting analytics data. This gives the raw export its own permission.

## Changes

- **New permission** `tickets.ticket_analytics_export`, declared in the `PERMISSIONS` setting for the ticket model. Administrators and editors receive it through the existing `tickets.ticket.*` wildcard; agents don't. Smartmin creates the permission on migrate so no migration is needed.
- **`TicketCRUDL.AnalyticsExport`** now requires that permission, and the Export Raw item in the analytics page's context menu checks it.

## Behavior examples

| Role | Before | After |
|---|---|---|
| Administrator / editor | can export raw analytics via `tickets.ticket_export` | can export raw analytics via `tickets.ticket_analytics_export` |
| Agent | denied | denied |

## Test plan

- [x] Raw export test covers editors and administrators allowed, agents and anonymous users denied
- [x] `temba.tickets` CRUDL tests pass
- [x] `code_check.py` passes