### PR TITLE
Read message status tags written either as a single tag or as a tag per status value

### DIFF
--- a/temba/mailroom/events.py
+++ b/temba/mailroom/events.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from uuid import UUID
 
+import iso8601
+
 from temba.users.models import User
 from temba.utils import dynamo
 
@@ -49,13 +51,26 @@ class Event:
     # lifecycle events (opened/closed/reopened) which are shown everywhere
     ticket_detail_types = {TYPE_TICKET_ASSIGNED, TYPE_TICKET_NOTE_ADDED, TYPE_TICKET_TOPIC_CHANGED}
 
-    # message statuses in the order a message moves through them - failed and read are terminal, and errored ranks
-    # lowest because it's always followed by a retry which either moves the message on or fails it permanently
-    status_ranks = {"errored": 0, "wired": 1, "sent": 2, "delivered": 3, "read": 4, "failed": 5}
+    # message statuses in the order a message moves through them - failed and read are terminal. Errored isn't part of
+    # that progression: it can be recorded against a message that's already wired or sent, and is followed by a retry
+    # which either moves the message on or fails it permanently, so it only counts when it's the most recent status.
+    status_ranks = {"wired": 1, "sent": 2, "delivered": 3, "read": 4, "failed": 5}
+    status_errored = "errored"
 
     @classmethod
-    def _status_rank(cls, status_data: dict) -> int:
-        return cls.status_ranks.get(status_data.get("status"), -1)
+    def _is_later_status(cls, new: dict, current: dict) -> bool:
+        """
+        Whether the given new status tag represents a later state of the message than the current one.
+        """
+        if cls.status_errored in (new["status"], current["status"]):
+            new_rank, current_rank = cls.status_ranks.get(new["status"], 0), cls.status_ranks.get(current["status"], 0)
+
+            # errored can't follow delivery, so only competes with wired and sent, and then by which happened last
+            if max(new_rank, current_rank) >= cls.status_ranks["delivered"]:
+                return new_rank > current_rank
+            return iso8601.parse_date(new["created_on"]) > iso8601.parse_date(current["created_on"])
+
+        return cls.status_ranks.get(new["status"], 0) > cls.status_ranks.get(current["status"], 0)
 
     @classmethod
     def _from_item(cls, contact, item: dict) -> dict:
@@ -166,10 +181,9 @@ class Event:
                     event["_deleted"] = tag.data
                 elif tag.tag == "sts":
                     # a message can have several status tags (one per status value) as well as a single overwritten
-                    # tag from older writers, and since a message's status only ever moves forward, the most advanced
-                    # status recorded is its current one
+                    # tag from older writers, so we take the one representing the latest state of the message
                     current = event.get("_status")
-                    if not current or cls._status_rank(tag.data) > cls._status_rank(current):
+                    if not current or cls._is_later_status(tag.data, current):
                         event["_status"] = tag.data
 
         user_uuids = {event["_user"]["uuid"] for event in events if event.get("_user")}

--- a/temba/mailroom/events.py
+++ b/temba/mailroom/events.py
@@ -49,6 +49,14 @@ class Event:
     # lifecycle events (opened/closed/reopened) which are shown everywhere
     ticket_detail_types = {TYPE_TICKET_ASSIGNED, TYPE_TICKET_NOTE_ADDED, TYPE_TICKET_TOPIC_CHANGED}
 
+    # message statuses in the order a message moves through them - failed and read are terminal, and errored ranks
+    # lowest because it's always followed by a retry which either moves the message on or fails it permanently
+    status_ranks = {"errored": 0, "wired": 1, "sent": 2, "delivered": 3, "read": 4, "failed": 5}
+
+    @classmethod
+    def _status_rank(cls, status_data: dict) -> int:
+        return cls.status_ranks.get(status_data.get("status"), -1)
+
     @classmethod
     def _from_item(cls, contact, item: dict) -> dict:
         assert item["OrgID"] == contact.org_id, "org ID mismatch for contact event"
@@ -64,7 +72,9 @@ class Event:
     def _tag_from_item(cls, contact, item: dict) -> EventTag:
         assert item["OrgID"] == contact.org_id, "org ID mismatch for contact event tag"
 
