### PR TITLE
Fail contact import preview cleanly when a new group is requested at the group limit

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-09 15:15+0000\n"
+"POT-Creation-Date: 2026-09-10 21:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -2398,6 +2398,9 @@ msgid "Field name '%(name)s' is repeated."
 msgstr ""
 
 msgid "This workspace has reached its limit of fields."
+msgstr ""
+
+msgid "This workspace has reached its limit of groups."
 msgstr ""
 
 msgid "Required."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-09 15:15+0000\n"
+"POT-Creation-Date: 2026-09-10 21:49+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -2413,6 +2413,9 @@ msgstr "Se repite el nombre de campo '%(name)s'."
 
 msgid "This workspace has reached its limit of fields."
 msgstr "Este workspace ha alcanzado su límite de campos."
+
+msgid "This workspace has reached its limit of groups."
+msgstr "Este workspace ha alcanzado su límite de grupos."
 
 msgid "Required."
 msgstr "Requerido."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-09 15:15+0000\n"
+"POT-Creation-Date: 2026-09-10 21:49+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -2413,6 +2413,9 @@ msgstr "Le nom de champ '%(name)s' est répété."
 
 msgid "This workspace has reached its limit of fields."
 msgstr "Cet espace de travail a atteint sa limite de champs."
+
+msgid "This workspace has reached its limit of groups."
+msgstr "Cet espace de travail a atteint sa limite de groupes."
 
 msgid "Required."
 msgstr "Obligatoire."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-09 15:15+0000\n"
+"POT-Creation-Date: 2026-09-10 21:49+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -2417,6 +2417,9 @@ msgstr "Nome do campo '%(name)s' é repetido."
 
 msgid "This workspace has reached its limit of fields."
 msgstr "Esta área de trabalho atingiu seu limite de campos."
+
+msgid "This workspace has reached its limit of groups."
+msgstr "Esta área de trabalho atingiu seu limite de grupos."
 
 msgid "Required."
 msgstr "Obrigatório."

--- a/temba/contacts/tests/test_importcrudl.py
+++ b/temba/contacts/tests/test_importcrudl.py
@@ -83,6 +83,12 @@ class ContactImportCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.client.get(preview_url)
             self.assertEqual(response.context["form"].fields["group_mode"].choices, [("E", "existing group")])
 
+            # and trying to create a new group anyway is an error rather than a crash
+            response = self.client.post(
+                preview_url, {"add_to_group": True, "group_mode": "N", "new_group_name": "Import"}
+            )
+            self.assertFormError(response.context["form"], None, "This workspace has reached its limit of groups.")
+
         # finally create new group...
         response = self.client.post(preview_url, {"add_to_group": True, "group_mode": "N", "new_group_name": "Import"})
         self.assertRedirect(response, read_url)

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1308,6 +1308,10 @@ class ContactImportCRUDL(SmartCRUDL):
 
                 add_to_group = self.cleaned_data["add_to_group"]
                 if add_to_group:
+                    # a rejected mode means new group was requested but isn't a choice at the group limit
+                    if "group_mode" not in self.cleaned_data:
+                        raise forms.ValidationError(_("This workspace has reached its limit of groups."))
+
                     group_mode = self.cleaned_data["group_mode"]
                     if group_mode == self.GROUP_MODE_NEW:
                         new_group_name = self.cleaned_data.get("new_group_name")


### PR DESCRIPTION
## Summary

The contact import preview form crashed with a `KeyError: 'group_mode'` when a workspace at its group limit submitted the form asking for a new group. The form narrows the group mode choices to only "existing group" at the limit, so a submitted "new group" mode fails choice validation and never reaches `cleaned_data`, but `clean()` indexed it directly. It now returns a form error instead.

## Changes

- `temba/contacts/views.py`: `ContactImportCRUDL.Preview.Form.clean()` checks for a rejected `group_mode` before using it and raises "This workspace has reached its limit of groups." as a form error.
- `temba/contacts/tests/test_importcrudl.py`: regression test posting `group_mode=N` while the group limit is reached.
- `locale/*/LC_MESSAGES/django.po`: regenerated, with es/fr/pt_BR translations for the new string.

## Behavior

| | Before | After |
|---|---|---|
| POST `group_mode=N` at the group limit | 500 (`KeyError: 'group_mode'`) | form re-rendered with "This workspace has reached its limit of groups." |
| POST `group_mode=N` below the limit | new group created | unchanged |
| POST `group_mode=E` | existing group used | unchanged |

## Test plan

- [x] `temba.contacts` test suite passes
- [x] `code_check.py` passes, PO files regenerated