### PR TITLE
Update repository URLs after rename to nyaruka/temba

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,8 +2,8 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Feature Requests
-    url: https://github.com/nyaruka/rapidpro/discussions/categories/ideas
+    url: https://github.com/nyaruka/temba/discussions/categories/ideas
     about: Suggest a new feature to discuss before beginning development
   - name: Questions
-    url: https://github.com/nyaruka/rapidpro/discussions/categories/q-a
+    url: https://github.com/nyaruka/temba/discussions/categories/q-a
     about: Ask general questions about RapidPro

--- a/components/package.json
+++ b/components/package.json
@@ -6,9 +6,9 @@
   "author": "Nyaruka <code@nyaruka.com>",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "homepage": "https://github.com/rapidpro/rapidpro/",
+  "homepage": "https://github.com/nyaruka/temba/",
   "license": "AGPL-3.0-only",
-  "repository": "https://github.com/rapidpro/rapidpro/",
+  "repository": "https://github.com/nyaruka/temba/",
   "scripts": {
     "build": "rimraf dist && bun run svg && tsc && rollup -c rollup.components.mjs ",
     "build-wc": "rollup -c rollup.webchat.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rapidpro",
-  "repository": "git@github.com:rapidpro/rapidpro.git",
+  "repository": "git@github.com:nyaruka/temba.git",
   "license": "AGPL-3.0",
   "lint-staged": {
     "*.{js,jsx,css,md}": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 ]
 
 [project.urls]
-repository = "http://github.com/rapidpro/rapidpro"
+repository = "https://github.com/nyaruka/temba"
 
 
 [dependency-groups]


### PR DESCRIPTION
The GitHub repo has been renamed from nyaruka/rapidpro to nyaruka/temba. This updates the issue template contact links and the repository URLs in package.json, components/package.json and pyproject.toml (the latter three previously pointed at the AGPL mirror rather than this repo).