-        return EventTag(event_uuid=item["SK"][4:40], tag=item["SK"][41:], data=item.get("Data", {}))
+        # tag SKs are evt#<event-uuid>#<tag> optionally followed by #<qualifier>, e.g. evt#<uuid>#sts#D for a tag that
+        # is written per status value rather than overwritten
+        return EventTag(event_uuid=item["SK"][4:40], tag=item["SK"][41:].split("#")[0], data=item.get("Data", {}))
 
     @classmethod
     def get_by_contact(cls, contact, user, *, before: UUID, after: UUID, ticket: UUID, limit: int) -> list[dict]:
@@ -155,7 +165,12 @@ class Event:
                 if tag.tag == "del":
                     event["_deleted"] = tag.data
                 elif tag.tag == "sts":
-                    event["_status"] = tag.data
+                    # a message can have several status tags (one per status value) as well as a single overwritten
+                    # tag from older writers, and since a message's status only ever moves forward, the most advanced
+                    # status recorded is its current one
+                    current = event.get("_status")
+                    if not current or cls._status_rank(tag.data) > cls._status_rank(current):
+                        event["_status"] = tag.data
 
         user_uuids = {event["_user"]["uuid"] for event in events if event.get("_user")}
         users_by_uuid = {str(u.uuid): u for u in org.get_users().filter(uuid__in=user_uuids)}

--- a/temba/mailroom/tests/test_event.py
+++ b/temba/mailroom/tests/test_event.py
@@ -147,7 +147,7 @@ class EventTest(TembaTest):
                 "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593008#sts#E",  # per-status tag for event 8
                 "OrgID": self.org.id,
                 "Data": {
-                    "created_on": "2025-11-17T19:08:58.472259Z",
+                    "created_on": "2025-11-17T19:10:58.472259Z",  # errored after being sent, awaiting retry
                     "status": "errored",
                 },
             },
@@ -242,7 +242,7 @@ class EventTest(TembaTest):
                         "text": "Trying again",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_status": {"created_on": "2025-11-17T19:09:58.472259Z", "status": "sent"},  # most advanced
+                    "_status": {"created_on": "2025-11-17T19:10:58.472259Z", "status": "errored"},  # most recent
                 },
             ],
         )
@@ -269,7 +269,7 @@ class EventTest(TembaTest):
                         "text": "Trying again",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_status": {"created_on": "2025-11-17T19:09:58.472259Z", "status": "sent"},  # most advanced
+                    "_status": {"created_on": "2025-11-17T19:10:58.472259Z", "status": "errored"},  # most recent
                 },
             ],
         )
@@ -438,6 +438,46 @@ class EventTest(TembaTest):
                 "019a9336-9228-73e8-b4f5-3a2b42593bb0",
                 "019a9336-9228-71f0-becb-a56435927677",
             ],
+        )
+
+    def test_is_later_status(self):
+        def sts(status: str, created_on: str) -> dict:
+            return {"status": status, "created_on": created_on}
+
+        # progression statuses compare by how far along the message is
+        self.assertTrue(
+            Event._is_later_status(sts("sent", "2025-11-17T19:00:00Z"), sts("wired", "2025-11-17T19:01:00Z"))
+        )
+        self.assertFalse(
+            Event._is_later_status(sts("wired", "2025-11-17T19:01:00Z"), sts("sent", "2025-11-17T19:00:00Z"))
+        )
+        self.assertFalse(
+            Event._is_later_status(sts("read", "2025-11-17T19:00:00Z"), sts("read", "2025-11-17T19:01:00Z"))
+        )
+        self.assertTrue(
+            Event._is_later_status(sts("failed", "2025-11-17T19:00:00Z"), sts("delivered", "2025-11-17T19:01:00Z"))
+        )
+
+        # errored competes with wired and sent by which happened last
+        self.assertTrue(
+            Event._is_later_status(sts("errored", "2025-11-17T19:01:00Z"), sts("wired", "2025-11-17T19:00:00Z"))
+        )
+        self.assertFalse(
+            Event._is_later_status(sts("errored", "2025-11-17T19:00:00Z"), sts("sent", "2025-11-17T19:01:00Z"))
+        )
+        self.assertTrue(
+            Event._is_later_status(sts("wired", "2025-11-17T19:05:00Z"), sts("errored", "2025-11-17T19:00:00Z"))
+        )
+        self.assertFalse(
+            Event._is_later_status(sts("errored", "2025-11-17T19:00:00Z"), sts("errored", "2025-11-17T19:00:00Z"))
+        )
+
+        # but never beats delivered, read or failed
+        self.assertFalse(
+            Event._is_later_status(sts("errored", "2025-11-17T19:05:00Z"), sts("delivered", "2025-11-17T19:00:00Z"))
+        )
+        self.assertTrue(
+            Event._is_later_status(sts("read", "2025-11-17T19:00:00Z"), sts("errored", "2025-11-17T19:05:00Z"))
         )
 
     def test_from_item(self):

--- a/temba/mailroom/tests/test_event.py
+++ b/temba/mailroom/tests/test_event.py
@@ -135,11 +135,29 @@ class EventTest(TembaTest):
             },
             {
                 "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
-                "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593008#sts",  # status tag for event 8
+                "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593008#sts",  # status tag for event 8 (older single tag)
                 "OrgID": self.org.id,
                 "Data": {
                     "created_on": "2025-11-17T19:07:58.472259Z",
                     "status": "wired",
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593008#sts#E",  # per-status tag for event 8
+                "OrgID": self.org.id,
+                "Data": {
+                    "created_on": "2025-11-17T19:08:58.472259Z",
+                    "status": "errored",
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593008#sts#S",  # per-status tag for event 8
+                "OrgID": self.org.id,
+                "Data": {
+                    "created_on": "2025-11-17T19:09:58.472259Z",
+                    "status": "sent",
                 },
             },
         ]
@@ -224,7 +242,7 @@ class EventTest(TembaTest):
                         "text": "Trying again",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_status": {"created_on": "2025-11-17T19:07:58.472259Z", "status": "wired"},
+                    "_status": {"created_on": "2025-11-17T19:09:58.472259Z", "status": "sent"},  # most advanced
                 },
             ],
         )
@@ -251,7 +269,7 @@ class EventTest(TembaTest):
                         "text": "Trying again",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_status": {"created_on": "2025-11-17T19:07:58.472259Z", "status": "wired"},
+                    "_status": {"created_on": "2025-11-17T19:09:58.472259Z", "status": "sent"},  # most advanced
                 },
             ],
         )


### PR DESCRIPTION
## Summary

Outgoing message status is recorded in the contact history table as a tag on the message's `msg_created` event. Today that's a single item at `evt#<msg-uuid>#sts` which each status change overwrites, so writers racing from different processes can leave an older status as the last write. The plan is to move writers to one immutable item per status value (`evt#<msg-uuid>#sts#W`, `#sts#S`, ...) so nothing is ever overwritten. This makes the reader handle both shapes first, so writers can switch over without a coordinated deploy.

## Changes

**`temba/mailroom/events.py`**

- Tag sort keys are parsed as `evt#<event-uuid>#<tag>[#<qualifier>]`, so `#sts` and `#sts#D` both resolve to the `sts` tag. The qualifier isn't needed by the reader since each item's data carries the status name.
- When an event has more than one status tag, the one representing the latest state of the message wins rather than whichever was read last:
  - wired, sent, delivered, read and failed compare by how far along the message is, since a message only moves forward through them
  - errored isn't part of that progression: it can be recorded against a message that's already wired or sent and is followed by a retry, so against wired or sent it wins only if it's the most recent tag, and it never beats delivered, read or failed
- The injected `_status` value keeps its existing shape (the winning tag's data), so no client changes are needed.

**`temba/mailroom/tests/test_event.py`**

- The message event fixture now has an older single `#sts` tag alongside per-status `#sts#S` and `#sts#E` tags, and the test asserts the most recent errored tag is the one injected.
- New `test_is_later_status` covering the progression comparison, errored against wired and sent by recency, and errored never beating delivery.

## Behavior examples

| Status tags present for a message | `_status.status` before | after |
|---|---|---|
| `#sts` (wired) | wired | wired |
| `#sts#W`, `#sts#S`, `#sts#D` | *(not parsed as `sts`)* | delivered |
| `#sts#W` at 19:00, `#sts#E` at 19:05 (awaiting retry) | *(last read)* | errored |
| `#sts#E` at 19:00, `#sts#W` at 19:05 (retry succeeded) | *(last read)* | wired |
| `#sts#E`, `#sts#D` | *(last read)* | delivered |

## Test plan

- [x] `temba.mailroom.tests.test_event` passes with the mixed-shape fixture and the new comparison test
- [x] `temba.mailroom` and contact tests pass
- [x] `code_check.py` and `makemigrations --check` clean
- [x] CI green on the final head